### PR TITLE
Fix demo orders contract to include timestamp and currency

### DIFF
--- a/src/dc43/demo_app/demo_data/contracts/orders/1.1.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/orders/1.1.0.json
@@ -19,6 +19,7 @@
       "properties": [
         {"name": "order_id", "physicalType": "integer", "required": true, "unique": true},
         {"name": "customer_id", "physicalType": "integer", "required": true},
+        {"name": "order_ts", "physicalType": "string", "required": true},
         {
           "name": "amount",
           "physicalType": "double",
@@ -26,7 +27,8 @@
           "quality": [
             {"mustBeGreaterThan": 0}
           ]
-        }
+        },
+        {"name": "currency", "physicalType": "string", "required": true}
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- include `order_ts` and `currency` fields in the demo orders 1.1.0 contract so reads retain required columns

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b97618aba8832eb39f4a1e0b6a64f6