### PR TITLE
Refactor pipeline to delegate DQ logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS Instructions
+
+## Development
+- Use `rg` for searching instead of `grep -R`.
+- Install dependencies for tests and demo with:
+  ```bash
+  pip install -q pyspark==3.5.1 fastapi httpx uvicorn jinja2 python-multipart
+  pip install -e . -q
+  ```
+- Run tests with `pytest -q` after making changes.
+- Keep code small, readable, and documented.
+

--- a/src/dc43/demo_app/demo_data/contracts/customers/1.0.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/customers/1.0.0.json
@@ -10,7 +10,7 @@
     {
       "server": "local",
       "type": "filesystem",
-      "path": "data",
+      "path": "data/customers.json",
       "format": "json"
     }
   ],

--- a/src/dc43/demo_app/demo_data/contracts/customers/1.0.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/customers/1.0.0.json
@@ -10,7 +10,7 @@
     {
       "server": "local",
       "type": "filesystem",
-      "path": "lookup",
+      "path": "data",
       "format": "json"
     }
   ],

--- a/src/dc43/demo_app/demo_data/contracts/orders/1.0.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/orders/1.0.0.json
@@ -10,7 +10,7 @@
     {
       "server": "local",
       "type": "filesystem",
-      "path": "data",
+      "path": "data/orders.json",
       "format": "json"
     }
   ],

--- a/src/dc43/demo_app/demo_data/contracts/orders/1.0.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/orders/1.0.0.json
@@ -10,7 +10,7 @@
     {
       "server": "local",
       "type": "filesystem",
-      "path": "outputs",
+      "path": "data",
       "format": "json"
     }
   ],

--- a/src/dc43/demo_app/demo_data/contracts/orders/1.1.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/orders/1.1.0.json
@@ -10,7 +10,7 @@
     {
       "server": "local",
       "type": "filesystem",
-      "path": "data",
+      "path": "data/orders.json",
       "format": "json"
     }
   ],

--- a/src/dc43/demo_app/demo_data/contracts/orders/1.1.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/orders/1.1.0.json
@@ -10,7 +10,7 @@
     {
       "server": "local",
       "type": "filesystem",
-      "path": "outputs",
+      "path": "data",
       "format": "json"
     }
   ],

--- a/src/dc43/demo_app/demo_data/contracts/orders_enriched/1.0.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/orders_enriched/1.0.0.json
@@ -10,7 +10,7 @@
     {
       "server": "local",
       "type": "filesystem",
-      "path": "outputs",
+      "path": "data",
       "format": "parquet"
     }
   ],

--- a/src/dc43/demo_app/demo_data/contracts/orders_enriched/1.0.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/orders_enriched/1.0.0.json
@@ -10,7 +10,7 @@
     {
       "server": "local",
       "type": "filesystem",
-      "path": "data",
+      "path": "data/orders_enriched.parquet",
       "format": "parquet"
     }
   ],

--- a/src/dc43/demo_app/demo_data/contracts/orders_enriched/1.1.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/orders_enriched/1.1.0.json
@@ -10,7 +10,7 @@
     {
       "server": "local",
       "type": "filesystem",
-      "path": "outputs",
+      "path": "data",
       "format": "parquet"
     }
   ],

--- a/src/dc43/demo_app/demo_data/contracts/orders_enriched/1.1.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/orders_enriched/1.1.0.json
@@ -10,7 +10,7 @@
     {
       "server": "local",
       "type": "filesystem",
-      "path": "data",
+      "path": "data/orders_enriched.parquet",
       "format": "parquet"
     }
   ],

--- a/src/dc43/demo_app/demo_data/contracts/orders_enriched/2.0.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/orders_enriched/2.0.0.json
@@ -10,7 +10,7 @@
     {
       "server": "local",
       "type": "filesystem",
-      "path": "outputs",
+      "path": "data",
       "format": "parquet"
     }
   ],

--- a/src/dc43/demo_app/demo_data/contracts/orders_enriched/2.0.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/orders_enriched/2.0.0.json
@@ -10,7 +10,7 @@
     {
       "server": "local",
       "type": "filesystem",
-      "path": "data",
+      "path": "data/orders_enriched.parquet",
       "format": "parquet"
     }
   ],

