### PR TITLE
feat: configure example collection and surface dq warnings

### DIFF
--- a/src/dc43/demo_app/server.py
+++ b/src/dc43/demo_app/server.py
@@ -137,6 +137,8 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
             "contract_version": "1.1.0",
             "dataset_name": "output-wrong-quality",
             "run_type": "enforce",
+            "collect_examples": True,
+            "examples_limit": 3,
         },
     },
     "schema-dq": {
@@ -370,6 +372,8 @@ async def run_pipeline_endpoint(scenario: str = Form(...)) -> HTMLResponse:
             p["dataset_name"],
             p.get("dataset_version"),
             p.get("run_type", "infer"),
+            p.get("collect_examples", False),
+            p.get("examples_limit", 5),
         )
         params = urlencode({"msg": f"Run succeeded: {p['dataset_name']} {new_version}"})
     except Exception as exc:  # pragma: no cover - surface pipeline errors

--- a/src/dc43/demo_app/templates/datasets.html
+++ b/src/dc43/demo_app/templates/datasets.html
@@ -34,13 +34,27 @@
     <tbody>
     {% for r in records %}
       <tr>
-        <td>{{ r.contract_id }}</td>
-        <td>{{ r.contract_version }}</td>
+        <td><a href="/api/contracts/{{ r.contract_id }}/{{ r.contract_version }}" target="_blank">{{ r.contract_id }}</a></td>
+        <td><a href="/api/contracts/{{ r.contract_id }}/{{ r.contract_version }}" target="_blank">{{ r.contract_version }}</a></td>
         <td>{{ r.dataset_name }}</td>
-        <td>{{ r.dataset_version }}</td>
+        <td><a href="/api/datasets/{{ r.dataset_version }}" target="_blank">{{ r.dataset_version }}</a></td>
         <td>{{ r.run_type }}</td>
-        <td>{{ r.status }}</td>
-        <td>{{ r.violations }}</td>
+        <td>
+          {{ r.status }}
+          {% if r.dq_details.get('output', {}).get('warnings') %}
+            <span class="text-warning ms-1" title="Schema warnings">&#9888;</span>
+          {% endif %}
+        </td>
+        <td>
+          {% set fails = r.dq_details.get('output', {}).get('failed_expectations', {}) %}
+          {% if fails %}
+            {% for key, info in fails.items() %}
+              <div>{{ key }} ({{ info.count }})</div>
+            {% endfor %}
+          {% else %}
+            {{ r.violations }}
+          {% endif %}
+        </td>
         <td>
           <details>
             <summary>Show</summary>


### PR DESCRIPTION
## Summary
- make demo pipeline collect failed examples only when enabled and report failed expectations
- surface configuration for example collection through scenario config
- highlight schema warnings and link contract/dataset versions in datasets table

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b9828b1dbc832e9e803d2e9ea70dac