### PR TITLE
Enhance demo app pipeline UI and dataset metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,11 @@ package-dir = {"" = "src"}
 where = ["src"]
 
 [tool.setuptools.package-data]
-"dc43.demo_app" = ["demo_data/**/*", "static/**/*"]
+"dc43.demo_app" = [
+  "demo_data/**/*",
+  "static/**/*",
+  "templates/**/*",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/dc43/demo_app/demo_data/contract_meta.json
+++ b/src/dc43/demo_app/demo_data/contract_meta.json
@@ -1,3 +1,4 @@
 [
-  {"id": "orders", "version": "1.0.0", "status": "draft"}
+  {"id": "orders", "version": "1.0.0", "status": "draft"},
+  {"id": "orders", "version": "1.1.0", "status": "draft"}
 ]

--- a/src/dc43/demo_app/demo_data/contracts/orders/1.0.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/orders/1.0.0.json
@@ -6,6 +6,13 @@
   "name": "Orders",
   "description": {"usage": "Sample orders contract"},
   "status": "draft",
+  "servers": [
+    {
+      "server": "local",
+      "type": "filesystem",
+      "path": "outputs/orders"
+    }
+  ],
   "schema": [
     {
       "name": "orders",
@@ -13,7 +20,7 @@
         {"name": "id", "physicalType": "integer", "required": true, "unique": true},
         {
           "name": "amount",
-          "physicalType": "number",
+          "physicalType": "double",
           "required": true,
           "quality": [
             {"mustBeGreaterThan": 0}

--- a/src/dc43/demo_app/demo_data/contracts/orders/1.0.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/orders/1.0.0.json
@@ -10,14 +10,14 @@
     {
       "server": "local",
       "type": "filesystem",
-      "path": "outputs/orders"
+      "path": "outputs"
     }
   ],
   "schema": [
     {
       "name": "orders",
       "properties": [
-        {"name": "id", "physicalType": "integer", "required": true, "unique": true},
+        {"name": "order_id", "physicalType": "integer", "required": true, "unique": true},
         {
           "name": "amount",
           "physicalType": "double",

--- a/src/dc43/demo_app/demo_data/contracts/orders/1.1.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/orders/1.1.0.json
@@ -1,0 +1,32 @@
+{
+  "version": "1.1.0",
+  "kind": "DataContract",
+  "apiVersion": "3.0.2",
+  "id": "orders",
+  "name": "Orders",
+  "description": {"usage": "Sample orders contract"},
+  "status": "draft",
+  "servers": [
+    {
+      "server": "local",
+      "type": "filesystem",
+      "path": "outputs"
+    }
+  ],
+  "schema": [
+    {
+      "name": "orders",
+      "properties": [
+        {"name": "order_id", "physicalType": "integer", "required": true, "unique": true},
+        {
+          "name": "amount",
+          "physicalType": "double",
+          "required": true,
+          "quality": [
+            {"mustBeGreaterThan": 0}
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/dc43/demo_app/demo_data/datasets.json
+++ b/src/dc43/demo_app/demo_data/datasets.json
@@ -2,6 +2,7 @@
   {
     "contract_id": "orders",
     "contract_version": "1.0.0",
+    "dataset_name": "orders",
     "dataset_version": "v1",
     "status": "ok",
     "dq_details": {"violations": 0, "metrics": {"row_count": 2}}

--- a/src/dc43/demo_app/demo_data/datasets.json
+++ b/src/dc43/demo_app/demo_data/datasets.json
@@ -1,9 +1,9 @@
 [
   {
     "contract_id": "orders",
-    "contract_version": "1.0.0",
+    "contract_version": "1.1.0",
     "dataset_name": "orders",
-    "dataset_version": "v1",
+    "dataset_version": "1.0.0",
     "status": "ok",
     "dq_details": {"violations": 0, "metrics": {"row_count": 2}}
   }

--- a/src/dc43/demo_app/pipeline.py
+++ b/src/dc43/demo_app/pipeline.py
@@ -21,11 +21,20 @@ from dc43.integration.spark_io import read_with_contract, write_with_contract
 from pyspark.sql import SparkSession
 
 
+def _next_version(existing: list[str]) -> str:
+    """Return the next patch version given existing semver strings."""
+    if not existing:
+        return "1.0.0"
+    parts = [list(map(int, v.split("."))) for v in existing]
+    major, minor, patch = max(parts)
+    return f"{major}.{minor}.{patch + 1}"
+
+
 def run_pipeline(
     contract_id: str,
     contract_version: str,
     dataset_name: str,
-    dataset_version: str,
+    dataset_version: str | None,
     run_type: str,
     input_path: str,
 ) -> None:
@@ -43,6 +52,10 @@ def run_pipeline(
         return_status=True,
     )
     # placeholder transformation could occur here
+    records = load_records()
+    if not dataset_version:
+        existing = [r.dataset_version for r in records if r.dataset_name == dataset_name]
+        dataset_version = _next_version(existing)
     server = (contract.servers or [None])[0]
     base_path = Path(getattr(server, "path", "")) if server else Path()
     if not base_path.is_absolute():
@@ -56,7 +69,6 @@ def run_pipeline(
         mode="overwrite",
         enforce=True,
     )
-    records = load_records()
     records.append(
         DatasetRecord(
             contract_id,

--- a/src/dc43/demo_app/pipeline.py
+++ b/src/dc43/demo_app/pipeline.py
@@ -24,8 +24,10 @@ from pyspark.sql import SparkSession
 def run_pipeline(
     contract_id: str,
     contract_version: str,
-    input_path: str,
+    dataset_name: str,
     dataset_version: str,
+    run_type: str,
+    input_path: str,
 ) -> None:
     """Run an example pipeline using the stored contract."""
     spark = SparkSession.builder.appName("dc43-demo").getOrCreate()
@@ -45,9 +47,8 @@ def run_pipeline(
     base_path = Path(getattr(server, "path", "")) if server else Path()
     if not base_path.is_absolute():
         base_path = Path(DATASETS_FILE).parent / base_path
-    output_path = base_path / dataset_version
+    output_path = base_path / dataset_name / dataset_version
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    dataset_name = base_path.name
     write_with_contract(
         df=df,
         contract=contract,
@@ -64,6 +65,7 @@ def run_pipeline(
             dataset_version,
             status.status,
             status.details or {},
+            run_type,
         )
     )
     save_records(records)

--- a/src/dc43/demo_app/pipeline.py
+++ b/src/dc43/demo_app/pipeline.py
@@ -25,7 +25,6 @@ def run_pipeline(
     contract_id: str,
     contract_version: str,
     input_path: str,
-    output_path: str,
     dataset_version: str,
 ) -> None:
     """Run an example pipeline using the stored contract."""
@@ -42,10 +41,17 @@ def run_pipeline(
         return_status=True,
     )
     # placeholder transformation could occur here
+    server = (contract.servers or [None])[0]
+    base_path = Path(getattr(server, "path", "")) if server else Path()
+    if not base_path.is_absolute():
+        base_path = Path(DATASETS_FILE).parent / base_path
+    output_path = base_path / dataset_version
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    dataset_name = base_path.name
     write_with_contract(
         df=df,
         contract=contract,
-        path=output_path,
+        path=str(output_path),
         mode="overwrite",
         enforce=True,
     )
@@ -54,6 +60,7 @@ def run_pipeline(
         DatasetRecord(
             contract_id,
             contract_version,
+            dataset_name,
             dataset_version,
             status.status,
             status.details or {},

--- a/src/dc43/demo_app/server.py
+++ b/src/dc43/demo_app/server.py
@@ -65,6 +65,7 @@ class DatasetRecord:
     dataset_version: str = ""
     status: str = "unknown"
     dq_details: Dict[str, Any] = field(default_factory=dict)
+    run_type: str = "unknown"
 
 
 def load_records() -> List[DatasetRecord]:
@@ -267,12 +268,14 @@ async def list_datasets(request: Request) -> HTMLResponse:
     contract_ids = sorted({m["id"] for m in meta})
     contract_versions = {cid: sorted([m["version"] for m in meta if m["id"] == cid]) for cid in contract_ids}
     dataset_versions = sorted({r.dataset_version for r in records if r.dataset_version})
+    dataset_names = sorted({r.dataset_name for r in records if r.dataset_name})
     context = {
         "request": request,
         "records": records,
         "contract_ids": contract_ids,
         "contract_versions": contract_versions,
         "dataset_versions": dataset_versions,
+        "dataset_names": dataset_names,
     }
     return templates.TemplateResponse("datasets.html", context)
 
@@ -281,7 +284,9 @@ async def list_datasets(request: Request) -> HTMLResponse:
 async def run_pipeline_endpoint(
     contract_id: str = Form(...),
     contract_version: str = Form(...),
+    dataset_name: str = Form(...),
     dataset_version: str = Form(...),
+    run_type: str = Form("unknown"),
 ) -> HTMLResponse:
     from .pipeline import run_pipeline
 
@@ -289,8 +294,10 @@ async def run_pipeline_endpoint(
     run_pipeline(
         contract_id,
         contract_version,
-        input_path,
+        dataset_name,
         dataset_version,
+        run_type,
+        input_path,
     )
     return RedirectResponse(url="/datasets", status_code=303)
 

--- a/src/dc43/demo_app/server.py
+++ b/src/dc43/demo_app/server.py
@@ -266,7 +266,7 @@ async def list_datasets(request: Request) -> HTMLResponse:
     records = load_records()
     meta = load_contract_meta()
     contract_ids = sorted({m["id"] for m in meta})
-    contract_versions = {cid: sorted([m["version"] for m in meta if m["id"] == cid]) for cid in contract_ids}
+    contract_versions = {cid: sorted([m["version"] for m in meta if m["id"] == cid], reverse=True) for cid in contract_ids}
     dataset_versions = sorted({r.dataset_version for r in records if r.dataset_version})
     dataset_names = sorted({r.dataset_name for r in records if r.dataset_name})
     context = {
@@ -285,7 +285,7 @@ async def run_pipeline_endpoint(
     contract_id: str = Form(...),
     contract_version: str = Form(...),
     dataset_name: str = Form(...),
-    dataset_version: str = Form(...),
+    dataset_version: str = Form(""),
     run_type: str = Form("unknown"),
 ) -> HTMLResponse:
     from .pipeline import run_pipeline
@@ -295,7 +295,7 @@ async def run_pipeline_endpoint(
         contract_id,
         contract_version,
         dataset_name,
-        dataset_version,
+        dataset_version or None,
         run_type,
         input_path,
     )

--- a/src/dc43/demo_app/static/index.html
+++ b/src/dc43/demo_app/static/index.html
@@ -10,7 +10,9 @@
   <h1 class="mb-4">DC43 Demo</h1>
   <div class="mb-3">
     <button class="btn btn-primary me-2" @click="view='datasets'">Datasets</button>
-    <button class="btn btn-secondary" @click="view='contracts'">Contracts</button>
+    <button class="btn btn-secondary me-2" @click="view='contracts'">Contracts</button>
+    <a class="btn btn-outline-primary me-2" href="/datasets">Pipeline Form</a>
+    <a class="btn btn-outline-secondary" href="/contracts">Contracts UI</a>
   </div>
 
   <div v-if="view==='datasets'">

--- a/src/dc43/demo_app/static/index.html
+++ b/src/dc43/demo_app/static/index.html
@@ -6,6 +6,15 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
 </head>
 <body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="/">DC43 Demo</a>
+    <div class="navbar-nav">
+      <a class="nav-link" href="/contracts">Contracts</a>
+      <a class="nav-link" href="/datasets">Datasets</a>
+    </div>
+  </div>
+</nav>
 <div id="app" class="container py-4">
   <h1 class="mb-4">DC43 Demo</h1>
   <div class="mb-3">

--- a/src/dc43/demo_app/templates/base.html
+++ b/src/dc43/demo_app/templates/base.html
@@ -9,7 +9,7 @@
 <body>
 <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
   <div class="container-fluid">
-    <a class="navbar-brand" href="/contracts">DC43 Demo</a>
+    <a class="navbar-brand" href="/">DC43 Demo</a>
     <div class="navbar-nav">
       <a class="nav-link" href="/contracts">Contracts</a>
       <a class="nav-link" href="/datasets">Datasets</a>

--- a/src/dc43/demo_app/templates/contracts.html
+++ b/src/dc43/demo_app/templates/contracts.html
@@ -3,10 +3,10 @@
 <h1>Contracts</h1>
 <a class="btn btn-primary mb-3" href="/contracts/new">Add Contract</a>
 <table class="table table-striped">
-    <thead><tr><th>Contract ID</th><th>Version</th></tr></thead>
+    <thead><tr><th>Contract ID</th><th>Version</th><th>Dataset Path</th></tr></thead>
     <tbody>
     {% for c in contracts %}
-    <tr><td>{{ c.id }}</td><td>{{ c.version }}</td></tr>
+    <tr><td>{{ c.id }}</td><td>{{ c.version }}</td><td>{{ c.path or '' }}</td></tr>
     {% endfor %}
     </tbody>
 </table>

--- a/src/dc43/demo_app/templates/datasets.html
+++ b/src/dc43/demo_app/templates/datasets.html
@@ -4,31 +4,52 @@
 <form class="row g-3 mb-4" method="post" action="/pipeline/run">
   <div class="col-md-4">
     <label class="form-label">Contract ID</label>
-    <select class="form-select" name="contract_id">
+    <select class="form-select" name="contract_id" id="contract_id">
       {% for cid in contract_ids %}
       <option value="{{ cid }}">{{ cid }}</option>
       {% endfor %}
     </select>
   </div>
-  <div class="col-md-3">
+  <div class="col-md-4">
     <label class="form-label">Contract Version</label>
-    <input class="form-control" name="contract_version"/>
+    <select class="form-select" name="contract_version" id="contract_version"></select>
   </div>
-  <div class="col-md-3">
+  <div class="col-md-2">
     <label class="form-label">Dataset Version</label>
-    <input class="form-control" name="dataset_version"/>
+    <input class="form-control" name="dataset_version" list="dataset_versions"/>
+    <datalist id="dataset_versions">
+      {% for dv in dataset_versions %}
+      <option value="{{ dv }}"/>
+      {% endfor %}
+    </datalist>
   </div>
   <div class="col-md-2 align-self-end">
     <button class="btn btn-primary w-100" type="submit">Run Pipeline</button>
   </div>
 </form>
 <table class="table table-striped">
-  <thead><tr><th>Contract ID</th><th>Contract Version</th><th>Dataset Version</th><th>Status</th></tr></thead>
+  <thead><tr><th>Contract ID</th><th>Contract Version</th><th>Dataset</th><th>Version</th><th>Status</th></tr></thead>
   <tbody>
   {% for r in records %}
-  <tr><td>{{ r.contract_id }}</td><td>{{ r.contract_version }}</td><td>{{ r.dataset_version }}</td><td>{{ r.status }}</td></tr>
+  <tr><td>{{ r.contract_id }}</td><td>{{ r.contract_version }}</td><td>{{ r.dataset_name }}</td><td>{{ r.dataset_version }}</td><td>{{ r.status }}</td></tr>
   {% endfor %}
   </tbody>
 </table>
+<script>
+  const contractVersions = {{ contract_versions | tojson }};
+  const cidSel = document.getElementById('contract_id');
+  const verSel = document.getElementById('contract_version');
+  function updateVersions() {
+    verSel.innerHTML = '';
+    (contractVersions[cidSel.value] || []).forEach(v => {
+      const opt = document.createElement('option');
+      opt.value = v;
+      opt.textContent = v;
+      verSel.appendChild(opt);
+    });
+  }
+  cidSel.addEventListener('change', updateVersions);
+  updateVersions();
+</script>
 {% if not records %}<p>No datasets registered.</p>{% endif %}
 {% endblock %}

--- a/src/dc43/demo_app/templates/datasets.html
+++ b/src/dc43/demo_app/templates/datasets.html
@@ -15,6 +15,15 @@
     <select class="form-select" name="contract_version" id="contract_version"></select>
   </div>
   <div class="col-md-2">
+    <label class="form-label">Dataset Name</label>
+    <input class="form-control" name="dataset_name" list="dataset_names"/>
+    <datalist id="dataset_names">
+      {% for dn in dataset_names %}
+      <option value="{{ dn }}"/>
+      {% endfor %}
+    </datalist>
+  </div>
+  <div class="col-md-2">
     <label class="form-label">Dataset Version</label>
     <input class="form-control" name="dataset_version" list="dataset_versions"/>
     <datalist id="dataset_versions">
@@ -23,15 +32,23 @@
       {% endfor %}
     </datalist>
   </div>
+  <div class="col-md-2">
+    <label class="form-label">Run Type</label>
+    <select class="form-select" name="run_type">
+      <option value="new">New output without contract</option>
+      <option value="known">Output with known valid contract</option>
+      <option value="unknown">Unknown</option>
+    </select>
+  </div>
   <div class="col-md-2 align-self-end">
     <button class="btn btn-primary w-100" type="submit">Run Pipeline</button>
   </div>
 </form>
 <table class="table table-striped">
-  <thead><tr><th>Contract ID</th><th>Contract Version</th><th>Dataset</th><th>Version</th><th>Status</th></tr></thead>
+  <thead><tr><th>Contract ID</th><th>Contract Version</th><th>Dataset</th><th>Version</th><th>Run Type</th><th>Status</th></tr></thead>
   <tbody>
   {% for r in records %}
-  <tr><td>{{ r.contract_id }}</td><td>{{ r.contract_version }}</td><td>{{ r.dataset_name }}</td><td>{{ r.dataset_version }}</td><td>{{ r.status }}</td></tr>
+  <tr><td>{{ r.contract_id }}</td><td>{{ r.contract_version }}</td><td>{{ r.dataset_name }}</td><td>{{ r.dataset_version }}</td><td>{{ r.run_type }}</td><td>{{ r.status }}</td></tr>
   {% endfor %}
   </tbody>
 </table>

--- a/src/dc43/demo_app/templates/datasets.html
+++ b/src/dc43/demo_app/templates/datasets.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Datasets</h1>
+{% if message %}<div class="alert alert-success">{{ message }}</div>{% endif %}
+{% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
 <form class="row g-3 mb-4" method="post" action="/pipeline/run">
   <div class="col-md-4">
     <label class="form-label">Contract ID</label>
@@ -58,12 +60,16 @@
   const verSel = document.getElementById('contract_version');
   function updateVersions() {
     verSel.innerHTML = '';
-    (contractVersions[cidSel.value] || []).forEach(v => {
+    const versions = contractVersions[cidSel.value] || [];
+    versions.forEach(v => {
       const opt = document.createElement('option');
       opt.value = v;
       opt.textContent = v;
       verSel.appendChild(opt);
     });
+    if (versions.length) {
+      verSel.value = versions[0];
+    }
   }
   cidSel.addEventListener('change', updateVersions);
   updateVersions();

--- a/src/dc43/demo_app/templates/datasets.html
+++ b/src/dc43/demo_app/templates/datasets.html
@@ -24,8 +24,8 @@
     </datalist>
   </div>
   <div class="col-md-2">
-    <label class="form-label">Dataset Version</label>
-    <input class="form-control" name="dataset_version" list="dataset_versions"/>
+    <label class="form-label">Dataset Version (optional)</label>
+    <input class="form-control" name="dataset_version" list="dataset_versions" placeholder="auto"/>
     <datalist id="dataset_versions">
       {% for dv in dataset_versions %}
       <option value="{{ dv }}"/>

--- a/src/dc43/demo_app/templates/new_contract.html
+++ b/src/dc43/demo_app/templates/new_contract.html
@@ -19,6 +19,10 @@
     <input class="form-control" name="description" value="{{ description or '' }}"/>
   </div>
   <div class="mb-3">
+    <label class="form-label">Dataset Path</label>
+    <input class="form-control" name="dataset_path" value="{{ dataset_path or '' }}"/>
+  </div>
+  <div class="mb-3">
     <label class="form-label">Columns (name:type per line)</label>
     <textarea class="form-control" name="columns" rows="5" placeholder="order_id:bigint&#10;amount:double">{{ columns or '' }}</textarea>
   </div>

--- a/src/dc43/odcs.py
+++ b/src/dc43/odcs.py
@@ -23,6 +23,7 @@ from open_data_contract_standard.model import (
     SchemaProperty,
     CustomProperty,
     Description,
+    Server,
 )  # type: ignore
 import open_data_contract_standard as _odcs_pkg  # type: ignore
 
@@ -127,6 +128,7 @@ def build_odcs(
     properties: List[SchemaProperty] | None = None,
     schema_objects: List[SchemaObject] | None = None,
     custom_properties: List[CustomProperty] | None = None,
+    servers: List[Server] | None = None,
 ) -> OpenDataContractStandard:
     """Create a minimal ODCS document instance using typed classes.
 
@@ -144,4 +146,5 @@ def build_odcs(
         description=None if description is None else Description(usage=description),
         schema=schema_objects,  # type: ignore[arg-type]
         customProperties=custom_properties,
+        servers=servers,
     )


### PR DESCRIPTION
## Summary
- embed dataset path in contract server property and read it when listing contracts
- pipeline writes to server-defined path and records dataset name automatically
- simplify dataset form and add navigation links from landing page to demo pages

## Testing
- `pytest` *(fails: pyspark required for dc43 tests)*
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68b803422d70832eb667d63ec0de2973