--- a/src/dc43/demo_app/pipeline.py
+++ b/src/dc43/demo_app/pipeline.py
@@ -8,7 +8,6 @@ recording the dataset version in the demo app's registry.
 """
 
 from pathlib import Path
-from typing import Any, Dict
 
 from dc43.demo_app.server import (
     store,
@@ -19,9 +18,7 @@ from dc43.demo_app.server import (
     save_records,
 )
 from dc43.dq.stub import StubDQClient
-from dc43.dq.metrics import compute_metrics, expectations_from_contract
 from dc43.integration.spark_io import read_with_contract, write_with_contract
-from dc43.integration.validation import apply_contract
 from pyspark.sql import SparkSession
 
 
@@ -50,12 +47,6 @@ def run_pipeline(
     # Read primary orders dataset with its contract
     orders_contract = store.get("orders", "1.1.0")
     orders_path = str(DATA_INPUT_DIR / "orders.json")
-    dq.link_dataset_contract(
-        dataset_id="orders",
-        dataset_version="1.0.0",
-        contract_id="orders",
-        contract_version="1.1.0",
-    )
     orders_df, orders_status = read_with_contract(
         spark,
         path=orders_path,
@@ -69,12 +60,6 @@ def run_pipeline(
     # Join with customers lookup dataset
     customers_contract = store.get("customers", "1.0.0")
     customers_path = str(DATA_INPUT_DIR / "customers.json")
-    dq.link_dataset_contract(
-        dataset_id="customers",
-        dataset_version="1.0.0",
-        contract_id="customers",
-        contract_version="1.0.0",
-    )
     customers_df, customers_status = read_with_contract(
         spark,
         path=customers_path,
@@ -102,67 +87,34 @@ def run_pipeline(
         base_path = data_root / base_path
     output_path = base_path / dataset_name / dataset_version
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    error: Exception | None = None
-    output_details = {}
-    output_status = None
-    draft_version: str | None = None
-    try:
-        result, draft = write_with_contract(
-            df=df,
-            contract=output_contract,
-            path=str(output_path),
-            format=getattr(server, "format", "parquet"),
-            mode="overwrite",
-            enforce=False,
-            draft_on_mismatch=True,
-            draft_store=store,
-        )
-        if output_contract:
-            dq.link_dataset_contract(
-                dataset_id=dataset_name,
-                dataset_version=dataset_version,
-                contract_id=contract_id or output_contract.id,
-                contract_version=contract_version or output_contract.version,
-            )
-            aligned_df = apply_contract(df, output_contract)
-            metrics = compute_metrics(aligned_df, output_contract)
-            output_status = dq.submit_metrics(
-                contract=output_contract,
-                dataset_id=dataset_name,
-                dataset_version=dataset_version,
-                metrics=metrics,
-            )
-            output_details = {**result.details, **output_status.details}
-            if output_status.status != "ok":
-                failures: Dict[str, Dict[str, Any]] = {}
-                exps = expectations_from_contract(output_contract)
-                metrics = output_status.details.get("metrics", {})
-                for key, expr in exps.items():
-                    metric_key = f"violations.{key}"
-                    count = metrics.get(metric_key, 0)
-                    if count > 0:
-                        info: Dict[str, Any] = {"count": count, "expression": expr}
-                        if collect_examples:
-                            info["examples"] = [
-                                r.asDict()
-                                for r in aligned_df.filter(f"NOT ({expr})").limit(examples_limit).collect()
-                            ]
-                        failures[key] = info
-                if failures:
-                    output_details["failed_expectations"] = failures
-                if run_type == "enforce":
-                    error = ValueError(f"DQ violation: {output_status.details}")
-        else:
-            output_details = result.details
-            if run_type == "enforce":
-                error = ValueError("Contract required for existing mode")
-        if result.ok is False and error is None:
-            error = ValueError(f"Contract validation failed: {result.errors}")
-    except ValueError as exc:
-        error = exc
-    else:
-        if draft:
-            draft_version = draft.version
+
+    result, output_status, draft = write_with_contract(
+        df=df,
+        contract=output_contract,
+        path=str(output_path),
+        format=getattr(server, "format", "parquet"),
+        mode="overwrite",
+        enforce=False,
+        draft_on_mismatch=True,
+        draft_store=store,
+        dq_client=dq,
+        dataset_id=dataset_name,
+        dataset_version=dataset_version,
+        return_status=True,
+        collect_examples=collect_examples,
+        examples_limit=examples_limit,
+    )
+
+    if run_type == "enforce":
+        if not output_contract:
+            raise ValueError("Contract required for existing mode")
+        if output_status and output_status.status != "ok":
+            raise ValueError(f"DQ violation: {output_status.details}")
+        if not result.ok:
+            raise ValueError(f"Contract validation failed: {result.errors}")
+
+    draft_version: str | None = draft.version if draft else None
+    output_details = {**result.details, **(output_status.details if output_status else {})}
 
     combined_details = {
         "orders": orders_status.details if orders_status else None,
@@ -178,7 +130,6 @@ def run_pipeline(
         (orders_status and orders_status.status != "ok")
         or (customers_status and customers_status.status != "ok")
         or (output_status and output_status.status != "ok")
-        or error is not None
     ):
         status_value = "error"
     records.append(
@@ -196,6 +147,4 @@ def run_pipeline(
     )
     save_records(records)
     spark.stop()
-    if error:
-        raise error
     return dataset_version

--- a/src/dc43/demo_app/pipeline.py
+++ b/src/dc43/demo_app/pipeline.py
@@ -42,6 +42,8 @@ def _resolve_output_path(
     server = (contract.servers or [None])[0] if contract else None
     data_root = Path(DATA_DIR).parent
     base_path = Path(getattr(server, "path", "")) if server else data_root
+    if base_path.suffix:
+        base_path = base_path.parent
     if not base_path.is_absolute():
         base_path = data_root / base_path
     out = base_path / dataset_name / dataset_version
@@ -64,7 +66,7 @@ def run_pipeline(
 
     # Read primary orders dataset with its contract
     orders_contract = store.get("orders", "1.1.0")
-    orders_path = str(DATA_DIR / "orders.json")
+    orders_path = str(DATA_DIR / "orders/1.1.0/orders.json")
     orders_df, orders_status = read_with_contract(
         spark,
         path=orders_path,
@@ -72,12 +74,12 @@ def run_pipeline(
         expected_contract_version="==1.1.0",
         dq_client=dq,
         dataset_id="orders",
-        dataset_version="1.0.0",
+        dataset_version="1.1.0",
     )
 
     # Join with customers lookup dataset
     customers_contract = store.get("customers", "1.0.0")
-    customers_path = str(DATA_DIR / "customers.json")
+    customers_path = str(DATA_DIR / "customers/1.0.0/customers.json")
     customers_df, customers_status = read_with_contract(
         spark,
         path=customers_path,

--- a/src/dc43/demo_app/pipeline.py
+++ b/src/dc43/demo_app/pipeline.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from dc43.demo_app.server import (
     store,
     DATASETS_FILE,
-    DATA_INPUT_DIR,
+    DATA_DIR,
     DatasetRecord,
     load_records,
     save_records,
@@ -40,7 +40,7 @@ def _resolve_output_path(
 ) -> Path:
     """Return output path for dataset relative to contract servers."""
     server = (contract.servers or [None])[0] if contract else None
-    data_root = Path(DATA_INPUT_DIR).parent
+    data_root = Path(DATA_DIR).parent
     base_path = Path(getattr(server, "path", "")) if server else data_root
     if not base_path.is_absolute():
         base_path = data_root / base_path
@@ -64,7 +64,7 @@ def run_pipeline(
 
     # Read primary orders dataset with its contract
     orders_contract = store.get("orders", "1.1.0")
-    orders_path = str(DATA_INPUT_DIR / "orders.json")
+    orders_path = str(DATA_DIR / "orders.json")
     orders_df, orders_status = read_with_contract(
         spark,
         path=orders_path,
@@ -77,7 +77,7 @@ def run_pipeline(
 
     # Join with customers lookup dataset
     customers_contract = store.get("customers", "1.0.0")
-    customers_path = str(DATA_INPUT_DIR / "customers.json")
+    customers_path = str(DATA_DIR / "customers.json")
     customers_df, customers_status = read_with_contract(
         spark,
         path=customers_path,

--- a/src/dc43/demo_app/server.py
+++ b/src/dc43/demo_app/server.py
@@ -45,13 +45,13 @@ BASE_DIR = Path(__file__).resolve().parent
 SAMPLE_DIR = BASE_DIR / "demo_data"
 WORK_DIR = Path(tempfile.mkdtemp(prefix="dc43_demo_"))
 CONTRACT_DIR = WORK_DIR / "contracts"
-DATA_INPUT_DIR = WORK_DIR / "data"
+DATA_DIR = WORK_DIR / "data"
 RECORDS_DIR = WORK_DIR / "records"
 DATASETS_FILE = RECORDS_DIR / "datasets.json"
 
 # Copy sample data and records into a temporary working directory so the
 # application operates on absolute paths that are isolated per run.
-shutil.copytree(SAMPLE_DIR / "data", DATA_INPUT_DIR)
+shutil.copytree(SAMPLE_DIR / "data", DATA_DIR)
 shutil.copytree(SAMPLE_DIR / "records", RECORDS_DIR)
 
 # Prepare contracts with absolute server paths pointing inside the working dir.
@@ -383,7 +383,7 @@ async def save_contract_edits(
             col_name, col_type = [p.strip() for p in line.split(":", 1)]
             props.append(SchemaProperty(name=col_name, physicalType=col_type, required=True))
         if not path.is_absolute():
-            path = (Path(DATA_INPUT_DIR).parent / path).resolve()
+            path = (Path(DATA_DIR).parent / path).resolve()
         model = OpenDataContractStandard(
             version=contract_version,
             kind="DataContract",
@@ -445,7 +445,7 @@ async def create_contract(
             col_name, col_type = [p.strip() for p in line.split(":", 1)]
             props.append(SchemaProperty(name=col_name, physicalType=col_type, required=True))
         if not path.is_absolute():
-            path = (Path(DATA_INPUT_DIR).parent / path).resolve()
+            path = (Path(DATA_DIR).parent / path).resolve()
         model = OpenDataContractStandard(
             version=contract_version,
             kind="DataContract",
@@ -500,7 +500,7 @@ async def dataset_versions(request: Request, dataset_name: str) -> HTMLResponse:
 
 def _dataset_path(contract: OpenDataContractStandard | None, dataset_name: str, dataset_version: str) -> Path:
     server = (contract.servers or [None])[0] if contract else None
-    data_root = Path(DATA_INPUT_DIR).parent
+    data_root = Path(DATA_DIR).parent
     base = Path(getattr(server, "path", "")) if server else data_root
     if not base.is_absolute():
         base = data_root / base

--- a/src/dc43/demo_app/server.py
+++ b/src/dc43/demo_app/server.py
@@ -30,7 +30,7 @@ from fastapi.templating import Jinja2Templates
 from urllib.parse import urlencode
 
 from dc43.storage.fs import FSContractStore
-from dc43.dq.metrics import expectations_from_contract
+from dc43.dq.spark_metrics import expectations_from_contract
 from open_data_contract_standard.model import (
     OpenDataContractStandard,
     SchemaObject,

--- a/src/dc43/integration/dlt_helpers.py
+++ b/src/dc43/integration/dlt_helpers.py
@@ -8,7 +8,7 @@ Translate ODCS DataQuality rules to DLT expectations.
 from typing import Dict
 from open_data_contract_standard.model import OpenDataContractStandard  # type: ignore
 
-from ..dq.metrics import expectations_from_contract as _expectations_from_contract
+from ..dq.spark_metrics import expectations_from_contract as _expectations_from_contract
 
 
 def expectations_from_contract(contract: OpenDataContractStandard) -> Dict[str, str]:

--- a/src/dc43/integration/spark_io.py
+++ b/src/dc43/integration/spark_io.py
@@ -14,7 +14,7 @@ from pyspark.sql import DataFrame, SparkSession
 
 from .validation import validate_dataframe, apply_contract, ValidationResult
 from ..dq.base import DQClient, DQStatus
-from ..dq.metrics import compute_metrics
+from ..dq.metrics import compute_metrics, expectations_from_contract
 from .dataset import get_delta_version, dataset_id_from_ref
 from ..versioning import SemVer
 from ..odcs import contract_identity, ensure_version
@@ -304,11 +304,18 @@ def read_with_contract(
         ds_id = dataset_id or dataset_id_from_ref(table=table, path=path)
         ds_ver = dataset_version or get_delta_version(spark, table=table, path=path) or "unknown"
 
-        # Check dataset->contract linkage if tracked
+        # Check dataset->contract linkage if tracked; link when missing
         linked = dq_client.get_linked_contract_version(dataset_id=ds_id)
         if linked and linked != f"{cid}:{cver}":
             status = DQStatus(status="block", reason=f"dataset linked to {linked}")
         else:
+            if not linked:
+                dq_client.link_dataset_contract(
+                    dataset_id=ds_id,
+                    dataset_version=ds_ver,
+                    contract_id=cid,
+                    contract_version=cver,
+                )
             status = dq_client.get_status(
                 contract_id=cid,
                 contract_version=cver,
@@ -328,8 +335,9 @@ def read_with_contract(
     return (df, status) if return_status else df
 
 
-# Overloads allow static checkers to track the tuple return when
-# ``return_draft`` is set, avoiding "DataFrame is not iterable" warnings.
+# Overloads allow static checkers to track the tuple return when combinations of
+# ``return_draft`` and ``return_status`` are requested, avoiding "DataFrame is
+# not iterable" warnings.
 @overload
 def write_with_contract(
     *,
@@ -345,6 +353,64 @@ def write_with_contract(
     draft_on_mismatch: bool = False,
     draft_store: Optional[ContractStore] = None,
     draft_bump: str = "minor",
+    dq_client: Optional[DQClient] = None,
+    dataset_id: Optional[str] = None,
+    dataset_version: Optional[str] = None,
+    return_status: Literal[True],
+    collect_examples: bool = False,
+    examples_limit: int = 5,
+    return_draft: Literal[True],
+) -> tuple[ValidationResult, Optional[DQStatus], Optional[OpenDataContractStandard]]:
+    ...
+
+
+@overload
+def write_with_contract(
+    *,
+    df: DataFrame,
+    contract: Optional[OpenDataContractStandard] = None,
+    path: Optional[str] = None,
+    table: Optional[str] = None,
+    format: Optional[str] = None,
+    options: Optional[Dict[str, str]] = None,
+    mode: str = "append",
+    enforce: bool = True,
+    auto_cast: bool = True,
+    draft_on_mismatch: bool = False,
+    draft_store: Optional[ContractStore] = None,
+    draft_bump: str = "minor",
+    dq_client: Optional[DQClient] = None,
+    dataset_id: Optional[str] = None,
+    dataset_version: Optional[str] = None,
+    return_status: Literal[True],
+    collect_examples: bool = False,
+    examples_limit: int = 5,
+    return_draft: Literal[False],
+) -> tuple[ValidationResult, Optional[DQStatus]]:
+    ...
+
+
+@overload
+def write_with_contract(
+    *,
+    df: DataFrame,
+    contract: Optional[OpenDataContractStandard] = None,
+    path: Optional[str] = None,
+    table: Optional[str] = None,
+    format: Optional[str] = None,
+    options: Optional[Dict[str, str]] = None,
+    mode: str = "append",
+    enforce: bool = True,
+    auto_cast: bool = True,
+    draft_on_mismatch: bool = False,
+    draft_store: Optional[ContractStore] = None,
+    draft_bump: str = "minor",
+    dq_client: Optional[DQClient] = None,
+    dataset_id: Optional[str] = None,
+    dataset_version: Optional[str] = None,
+    return_status: Literal[False] = False,
+    collect_examples: bool = False,
+    examples_limit: int = 5,
     return_draft: Literal[True] = True,
 ) -> tuple[ValidationResult, Optional[OpenDataContractStandard]]:
     ...
@@ -365,28 +431,14 @@ def write_with_contract(
     draft_on_mismatch: bool = False,
     draft_store: Optional[ContractStore] = None,
     draft_bump: str = "minor",
-    return_draft: Literal[False],
+    dq_client: Optional[DQClient] = None,
+    dataset_id: Optional[str] = None,
+    dataset_version: Optional[str] = None,
+    return_status: Literal[False] = False,
+    collect_examples: bool = False,
+    examples_limit: int = 5,
+    return_draft: Literal[False] = False,
 ) -> ValidationResult:
-    ...
-
-
-@overload
-def write_with_contract(
-    *,
-    df: DataFrame,
-    contract: Optional[OpenDataContractStandard] = None,
-    path: Optional[str] = None,
-    table: Optional[str] = None,
-    format: Optional[str] = None,
-    options: Optional[Dict[str, str]] = None,
-    mode: str = "append",
-    enforce: bool = True,
-    auto_cast: bool = True,
-    draft_on_mismatch: bool = False,
-    draft_store: Optional[ContractStore] = None,
-    draft_bump: str = "minor",
-    return_draft: bool = True,
-) -> ValidationResult | tuple[ValidationResult, Optional[OpenDataContractStandard]]:
     ...
 
 
@@ -405,8 +457,15 @@ def write_with_contract(
     draft_on_mismatch: bool = False,
     draft_store: Optional[ContractStore] = None,
     draft_bump: str = "minor",
+    # DQ integration
+    dq_client: Optional[DQClient] = None,
+    dataset_id: Optional[str] = None,
+    dataset_version: Optional[str] = None,
+    return_status: bool = False,
+    collect_examples: bool = False,
+    examples_limit: int = 5,
     return_draft: bool = True,
-) -> ValidationResult | Tuple[ValidationResult, Optional[OpenDataContractStandard]]:
+) -> Any:
     """Validate/align a DataFrame then write it using Spark writers.
 
     Applies the contract schema before writing and merges IO options coming
