### PR TITLE
feat(demo): add draft and invalid dataset flows

### DIFF
--- a/src/dc43/demo_app/pipeline.py
+++ b/src/dc43/demo_app/pipeline.py
@@ -15,9 +15,11 @@ from dc43.demo_app.server import (
     DatasetRecord,
     load_records,
     save_records,
+    set_contract_status,
 )
 from dc43.dq.stub import StubDQClient
-from dc43.integration.spark_io import read_with_contract, write_with_contract
+from dc43.dq.metrics import compute_metrics
+from dc43.integration.spark_io import write_with_contract
 from pyspark.sql import SparkSession
 
 
@@ -27,36 +29,74 @@ def run_pipeline(
     input_path: str,
     output_path: str,
     dataset_version: str,
+    *,
+    mode: str = "contract",
 ) -> None:
-    """Run an example pipeline using the stored contract."""
+    """Run an example pipeline using the stored contract.
+
+    Parameters
+    ----------
+    mode:
+        ``"contract"``      - enforce contract and run DQ metrics.
+        ``"draft"``         - allow mismatches and create a draft contract.
+        ``"invalid"``       - intentionally produce data violating expectations.
+    """
+
     spark = SparkSession.builder.appName("dc43-demo").getOrCreate()
     contract = store.get(contract_id, contract_version)
     dq = StubDQClient(base_path=str(Path(DATASETS_FILE).parent / "dq_state"))
-    df, status = read_with_contract(
-        spark,
-        format="json",
-        path=input_path,
-        contract=contract,
-        expected_contract_version=f"=={contract_version}",
-        dq_client=dq,
-        return_status=True,
-    )
-    # placeholder transformation could occur here
-    write_with_contract(
-        df=df,
-        contract=contract,
-        path=output_path,
-        mode="overwrite",
-        enforce=True,
-    )
+
+    df = spark.read.json(input_path)
+
+    status_str = "unknown"
+    details = {}
+
+    if mode == "draft":
+        vr, draft = write_with_contract(
+            df=df,
+            contract=contract,
+            path=output_path,
+            mode="overwrite",
+            enforce=False,
+            draft_on_mismatch=True,
+            draft_store=store,
+            return_draft=True,
+        )
+        if draft is not None:
+            contract_version = draft.version
+            set_contract_status(contract_id, contract_version, "draft")
+    else:
+        if mode == "invalid":
+            df = df.selectExpr("order_id as id", "-abs(amount) as amount")
+        else:  # "contract" flow
+            df = df.selectExpr("order_id as id", "amount")
+
+        write_with_contract(
+            df=df,
+            contract=contract,
+            path=output_path,
+            mode="overwrite",
+            enforce=True,
+        )
+
+        metrics = compute_metrics(df, contract)
+        dq_status = dq.submit_metrics(
+            contract=contract,
+            dataset_id=output_path,
+            dataset_version=dataset_version,
+            metrics=metrics,
+        )
+        status_str = dq_status.status
+        details = dq_status.details or {}
+
     records = load_records()
     records.append(
         DatasetRecord(
             contract_id,
             contract_version,
             dataset_version,
-            status.status,
-            status.details or {},
+            status_str,
+            details,
         )
     )
     save_records(records)

--- a/src/dc43/demo_app/server.py
+++ b/src/dc43/demo_app/server.py
@@ -249,6 +249,7 @@ async def run_pipeline_endpoint(
     contract_id: str = Form(...),
     contract_version: str = Form(...),
     dataset_version: str = Form(...),
+    mode: str = Form("contract"),
 ) -> HTMLResponse:
     from .pipeline import run_pipeline
 
@@ -256,7 +257,7 @@ async def run_pipeline_endpoint(
     output_dir = DATA_DIR / "outputs"
     output_dir.mkdir(exist_ok=True)
     output_path = str(output_dir / dataset_version)
-    run_pipeline(contract_id, contract_version, input_path, output_path, dataset_version)
+    run_pipeline(contract_id, contract_version, input_path, output_path, dataset_version, mode=mode)
     return RedirectResponse(url="/datasets", status_code=303)
 
 

--- a/src/dc43/demo_app/templates/datasets.html
+++ b/src/dc43/demo_app/templates/datasets.html
@@ -2,7 +2,7 @@
 {% block content %}
 <h1>Datasets</h1>
 <form class="row g-3 mb-4" method="post" action="/pipeline/run">
-  <div class="col-md-4">
+  <div class="col-md-3">
     <label class="form-label">Contract ID</label>
     <select class="form-select" name="contract_id">
       {% for cid in contract_ids %}
@@ -10,13 +10,21 @@
       {% endfor %}
     </select>
   </div>
-  <div class="col-md-3">
+  <div class="col-md-2">
     <label class="form-label">Contract Version</label>
     <input class="form-control" name="contract_version"/>
   </div>
   <div class="col-md-3">
     <label class="form-label">Dataset Version</label>
     <input class="form-control" name="dataset_version"/>
+  </div>
+  <div class="col-md-2">
+    <label class="form-label">Mode</label>
+    <select class="form-select" name="mode">
+      <option value="contract">Contract</option>
+      <option value="draft">Draft</option>
+      <option value="invalid">Invalid</option>
+    </select>
   </div>
   <div class="col-md-2 align-self-end">
     <button class="btn btn-primary w-100" type="submit">Run Pipeline</button>


### PR DESCRIPTION
## Summary
- extend demo pipeline with `mode` parameter to handle draft, contract, and invalid flows
- expose pipeline mode in UI and server endpoint
- record dataset status and contract version for draft runs

## Testing
- `pytest -q` *(fails: Skipped: pyspark required for dc43 tests)*

------
https://chatgpt.com/codex/tasks/task_b_68b7f69db6d4832e97e970d302a30ea8