### PR TITLE
Streamline demo pipeline scenarios

### DIFF
--- a/src/dc43/demo_app/demo_data/datasets.json
+++ b/src/dc43/demo_app/demo_data/datasets.json
@@ -1,8 +1,24 @@
 [
   {
     "contract_id": "orders",
+    "contract_version": "1.0.0",
+    "dataset_name": "orders",
+    "dataset_version": "1.0.0",
+    "status": "ok",
+    "dq_details": {"violations": 0, "metrics": {"row_count": 2}}
+  },
+  {
+    "contract_id": "orders",
     "contract_version": "1.1.0",
     "dataset_name": "orders",
+    "dataset_version": "1.1.0",
+    "status": "ok",
+    "dq_details": {"violations": 0, "metrics": {"row_count": 2}}
+  },
+  {
+    "contract_id": "customers",
+    "contract_version": "1.0.0",
+    "dataset_name": "customers",
     "dataset_version": "1.0.0",
     "status": "ok",
     "dq_details": {"violations": 0, "metrics": {"row_count": 2}}

--- a/src/dc43/demo_app/server.py
+++ b/src/dc43/demo_app/server.py
@@ -80,6 +80,65 @@ def save_records(records: List[DatasetRecord]) -> None:
     )
 
 
+# Predefined pipeline scenarios exposed in the UI. Each scenario describes the
+# parameters passed to the example pipeline along with a human readable
+# description shown to the user.
+SCENARIOS: Dict[str, Dict[str, Any]] = {
+    "no-contract": {
+        "label": "No contract provided",
+        "description": (
+            "Run without an output contract. Uses orders:1.1.0 and customers:1.0.0 "
+            "as input and is expected to error."
+        ),
+        "params": {
+            "contract_id": None,
+            "contract_version": None,
+            "dataset_name": "result-no-existing-contract",
+            "run_type": "enforce",
+        },
+    },
+    "ok": {
+        "label": "Existing contract OK",
+        "description": (
+            "Enforce contract orders_enriched:1.0.0 on valid data. "
+            "Produces a new dataset version with status ok."
+        ),
+        "params": {
+            "contract_id": "orders_enriched",
+            "contract_version": "1.0.0",
+            "dataset_name": "output-ok-contract",
+            "run_type": "enforce",
+        },
+    },
+    "dq": {
+        "label": "Existing contract fails DQ",
+        "description": (
+            "Enforce contract orders_enriched:1.1.0 which triggers a data quality "
+            "violation and results in an error."
+        ),
+        "params": {
+            "contract_id": "orders_enriched",
+            "contract_version": "1.1.0",
+            "dataset_name": "output-wrong-quality",
+            "run_type": "enforce",
+        },
+    },
+    "schema-dq": {
+        "label": "Contract fails schema and DQ",
+        "description": (
+            "Enforce contract orders_enriched:2.0.0 causing schema mismatch and "
+            "data quality errors. A draft contract is produced."
+        ),
+        "params": {
+            "contract_id": "orders_enriched",
+            "contract_version": "2.0.0",
+            "dataset_name": "output-ko",
+            "run_type": "enforce",
+        },
+    },
+}
+
+
 def load_contract_meta() -> List[Dict[str, Any]]:
     meta = json.loads(CONTRACT_META_FILE.read_text())
     for m in meta:
@@ -265,18 +324,10 @@ async def create_contract(
 @app.get("/datasets", response_class=HTMLResponse)
 async def list_datasets(request: Request) -> HTMLResponse:
     records = load_records()
-    meta = load_contract_meta()
-    contract_ids = sorted({m["id"] for m in meta})
-    contract_versions = {cid: sorted([m["version"] for m in meta if m["id"] == cid], reverse=True) for cid in contract_ids}
-    dataset_versions = sorted({r.dataset_version for r in records if r.dataset_version})
-    dataset_names = sorted({r.dataset_name for r in records if r.dataset_name})
     context = {
         "request": request,
         "records": records,
-        "contract_ids": contract_ids,
-        "contract_versions": contract_versions,
-        "dataset_versions": dataset_versions,
-        "dataset_names": dataset_names,
+        "scenarios": SCENARIOS,
         "message": request.query_params.get("msg"),
         "error": request.query_params.get("error"),
     }
@@ -284,26 +335,25 @@ async def list_datasets(request: Request) -> HTMLResponse:
 
 
 @app.post("/pipeline/run", response_class=HTMLResponse)
-async def run_pipeline_endpoint(
-    contract_id: str = Form(""),
-    contract_version: str = Form(""),
-    dataset_name: str = Form(...),
-    dataset_version: str = Form(""),
-    run_type: str = Form("infer"),
-) -> HTMLResponse:
+async def run_pipeline_endpoint(scenario: str = Form(...)) -> HTMLResponse:
     from .pipeline import run_pipeline
 
     input_path = str(DATA_DIR / "sample_input.json")
+    cfg = SCENARIOS.get(scenario)
+    if not cfg:
+        params = urlencode({"error": f"Unknown scenario: {scenario}"})
+        return RedirectResponse(url=f"/datasets?{params}", status_code=303)
+    p = cfg["params"]
     try:
         new_version = run_pipeline(
-            contract_id or None,
-            contract_version or None,
-            dataset_name,
-            dataset_version or None,
-            run_type,
+            p.get("contract_id"),
+            p.get("contract_version"),
+            p["dataset_name"],
+            p.get("dataset_version"),
+            p.get("run_type", "infer"),
             input_path,
         )
-        params = urlencode({"msg": f"Run succeeded: {dataset_name} {new_version}"})
+        params = urlencode({"msg": f"Run succeeded: {p['dataset_name']} {new_version}"})
     except Exception as exc:  # pragma: no cover - surface pipeline errors
         params = urlencode({"error": str(exc)})
     return RedirectResponse(url=f"/datasets?{params}", status_code=303)

--- a/src/dc43/demo_app/templates/datasets.html
+++ b/src/dc43/demo_app/templates/datasets.html
@@ -4,53 +4,15 @@
 {% if message %}<div class="alert alert-success">{{ message }}</div>{% endif %}
 {% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
 <form class="row g-3 mb-4" method="post" action="/pipeline/run">
-  <div class="col-md-3">
+  <div class="col-md-4">
     <label class="form-label">Scenario</label>
-    <select class="form-select" id="scenario">
-      <option value="">(custom)</option>
-      <option value="no-contract">No contract provided</option>
-      <option value="ok">Existing contract OK</option>
-      <option value="dq">Existing contract fails DQ</option>
-      <option value="schema-dq">Contract fails schema and DQ</option>
-    </select>
-  </div>
-  <div class="col-md-3">
-    <label class="form-label">Contract ID</label>
-    <select class="form-select" name="contract_id" id="contract_id">
-      <option value="">(none)</option>
-      {% for cid in contract_ids %}
-      <option value="{{ cid }}">{{ cid }}</option>
+    <select class="form-select" name="scenario" id="scenario">
+      <option value="">Select a scenario</option>
+      {% for key, sc in scenarios.items() %}
+      <option value="{{ key }}">{{ sc.label }}</option>
       {% endfor %}
     </select>
-  </div>
-  <div class="col-md-2">
-    <label class="form-label">Contract Version</label>
-    <select class="form-select" name="contract_version" id="contract_version"></select>
-  </div>
-  <div class="col-md-2">
-    <label class="form-label">Dataset Name</label>
-    <input class="form-control" name="dataset_name" list="dataset_names"/>
-    <datalist id="dataset_names">
-      {% for dn in dataset_names %}
-      <option value="{{ dn }}"/>
-      {% endfor %}
-    </datalist>
-  </div>
-  <div class="col-md-2">
-    <label class="form-label">Dataset Version (optional)</label>
-    <input class="form-control" name="dataset_version" list="dataset_versions" placeholder="auto"/>
-    <datalist id="dataset_versions">
-      {% for dv in dataset_versions %}
-      <option value="{{ dv }}"/>
-      {% endfor %}
-    </datalist>
-  </div>
-  <div class="col-md-2">
-    <label class="form-label">Run Type</label>
-    <select class="form-select" name="run_type">
-      <option value="infer">Infer contract from data</option>
-      <option value="enforce">Enforce existing contract</option>
-    </select>
+    <div class="form-text" id="scenario-desc"></div>
   </div>
   <div class="col-md-2 align-self-end">
     <button class="btn btn-primary w-100" type="submit">Run Pipeline</button>
@@ -83,64 +45,13 @@
     </tbody>
   </table>
 <script>
-    const contractVersions = {{ contract_versions | tojson }};
-    const cidSel = document.getElementById('contract_id');
-    const verSel = document.getElementById('contract_version');
+    const scenarios = {{ scenarios | tojson }};
     const scenarioSel = document.getElementById('scenario');
-    const dsName = document.querySelector('input[name="dataset_name"]');
-    const runTypeSel = document.querySelector('select[name="run_type"]');
-    function updateVersions() {
-    const versions = contractVersions[cidSel.value] || [];
-    verSel.innerHTML = '';
-    if (!versions.length) {
-      const opt = document.createElement('option');
-      opt.value = '';
-      opt.textContent = '';
-      verSel.appendChild(opt);
-      return;
-    }
-    versions.forEach(v => {
-      const opt = document.createElement('option');
-      opt.value = v;
-      opt.textContent = v;
-      verSel.appendChild(opt);
+    const descEl = document.getElementById('scenario-desc');
+    scenarioSel.addEventListener('change', () => {
+      const sc = scenarios[scenarioSel.value];
+      descEl.textContent = sc ? sc.description : '';
     });
-    verSel.value = versions[0];
-  }
-    cidSel.addEventListener('change', updateVersions);
-    updateVersions();
-    function applyScenario() {
-      switch (scenarioSel.value) {
-        case 'no-contract':
-          dsName.value = 'result-no-existing-contract';
-          cidSel.value = '';
-          updateVersions();
-          runTypeSel.value = 'enforce';
-          break;
-        case 'ok':
-          dsName.value = 'output-ok-contract';
-          cidSel.value = 'orders_enriched';
-          updateVersions();
-          verSel.value = '1.0.0';
-          runTypeSel.value = 'enforce';
-          break;
-        case 'dq':
-          dsName.value = 'output-wrong-quality';
-          cidSel.value = 'orders_enriched';
-          updateVersions();
-          verSel.value = '1.1.0';
-          runTypeSel.value = 'enforce';
-          break;
-        case 'schema-dq':
-          dsName.value = 'output-ko';
-          cidSel.value = 'orders_enriched';
-          updateVersions();
-          verSel.value = '2.0.0';
-          runTypeSel.value = 'enforce';
-          break;
-      }
-    }
-    scenarioSel.addEventListener('change', applyScenario);
 </script>
 {% if not records %}<p>No datasets registered.</p>{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- seed demo with orders and customers datasets for main page
- drive pipeline runs through predefined scenarios
- simplify dataset form to single scenario selector with description

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b957818074832e80e643db8e5f90bb