@@ -565,6 +624,52 @@ def write_with_contract(
             raise ValueError("Either table or path must be provided for write")
         logger.info("Writing dataframe to path %s", path)
         writer.save(path)
-    # Propagate the validation result to callers.  When ``return_draft`` is
-    # requested we include the proposed draft document as a second tuple value.
-    return (result, draft_doc) if return_draft else result
+
+    # DQ integration after write
+    status: Optional[DQStatus] = None
+    if dq_client and contract:
+        ds_id = dataset_id or dataset_id_from_ref(table=table, path=path)
+        ds_ver = dataset_version or get_delta_version(df.sparkSession, table=table, path=path) or "unknown"
+        linked = dq_client.get_linked_contract_version(dataset_id=ds_id)
+        if linked and linked != f"{cid}:{cver}":
+            status = DQStatus(status="block", reason=f"dataset linked to {linked}")
+        else:
+            if not linked:
+                dq_client.link_dataset_contract(
+                    dataset_id=ds_id,
+                    dataset_version=ds_ver,
+                    contract_id=cid,
+                    contract_version=cver,
+                )
+            metrics = compute_metrics(out_df, contract)
+            status = dq_client.submit_metrics(
+                contract=contract, dataset_id=ds_id, dataset_version=ds_ver, metrics=metrics
+            )
+            exps = expectations_from_contract(contract)
+            metrics_map = status.details.get("metrics", {}) if status.details else {}
+            failures: Dict[str, Dict[str, Any]] = {}
+            for key, expr in exps.items():
+                cnt = metrics_map.get(f"violations.{key}", 0)
+                if cnt > 0:
+                    info: Dict[str, Any] = {"count": cnt, "expression": expr}
+                    if collect_examples:
+                        info["examples"] = [
+                            r.asDict()
+                            for r in out_df.filter(f"NOT ({expr})").limit(examples_limit).collect()
+                        ]
+                    failures[key] = info
+            if failures:
+                if not status.details:
+                    status.details = {}
+                status.details["failed_expectations"] = failures
+        if enforce and status and status.status == "block":
+            raise ValueError(f"DQ violation: {status.details}")
+
+    # Propagate the validation result to callers.
+    if return_status and return_draft:
+        return result, status, draft_doc
+    if return_status:
+        return result, status
+    if return_draft:
+        return result, draft_doc
+    return result


### PR DESCRIPTION
## Summary
- simplify demo pipeline to focus on reading, joining and writing data
- link datasets and submit metrics inside `read_with_contract`
- extend `write_with_contract` with automatic DQ integration and status return

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b9fb953794832e82059babcc7c1398