### PR TITLE
Add FastAPI+Vue demo UI for managing contracts and datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ artifacts
 __pycache__
 test_temp_files
 pytest.log
+build

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ explore contracts, datasets and data quality results. Install the optional
 dependencies and launch the app with:
 
 ```bash
-pip install .[demo]
+pip install ".[demo]"
 dc43-demo
 ```
 
@@ -192,8 +192,6 @@ flowchart TD
 
     classDef err fill:#ffe5e5,stroke:#ff4d4f,color:#000
     class E1,E2,E3 err
-```
-
 ```
 
 Notes

--- a/README.md
+++ b/README.md
@@ -130,6 +130,32 @@ if draft:
     print("Draft created:", draft.id, draft.version)  # send to workflow
 ```
 
+## Demo application
+
+A Vue-powered FastAPI application in ``dc43.demo_app`` offers a visual way to
+explore contracts, datasets and data quality results. Install the optional
+dependencies and launch the app with:
+
+```bash
+pip install .[demo]
+dc43-demo
+```
+
+Visit ``http://localhost:8000`` to:
+
+- Browse contracts and their versions with draft/active status.
+- Inspect dataset versions, their linked contract, validation status and
+  detailed DQ metrics derived from contract rules.
+- Highlight datasets using draft contracts and trigger validation to promote
+  them.
+
+An additional Reveal.js presentation is available at
+``http://localhost:8000/static/presentation.html`` to walk through the
+contract lifecycle and automation steps.
+
+The application also exposes an example Spark pipeline in
+``dc43.demo_app.pipeline`` used when registering new dataset versions.
+
 ## Spark Flow (Mermaid)
 
 ```mermaid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,15 +27,25 @@ test = [
   "pytest>=7.0",
   "pyspark>=3.4",
 ]
+demo = [
+  "fastapi",
+  "uvicorn",
+  "jinja2",
+  "pyspark>=3.4",
+]
 
 [project.scripts]
 dc43 = "dc43.cli:main"
+dc43-demo = "dc43.demo_app.server:run"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+"dc43.demo_app" = ["demo_data/**/*", "static/**/*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ demo = [
   "fastapi",
   "uvicorn",
   "jinja2",
+  "python-multipart",
   "pyspark>=3.4",
 ]
 

--- a/src/dc43/demo_app/__init__.py
+++ b/src/dc43/demo_app/__init__.py
@@ -1,0 +1,1 @@
+"""Demo web application showcasing dc43 features."""

--- a/src/dc43/demo_app/demo_data/contract_meta.json
+++ b/src/dc43/demo_app/demo_data/contract_meta.json
@@ -1,0 +1,3 @@
+[
+  {"id": "orders", "version": "1.0.0", "status": "draft"}
+]

