### PR TITLE
Automate draft creation during demo pipeline runs

### DIFF
--- a/src/dc43/components/integration/spark_io.py
+++ b/src/dc43/components/integration/spark_io.py
@@ -12,12 +12,7 @@ from pathlib import Path
 
 from pyspark.sql import DataFrame, SparkSession
 
-from dc43.components.data_quality import (
-    DataQualityManager,
-    DQClient,
-    DQStatus,
-    QualityDraftContext,
-)
+from dc43.components.data_quality import DataQualityManager, DQClient, DQStatus
 from dc43.components.data_quality.engine import ValidationResult
 from dc43.components.data_quality.integration import build_metrics_payload, validate_dataframe
 from dc43.components.data_quality.validation import apply_contract
@@ -484,22 +479,13 @@ def write_with_contract(
             elif status and status.status not in (None, "ok"):
                 request_draft = True
         if request_draft:
-            dq_feedback: Mapping[str, Any] | None = None
-            if status and status.details:
-                dq_feedback = dict(status.details)
-                if status.reason:
-                    dq_feedback.setdefault("reason", status.reason)
-                dq_feedback.setdefault("status", status.status)
-            context = QualityDraftContext(
-                dataset_id=dq_dataset_id,
-                dataset_version=dq_dataset_version,
-                data_format=format,
-                dq_feedback=dq_feedback,
-            )
             draft_contract = quality_manager.review_validation_outcome(
                 validation=result,
                 base_contract=contract,
-                context=context,
+                dataset_id=dq_dataset_id,
+                dataset_version=dq_dataset_version,
+                data_format=format,
+                dq_status=status,
                 draft_requested=True,
             )
             if draft_contract is not None:


### PR DESCRIPTION
## Summary
- allow the data-quality manager to persist generated drafts when a contract store is provided
- request governance drafts from the Spark write helper whenever schema or data-quality mismatches occur and surface the draft version in the returned status
- record demo pipeline draft versions from the status payload without manually invoking governance helpers

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68d4ccf25cc4832ead143a282612abad