### PR TITLE
feat: show contract versions and drafts

### DIFF
--- a/src/dc43/demo_app/pipeline.py
+++ b/src/dc43/demo_app/pipeline.py
@@ -109,6 +109,7 @@ def run_pipeline(
     error: Exception | None = None
     output_details = {}
     output_status = None
+    draft_version: str | None = None
     try:
         result, draft = write_with_contract(
             df=df,
@@ -169,13 +170,13 @@ def run_pipeline(
             meta = load_contract_meta()
             meta.append({"id": contract_id, "version": next_ver, "status": "draft"})
             save_contract_meta(meta)
+            draft_version = next_ver
     else:
         if draft:
             meta = load_contract_meta()
             meta.append({"id": draft.id, "version": draft.version, "status": "draft"})
             save_contract_meta(meta)
-            contract_id = draft.id
-            contract_version = draft.version
+            draft_version = draft.version
 
     combined_details = {
         "orders": orders_status.details if orders_status else None,
@@ -204,6 +205,7 @@ def run_pipeline(
             combined_details,
             run_type,
             total_violations,
+            draft_contract_version=draft_version,
         )
     )
     save_records(records)

--- a/src/dc43/demo_app/templates/contract_versions.html
+++ b/src/dc43/demo_app/templates/contract_versions.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Contract {{ contract_id }}</h1>
+<table class="table table-striped">
+  <thead><tr><th>Version</th><th>Status</th><th>Dataset Path</th><th>Actions</th></tr></thead>
+  <tbody>
+  {% for c in contracts %}
+  <tr>
+    <td><a href="/contracts/{{ contract_id }}/{{ c.version }}">{{ c.version }}</a></td>
+    <td>{{ c.status }}</td>
+    <td>{{ c.path or '' }}</td>
+    <td>
+      <a class="btn btn-sm btn-primary" href="/contracts/{{ contract_id }}/{{ c.version }}/edit">Edit</a>
+      {% if c.status == 'draft' %}
+      <form method="post" action="/contracts/{{ contract_id }}/{{ c.version }}/validate" class="d-inline">
+        <button class="btn btn-sm btn-success" type="submit">Validate</button>
+      </form>
+      {% endif %}
+    </td>
+  </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% if not contracts %}<p>No versions found.</p>{% endif %}
+{% endblock %}

--- a/src/dc43/demo_app/templates/dataset_detail.html
+++ b/src/dc43/demo_app/templates/dataset_detail.html
@@ -1,7 +1,11 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Dataset {{ record.dataset_name }} {{ record.dataset_version }}</h1>
-<p>Contract: <a href="/contracts/{{ record.contract_id }}/{{ record.contract_version }}">{{ record.contract_id }} {{ record.contract_version }}</a> - {{ contract_status }}</p>
+<p>Contract: <a href="/contracts/{{ record.contract_id }}">{{ record.contract_id }}</a>
+<a href="/contracts/{{ record.contract_id }}/{{ record.contract_version }}">{{ record.contract_version }}</a> - {{ contract_status }}</p>
+{% if record.draft_contract_version %}
+<p>Draft Contract: <a href="/contracts/{{ record.contract_id }}/{{ record.draft_contract_version }}">{{ record.draft_contract_version }}</a>{% if draft_contract_status %} - {{ draft_contract_status }}{% endif %}</p>
+{% endif %}
 <p>Status: {{ record.status }} | Run type: {{ record.run_type }}</p>
 {% set fails = record.dq_details.get('output', {}).get('failed_expectations', {}) %}
 <h2>Data Quality Details</h2>

--- a/src/dc43/demo_app/templates/datasets.html
+++ b/src/dc43/demo_app/templates/datasets.html
@@ -23,6 +23,7 @@
       <tr>
         <th>Contract ID</th>
         <th>Contract Version</th>
+        <th>Draft Version</th>
         <th>Contract Status</th>
         <th>Dataset</th>
         <th>Version</th>
@@ -35,8 +36,14 @@
     <tbody>
     {% for r in records %}
       <tr>
-        <td><a href="/contracts/{{ r.contract_id }}/{{ r.contract_version }}">{{ r.contract_id }}</a></td>
+        <td><a href="/contracts/{{ r.contract_id }}">{{ r.contract_id }}</a></td>
         <td><a href="/contracts/{{ r.contract_id }}/{{ r.contract_version }}">{{ r.contract_version }}</a></td>
+        <td>
+          {% if r.draft_contract_version %}
+            <a href="/contracts/{{ r.contract_id }}/{{ r.draft_contract_version }}">{{ r.draft_contract_version }}</a>
+            {% if r.draft_contract_status %} ({{ r.draft_contract_status }}){% endif %}
+          {% endif %}
+        </td>
         <td>{{ r.contract_status }}</td>
         <td>{{ r.dataset_name }}</td>
         <td><a href="/datasets/{{ r.dataset_version }}">{{ r.dataset_version }}</a></td>

--- a/tests/test_server_pages.py
+++ b/tests/test_server_pages.py
@@ -10,6 +10,13 @@ def test_contract_detail_page():
     assert resp.status_code == 200
 
 
+def test_contract_versions_page():
+    rec = load_records()[0]
+    client = TestClient(app)
+    resp = client.get(f"/contracts/{rec.contract_id}")
+    assert resp.status_code == 200
+
+
 def test_dataset_detail_page():
     rec = load_records()[0]
     client = TestClient(app)


### PR DESCRIPTION
## Summary
- track draft contract versions in dataset records
- add contract versions page and display draft links in dataset views
- keep applied contract version separate from drafts in pipeline

## Testing
- `pytest` *(fails: pyspark required for dc43 tests)*

------
https://chatgpt.com/codex/tasks/task_b_68b9987c8c48832e9690c3715bf6c6f7