--- a/src/dc43/demo_app/demo_data/contracts/orders/1.0.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/orders/1.0.0.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0.0",
+  "kind": "DataContract",
+  "apiVersion": "3.0.2",
+  "id": "orders",
+  "name": "Orders",
+  "description": {"usage": "Sample orders contract"},
+  "status": "draft",
+  "schema": [
+    {
+      "name": "orders",
+      "properties": [
+        {"name": "id", "physicalType": "integer", "required": true, "unique": true},
+        {
+          "name": "amount",
+          "physicalType": "number",
+          "required": true,
+          "quality": [
+            {"mustBeGreaterThan": 0}
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/dc43/demo_app/demo_data/datasets.json
+++ b/src/dc43/demo_app/demo_data/datasets.json
@@ -1,0 +1,9 @@
+[
+  {
+    "contract_id": "orders",
+    "contract_version": "1.0.0",
+    "dataset_version": "v1",
+    "status": "ok",
+    "dq_details": {"violations": 0, "metrics": {"row_count": 2}}
+  }
+]

--- a/src/dc43/demo_app/demo_data/sample_input.json
+++ b/src/dc43/demo_app/demo_data/sample_input.json
@@ -1,0 +1,2 @@
+{"order_id":1,"customer_id":101,"order_ts":"2024-01-01T10:00:00","amount":10.0,"currency":"EUR"}
+{"order_id":2,"customer_id":102,"order_ts":"2024-01-02T10:00:00","amount":20.5,"currency":"USD"}

--- a/src/dc43/demo_app/pipeline.py
+++ b/src/dc43/demo_app/pipeline.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Example transformation pipeline using dc43 helpers.
+
+This script demonstrates how a Spark job might read data with contract
+validation, perform transformations (omitted) and write the result while
+recording the dataset version in the demo app's registry.
+"""
+
+from pathlib import Path
+
+from dc43.demo_app.server import (
+    store,
+    DATASETS_FILE,
+    DatasetRecord,
+    load_records,
+    save_records,
+)
+from dc43.dq.stub import StubDQClient
+from dc43.integration.spark_io import read_with_contract, write_with_contract
+from pyspark.sql import SparkSession
+
+
+def run_pipeline(
+    contract_id: str,
+    contract_version: str,
+    input_path: str,
+    output_path: str,
+    dataset_version: str,
+) -> None:
+    """Run an example pipeline using the stored contract."""
+    spark = SparkSession.builder.appName("dc43-demo").getOrCreate()
+    contract = store.get(contract_id, contract_version)
+    dq = StubDQClient(base_path=str(Path(DATASETS_FILE).parent / "dq_state"))
+    df, status = read_with_contract(
+        spark,
+        format="json",
+        path=input_path,
+        contract=contract,
+        expected_contract_version=f"=={contract_version}",
+        dq_client=dq,
+        return_status=True,
+    )
+    # placeholder transformation could occur here
+    write_with_contract(
+        df=df,
+        contract=contract,
+        path=output_path,
+        mode="overwrite",
+        enforce=True,
+    )
+    records = load_records()
+    records.append(
+        DatasetRecord(
+            contract_id,
+            contract_version,
+            dataset_version,
+            status.status,
+            status.details or {},
+        )
+    )
+    save_records(records)
+    spark.stop()
+

--- a/src/dc43/demo_app/server.py
+++ b/src/dc43/demo_app/server.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+"""FastAPI demo application for dc43.
+
+This application provides a small Bootstrap-powered UI to manage data
+contracts and run an example Spark pipeline that records dataset versions
+with their validation status. Contracts are stored on the local
+filesystem using :class:`~dc43.storage.fs.FSContractStore` and dataset
+metadata lives in a JSON file.
+
+Run the application with::
+
+    uvicorn dc43.demo_app.server:app --reload
+
+Optional dependencies needed: ``fastapi``, ``uvicorn``, ``jinja2`` and
+``pyspark``.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Dict, Any
+import json
+
+from fastapi import FastAPI, Request, Form, HTTPException
+from fastapi.responses import HTMLResponse, RedirectResponse, FileResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from dc43.storage.fs import FSContractStore
+from dc43.dq.metrics import expectations_from_contract
+from open_data_contract_standard.model import (
+    OpenDataContractStandard,
+    SchemaObject,
+    SchemaProperty,
+    Description,
+)
+from pydantic import ValidationError
+
+BASE_DIR = Path(__file__).resolve().parent
+DATA_DIR = BASE_DIR / "demo_data"
+CONTRACT_DIR = DATA_DIR / "contracts"
+DATASETS_FILE = DATA_DIR / "datasets.json"
+CONTRACT_META_FILE = DATA_DIR / "contract_meta.json"
+
+CONTRACT_DIR.mkdir(parents=True, exist_ok=True)
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+if not DATASETS_FILE.exists():
+    DATASETS_FILE.write_text("[]", encoding="utf-8")
+if not CONTRACT_META_FILE.exists():
+    CONTRACT_META_FILE.write_text("[]", encoding="utf-8")
+
+store = FSContractStore(str(CONTRACT_DIR))
+
+app = FastAPI(title="DC43 Demo")
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static"), check_dir=False), name="static")
+
+
+@dataclass
+class DatasetRecord:
+    contract_id: str
+    contract_version: str
+    dataset_version: str
+    status: str = "unknown"
+    dq_details: Dict[str, Any] = field(default_factory=dict)
+
+
+def load_records() -> List[DatasetRecord]:
+    raw = json.loads(DATASETS_FILE.read_text())
+    return [DatasetRecord(**r) for r in raw]
+
+
+def save_records(records: List[DatasetRecord]) -> None:
+    DATASETS_FILE.write_text(
+        json.dumps([r.__dict__ for r in records], indent=2), encoding="utf-8"
+    )
+
+
+def load_contract_meta() -> List[Dict[str, Any]]:
+    return json.loads(CONTRACT_META_FILE.read_text())
+
+
+def save_contract_meta(meta: List[Dict[str, Any]]) -> None:
+    CONTRACT_META_FILE.write_text(
+        json.dumps(meta, indent=2), encoding="utf-8"
+    )
+
+
+def get_contract_status(cid: str, ver: str) -> str:
+    meta = load_contract_meta()
+    for m in meta:
+        if m["id"] == cid and m["version"] == ver:
+            return m.get("status", "unknown")
+    return "unknown"
+
+
+def set_contract_status(cid: str, ver: str, status: str) -> None:
+    meta = load_contract_meta()
+    for m in meta:
+        if m["id"] == cid and m["version"] == ver:
+            m["status"] = status
+            break
+    else:
+        meta.append({"id": cid, "version": ver, "status": status})
+    save_contract_meta(meta)
+
+
+def contract_to_dict(c: OpenDataContractStandard) -> Dict[str, Any]:
+    try:
+        data = c.model_dump()
+    except AttributeError:  # pydantic v1 fallback
+        data = c.dict()  # type: ignore
+    # Pydantic names the "schema" field "schema_" to avoid clashing with the
+    # ``BaseModel.schema`` method. Rename it here so the client can simply
+    # access ``contract.schema`` without worrying about the underscore suffix.
+    if "schema_" in data:
+        data["schema"] = data.pop("schema_")
+    return data
+
+
+@app.get("/api/contracts")
+async def api_contracts() -> List[Dict[str, Any]]:
+    return load_contract_meta()
+
+
+@app.get("/api/contracts/{cid}/{ver}")
+async def api_contract_detail(cid: str, ver: str) -> Dict[str, Any]:
+    try:
+        contract = store.get(cid, ver)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    datasets = [r.__dict__ for r in load_records() if r.contract_id == cid and r.contract_version == ver]
+    expectations = expectations_from_contract(contract)
+    return {
+        "contract": contract_to_dict(contract),
+        "status": get_contract_status(cid, ver),
+        "datasets": datasets,
+        "expectations": expectations,
+    }
+
+
+@app.post("/api/contracts/{cid}/{ver}/validate")
+async def api_validate_contract(cid: str, ver: str) -> Dict[str, str]:
+    set_contract_status(cid, ver, "active")
+    return {"status": "active"}
+
+
+@app.get("/api/datasets")
+async def api_datasets() -> List[Dict[str, Any]]:
+    records = load_records()
+    out: List[Dict[str, Any]] = []
+    for r in records:
+        rec = r.__dict__.copy()
+        rec["contract_status"] = get_contract_status(r.contract_id, r.contract_version)
+        out.append(rec)
+    return out
+
+
+@app.get("/api/datasets/{dataset_version}")
+async def api_dataset_detail(dataset_version: str) -> Dict[str, Any]:
+    for r in load_records():
+        if r.dataset_version == dataset_version:
+            contract = store.get(r.contract_id, r.contract_version)
+            return {
+                "record": r.__dict__,
+                "contract": contract_to_dict(contract),
+                "contract_status": get_contract_status(r.contract_id, r.contract_version),
+                "expectations": expectations_from_contract(contract),
+            }
+    raise HTTPException(status_code=404, detail="Dataset not found")
+
+
+@app.get("/")
+async def index() -> FileResponse:
+    return FileResponse(str(BASE_DIR / "static" / "index.html"))
+
+
+@app.get("/contracts", response_class=HTMLResponse)
+async def list_contracts(request: Request) -> HTMLResponse:
+    contracts = []
+    for cid_dir in CONTRACT_DIR.glob("*"):
+        if cid_dir.is_dir():
+            versions = store.list_versions(cid_dir.name)
+            for v in versions:
+                contracts.append({"id": cid_dir.name, "version": v})
+    return templates.TemplateResponse("contracts.html", {"request": request, "contracts": contracts})
+
+
+@app.get("/contracts/new", response_class=HTMLResponse)
+async def new_contract_form(request: Request) -> HTMLResponse:
+    return templates.TemplateResponse("new_contract.html", {"request": request})
+
+
+@app.post("/contracts/new", response_class=HTMLResponse)
+async def create_contract(
+    request: Request,
+    contract_id: str = Form(...),
+    contract_version: str = Form(...),
+    name: str = Form(...),
+    description: str = Form(""),
+    columns: str = Form(""),
+) -> HTMLResponse:
+    try:
+        props = []
+        for line in columns.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            col_name, col_type = [p.strip() for p in line.split(":", 1)]
+            props.append(SchemaProperty(name=col_name, physicalType=col_type, required=True))
+        model = OpenDataContractStandard(
+            version=contract_version,
+            kind="DataContract",
+            apiVersion="3.0.2",
+            id=contract_id,
+            name=name,
+            description=Description(usage=description),
+            schema=[SchemaObject(name=name, properties=props)],
+        )
+        store.put(model)
+        return RedirectResponse(url="/contracts", status_code=303)
+    except ValidationError as ve:
+        error = str(ve)
+    except Exception as exc:  # pragma: no cover - display any other error
+        error = str(exc)
+    context = {
+        "request": request,
+        "error": error,
+        "contract_id": contract_id,
+        "contract_version": contract_version,
+        "name": name,
+        "description": description,
+        "columns": columns,
+    }
+    return templates.TemplateResponse("new_contract.html", context)
+
+
+@app.get("/datasets", response_class=HTMLResponse)
+async def list_datasets(request: Request) -> HTMLResponse:
+    records = load_records()
+    contract_ids = [d.name for d in CONTRACT_DIR.glob("*") if d.is_dir()]
+    return templates.TemplateResponse(
+        "datasets.html", {"request": request, "records": records, "contract_ids": contract_ids}
+    )
+
+
+@app.post("/pipeline/run", response_class=HTMLResponse)
+async def run_pipeline_endpoint(
+    contract_id: str = Form(...),
+    contract_version: str = Form(...),
+    dataset_version: str = Form(...),
+) -> HTMLResponse:
+    from .pipeline import run_pipeline
+
+    input_path = str(DATA_DIR / "sample_input.json")
+    output_dir = DATA_DIR / "outputs"
+    output_dir.mkdir(exist_ok=True)
+    output_path = str(output_dir / dataset_version)
+    run_pipeline(contract_id, contract_version, input_path, output_path, dataset_version)
+    return RedirectResponse(url="/datasets", status_code=303)
+
+
+def run() -> None:  # pragma: no cover - convenience runner
+    """Run the demo app with uvicorn."""
+    import uvicorn
+
+    uvicorn.run("dc43.demo_app.server:app", host="0.0.0.0", port=8000)

--- a/src/dc43/demo_app/static/app.js
+++ b/src/dc43/demo_app/static/app.js
@@ -1,0 +1,31 @@
+const { createApp } = Vue;
+
+createApp({
+  data() {
+    return {
+      view: 'datasets',
+      datasets: [],
+      contracts: [],
+      datasetDetail: null,
+      contractDetail: null,
+    };
+  },
+  methods: {
+    refresh() {
+      fetch('/api/datasets').then(r => r.json()).then(d => this.datasets = d);
+      fetch('/api/contracts').then(r => r.json()).then(d => this.contracts = d);
+    },
+    openDataset(ver) {
+      fetch(`/api/datasets/${ver}`).then(r => r.json()).then(d => { this.datasetDetail = d; this.view = 'dataset-detail'; });
+    },
+    openContract(id, ver) {
+      fetch(`/api/contracts/${id}/${ver}`).then(r => r.json()).then(d => { this.contractDetail = d; this.view = 'contract-detail'; });
+    },
+    validateContract(id, ver) {
+      fetch(`/api/contracts/${id}/${ver}/validate`, {method: 'POST'}).then(() => this.refresh());
+    }
+  },
+  mounted() {
+    this.refresh();
+  }
+}).mount('#app');

--- a/src/dc43/demo_app/static/index.html
+++ b/src/dc43/demo_app/static/index.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>DC43 Demo</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body>
+<div id="app" class="container py-4">
+  <h1 class="mb-4">DC43 Demo</h1>
+  <div class="mb-3">
+    <button class="btn btn-primary me-2" @click="view='datasets'">Datasets</button>
+    <button class="btn btn-secondary" @click="view='contracts'">Contracts</button>
+  </div>
+
+  <div v-if="view==='datasets'">
+    <h2>Datasets</h2>
+    <table class="table">
+      <thead><tr><th>Dataset Version</th><th>Contract</th><th>Status</th><th></th></tr></thead>
+      <tbody>
+        <tr v-for="ds in datasets" :key="ds.dataset_version" :class="{'table-warning': ds.contract_status==='draft'}">
+          <td><a href="#" @click.prevent="openDataset(ds.dataset_version)">{{ ds.dataset_version }}</a></td>
+          <td>{{ ds.contract_id }}:{{ ds.contract_version }} <span class="badge bg-warning text-dark" v-if="ds.contract_status==='draft'">draft</span></td>
+          <td>{{ ds.status }}</td>
+          <td v-if="ds.contract_status==='draft'"><button class="btn btn-sm btn-outline-primary" @click="validateContract(ds.contract_id, ds.contract_version)">Validate</button></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div v-if="view==='dataset-detail'">
+    <button class="btn btn-link" @click="view='datasets'">&larr; Back</button>
+    <h2>Dataset {{datasetDetail.record.dataset_version}}</h2>
+    <p><strong>Contract:</strong> {{datasetDetail.record.contract_id}}:{{datasetDetail.record.contract_version}}</p>
+    <p><strong>Status:</strong> {{datasetDetail.record.status}}</p>
+    <div>
+      <h3>Schema</h3>
+      <ul>
+        <li v-for="prop in datasetDetail.contract.schema[0].properties" :key="prop.name">{{ prop.name }}: {{ prop.physicalType }}</li>
+      </ul>
+    </div>
+    <div>
+      <h3>Data Quality</h3>
+      <table class="table">
+        <thead><tr><th>Rule</th><th>Predicate</th><th>Violations</th></tr></thead>
+        <tbody>
+          <tr v-for="(expr, name) in datasetDetail.expectations" :key="name">
+            <td>{{ name }}</td>
+            <td>{{ expr }}</td>
+            <td>{{ datasetDetail.record.dq_details.metrics['violations.' + name] || 0 }}</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>Row count: {{ datasetDetail.record.dq_details.metrics['row_count'] }}</p>
+    </div>
+  </div>
+
+  <div v-if="view==='contracts'">
+    <h2>Contracts</h2>
+    <table class="table">
+      <thead><tr><th>Contract</th><th>Status</th></tr></thead>
+      <tbody>
+        <tr v-for="c in contracts" :key="c.id + c.version">
+          <td><a href="#" @click.prevent="openContract(c.id, c.version)">{{c.id}}:{{c.version}}</a></td>
+          <td>{{ c.status }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div v-if="view==='contract-detail'">
+    <button class="btn btn-link" @click="view='contracts'">&larr; Back</button>
+    <h2>Contract {{contractDetail.contract.id}}:{{contractDetail.contract.version}}</h2>
+    <p><strong>Status:</strong> {{contractDetail.status}}</p>
+    <div>
+      <h3>Schema</h3>
+      <ul>
+        <li v-for="prop in contractDetail.contract.schema[0].properties" :key="prop.name">{{prop.name}}: {{prop.physicalType}}</li>
+      </ul>
+    </div>
+    <div>
+      <h3>Data Quality Rules</h3>
+      <ul>
+        <li v-for="(expr, name) in contractDetail.expectations" :key="name">{{name}}: {{expr}}</li>
+      </ul>
+    </div>
+    <div>
+      <h3>Dataset history</h3>
+      <ul>
+        <li v-for="r in contractDetail.datasets" :key="r.dataset_version">
+          {{r.dataset_version}} - {{r.status}}
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+<script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+<script src="/static/app.js"></script>
+</body>
+</html>

--- a/src/dc43/demo_app/static/presentation.html
+++ b/src/dc43/demo_app/static/presentation.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>dc43 demo presentation</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/reveal.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/theme/white.css">
+</head>
+<body>
+<div class="reveal">
+  <div class="slides">
+    <section>
+      <h1>dc43 Demo</h1>
+      <p>Data contracts, automation and quality checks</p>
+    </section>
+    <section>
+      <h2>1. Author Contract</h2>
+      <p>Describe schema and quality rules using ODCS.</p>
+    </section>
+    <section>
+      <h2>2. Register Dataset Versions</h2>
+      <p>Pipelines write data and log dataset versions automatically.</p>
+    </section>
+    <section>
+      <h2>3. Validate and Collect Metrics</h2>
+      <p>Contracts drive data validation and DQ metric computation.</p>
+    </section>
+    <section>
+      <h2>4. Review & Promote</h2>
+      <p>UI highlights drafts, violations and contract status.</p>
+    </section>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/reveal.js"></script>
+<script>
+  Reveal.initialize();
+</script>
+</body>
+</html>

--- a/src/dc43/demo_app/templates/base.html
+++ b/src/dc43/demo_app/templates/base.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>DC43 Demo</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="/contracts">DC43 Demo</a>
+    <div class="navbar-nav">
+      <a class="nav-link" href="/contracts">Contracts</a>
+      <a class="nav-link" href="/datasets">Datasets</a>
+    </div>
+  </div>
+</nav>
+<div class="container">
+{% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/src/dc43/demo_app/templates/contracts.html
+++ b/src/dc43/demo_app/templates/contracts.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Contracts</h1>
+<a class="btn btn-primary mb-3" href="/contracts/new">Add Contract</a>
+<table class="table table-striped">
+    <thead><tr><th>Contract ID</th><th>Version</th></tr></thead>
+    <tbody>
+    {% for c in contracts %}
+    <tr><td>{{ c.id }}</td><td>{{ c.version }}</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% if not contracts %}<p>No contracts stored.</p>{% endif %}
+{% endblock %}

--- a/src/dc43/demo_app/templates/datasets.html
+++ b/src/dc43/demo_app/templates/datasets.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Datasets</h1>
+<form class="row g-3 mb-4" method="post" action="/pipeline/run">
+  <div class="col-md-4">
+    <label class="form-label">Contract ID</label>
+    <select class="form-select" name="contract_id">
+      {% for cid in contract_ids %}
+      <option value="{{ cid }}">{{ cid }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-md-3">
+    <label class="form-label">Contract Version</label>
+    <input class="form-control" name="contract_version"/>
+  </div>
+  <div class="col-md-3">
+    <label class="form-label">Dataset Version</label>
+    <input class="form-control" name="dataset_version"/>
+  </div>
+  <div class="col-md-2 align-self-end">
+    <button class="btn btn-primary w-100" type="submit">Run Pipeline</button>
+  </div>
+</form>
+<table class="table table-striped">
+  <thead><tr><th>Contract ID</th><th>Contract Version</th><th>Dataset Version</th><th>Status</th></tr></thead>
+  <tbody>
+  {% for r in records %}
+  <tr><td>{{ r.contract_id }}</td><td>{{ r.contract_version }}</td><td>{{ r.dataset_version }}</td><td>{{ r.status }}</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% if not records %}<p>No datasets registered.</p>{% endif %}
+{% endblock %}

--- a/src/dc43/demo_app/templates/new_contract.html
+++ b/src/dc43/demo_app/templates/new_contract.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>New Contract</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Contract ID</label>
+    <input class="form-control" name="contract_id" value="{{ contract_id or '' }}"/>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Version</label>
+    <input class="form-control" name="contract_version" value="{{ contract_version or '' }}"/>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input class="form-control" name="name" value="{{ name or '' }}"/>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Description</label>
+    <input class="form-control" name="description" value="{{ description or '' }}"/>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Columns (name:type per line)</label>
+    <textarea class="form-control" name="columns" rows="5" placeholder="order_id:bigint&#10;amount:double">{{ columns or '' }}</textarea>
+  </div>
+  <button class="btn btn-primary" type="submit">Save</button>
+</form>
+{% if error %}<div class="alert alert-danger mt-3">{{ error }}</div>{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- expose contract data-quality rules and violations in the demo UI
- include a Reveal.js slide deck illustrating the contract lifecycle
- document viewing DQ metrics and the presentation link
- normalize contract API output so the Vue views read `schema` data correctly

## Testing
- `python -m pip install pyspark` *(fails: Could not find a version that satisfies the requirement pyspark)*
- `pytest` *(fails: Skipped: pyspark required for dc43 tests)*

------
https://chatgpt.com/codex/tasks/task_b_68b7d270db08832eac3e4c7ed9c9a1b2