### PR TITLE
Improve draft contract quality rule retention and logging

### DIFF
--- a/src/dc43/components/contract_drafter/observations.py
+++ b/src/dc43/components/contract_drafter/observations.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Mapping, Optional
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
 from open_data_contract_standard.model import (  # type: ignore
     CustomProperty,
+    DataQuality,
     OpenDataContractStandard,
     SchemaObject,
     SchemaProperty,
@@ -15,6 +16,378 @@ from open_data_contract_standard.model import (  # type: ignore
 from dc43.components.data_quality.engine import ValidationResult
 from dc43.odcs import contract_identity
 from dc43.versioning import SemVer
+
+
+def _resolve_observed_type(
+    info: Mapping[str, Any] | None,
+    fallback: str | None,
+) -> Tuple[str, Optional[bool]]:
+    """Return the preferred ODCS physical type and nullable flag."""
+
+    observed_type = str(
+        (info or {}).get("odcs_type")
+        or (info or {}).get("type")
+        or (info or {}).get("backend_type")
+        or fallback
+        or "string"
+    )
+    nullable = None
+    if info is not None and "nullable" in info:
+        nullable = bool(info.get("nullable", False))
+    return observed_type, nullable
+
+
+def _quality_rule_key(field: SchemaProperty, dq: DataQuality) -> Optional[Tuple[str, str]]:
+    """Return the expectation rule prefix and human readable label."""
+
+    name = field.name or ""
+    if not name:
+        return None
+
+    if dq.mustBeGreaterThan is not None:
+        return "gt", f"mustBeGreaterThan {dq.mustBeGreaterThan}"
+    if dq.mustBeGreaterOrEqualTo is not None:
+        return "ge", f"mustBeGreaterOrEqualTo {dq.mustBeGreaterOrEqualTo}"
+    if dq.mustBeLessThan is not None:
+        return "lt", f"mustBeLessThan {dq.mustBeLessThan}"
+    if dq.mustBeLessOrEqualTo is not None:
+        return "le", f"mustBeLessOrEqualTo {dq.mustBeLessOrEqualTo}"
+
+    rule = (dq.rule or "").lower()
+    if rule == "unique":
+        return "unique", "unique"
+    if rule == "enum" and isinstance(dq.mustBe, Iterable):
+        return "enum", "enum"
+    if rule == "regex" and dq.mustBe:
+        return "regex", "regex"
+
+    return None
+
+
+def _quality_metric_value(
+    *,
+    metrics: Mapping[str, Any],
+    rule_prefix: str,
+    field_name: str,
+) -> Optional[float]:
+    key = f"violations.{rule_prefix}_{field_name}"
+    value = metrics.get(key)
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _extract_values(candidate: Any) -> List[Any]:
+    """Normalise different iterable payloads into a flat list of values."""
+
+    if candidate is None:
+        return []
+    if isinstance(candidate, Mapping):
+        values: List[Any] = []
+        for key in ("new", "new_values", "unexpected", "unexpected_values", "values", "items"):
+            inner = candidate.get(key)
+            if isinstance(inner, (list, tuple, set)):
+                values.extend(inner)
+            elif inner is not None:
+                values.append(inner)
+        return values
+    if isinstance(candidate, (list, tuple, set)):
+        return list(candidate)
+    return [candidate]
+
+
+def _enum_extension(
+    *,
+    dq: DataQuality,
+    metrics: Mapping[str, Any],
+    field_name: str,
+) -> Optional[Tuple[List[Any], List[Any]]]:
+    """Return updated enum values plus additions derived from observations."""
+
+    if not field_name:
+        return None
+    base_values: List[Any]
+    if isinstance(dq.mustBe, (list, tuple, set)):
+        base_values = list(dq.mustBe)
+    else:
+        return None
+
+    observed_sources = [
+        metrics.get(f"observed.enum_{field_name}"),
+        metrics.get("observed.enum", {}),
+    ]
+    observed_values: List[Any] = []
+    for source in observed_sources:
+        if isinstance(source, Mapping) and field_name in source:
+            observed_values.extend(_extract_values(source.get(field_name)))
+        else:
+            observed_values.extend(_extract_values(source))
+
+    if not observed_values:
+        return None
+
+    seen = {str(v) for v in base_values}
+    additions: List[Any] = []
+    for value in observed_values:
+        key = str(value)
+        if key not in seen:
+            additions.append(value)
+            seen.add(key)
+
+    if not additions:
+        return None
+
+    updated = list(base_values) + additions
+    return updated, additions
+
+
+def _build_field_draft(
+    *,
+    field: SchemaProperty,
+    schema_info: Mapping[str, Any] | None,
+    metrics: Mapping[str, Any],
+    change_log: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Return the updated field payload for the draft contract."""
+
+    data = field.model_dump()
+    name = field.name or ""
+
+    observed_type, observed_nullable = _resolve_observed_type(schema_info, field.physicalType)
+    if observed_type and observed_type != (field.physicalType or ""):
+        change_log.append(
+            {
+                "scope": f"field:{name}",
+                "kind": "type",
+                "status": "updated",
+                "details": {
+                    "from": field.physicalType,
+                    "to": observed_type,
+                },
+            }
+    )
+    data["physicalType"] = observed_type
+
+    if schema_info is None:
+        change_log.append(
+            {
+                "scope": f"field:{name}",
+                "kind": "observation",
+                "status": "missing",
+                "details": {
+                    "message": "Field not present in latest observations",
+                },
+            }
+        )
+
+    required_metric = None
+    if name:
+        for candidate in (
+            f"violations.not_null_{name}",
+            f"violations.required_{name}",
+        ):
+            value = metrics.get(candidate)
+            if isinstance(value, (int, float)):
+                required_metric = float(value)
+                break
+
+    if bool(field.required) and required_metric and required_metric > 0:
+        data["required"] = False
+        change_log.append(
+            {
+                "scope": f"field:{name}",
+                "kind": "constraint",
+                "constraint": "required",
+                "status": "relaxed",
+                "details": {
+                    "reason": f"Observed {required_metric:.0f} null value(s)",
+                },
+            }
+        )
+    elif bool(field.required):
+        change_log.append(
+            {
+                "scope": f"field:{name}",
+                "kind": "constraint",
+                "constraint": "required",
+                "status": "kept",
+                "details": {"violations": required_metric or 0},
+            }
+        )
+
+    if bool(field.unique):
+        unique_metric = _quality_metric_value(
+            metrics=metrics,
+            rule_prefix="unique",
+            field_name=name,
+        )
+        if unique_metric and unique_metric > 0:
+            data["unique"] = False
+            change_log.append(
+                {
+                    "scope": f"field:{name}",
+                    "kind": "constraint",
+                    "constraint": "unique",
+                    "status": "relaxed",
+                    "details": {"violations": unique_metric},
+                }
+            )
+        else:
+            change_log.append(
+                {
+                    "scope": f"field:{name}",
+                    "kind": "constraint",
+                    "constraint": "unique",
+                    "status": "kept",
+                    "details": {"violations": unique_metric or 0},
+                }
+            )
+
+    new_quality: List[Dict[str, Any]] = []
+    for dq in list(field.quality or []):
+        rule_info = _quality_rule_key(field, dq)
+        if rule_info is None:
+            new_quality.append(dq.model_dump())
+            change_log.append(
+                {
+                    "scope": f"field:{name}",
+                    "kind": "quality_rule",
+                    "rule": dq.rule or "custom",
+                    "status": "kept",
+                    "details": {"reason": "rule not automatically evaluated"},
+                }
+            )
+            continue
+
+        rule_prefix, label = rule_info
+        metric_value = _quality_metric_value(
+            metrics=metrics,
+            rule_prefix=rule_prefix,
+            field_name=name,
+        )
+
+        if metric_value is None:
+            new_quality.append(dq.model_dump())
+            change_log.append(
+                {
+                    "scope": f"field:{name}",
+                    "kind": "quality_rule",
+                    "rule": label,
+                    "status": "kept",
+                    "details": {"reason": "no violations reported"},
+                }
+            )
+            continue
+
+        enum_extension: Optional[Tuple[List[Any], List[Any]]] = None
+        if rule_prefix == "enum":
+            enum_extension = _enum_extension(dq=dq, metrics=metrics, field_name=name)
+
+        if enum_extension is not None:
+            updated_values, additions = enum_extension
+            payload = dq.model_dump()
+            payload["mustBe"] = updated_values
+            new_quality.append(payload)
+            change_log.append(
+                {
+                    "scope": f"field:{name}",
+                    "kind": "quality_rule",
+                    "rule": label,
+                    "status": "updated",
+                    "details": {
+                        "violations": metric_value or 0,
+                        "added_values": additions,
+                    },
+                }
+            )
+            continue
+
+        if metric_value and metric_value > 0:
+            change_log.append(
+                {
+                    "scope": f"field:{name}",
+                    "kind": "quality_rule",
+                    "rule": label,
+                    "status": "removed",
+                    "details": {"violations": metric_value},
+                }
+            )
+            continue
+
+        new_quality.append(dq.model_dump())
+        change_log.append(
+            {
+                "scope": f"field:{name}",
+                "kind": "quality_rule",
+                "rule": label,
+                "status": "kept",
+                "details": {"violations": 0},
+            }
+        )
+
+    data["quality"] = new_quality or None
+
+    if observed_nullable is False and not data.get("required"):
+        change_log.append(
+            {
+                "scope": f"field:{name}",
+                "kind": "observation",
+                "status": "not_nullable",
+                "details": {
+                    "message": "Runtime reported non-nullable column despite optional contract",
+                },
+            }
+        )
+
+    return data
+
+
+def _append_validation_feedback(
+    contract: OpenDataContractStandard,
+    validation: ValidationResult,
+) -> None:
+    """Record validation errors and warnings in the contract change log."""
+
+    entries: List[Dict[str, Any]] = []
+    for message in validation.errors:
+        entries.append(
+            {
+                "scope": "contract",
+                "kind": "validation",
+                "status": "error",
+                "details": {"message": message},
+            }
+        )
+    for message in validation.warnings:
+        entries.append(
+            {
+                "scope": "contract",
+                "kind": "validation",
+                "status": "warning",
+                "details": {"message": message},
+            }
+        )
+
+    if not entries:
+        return
+
+    props = list(contract.customProperties or [])
+    existing = None
+    for prop in props:
+        if prop.property == "draft_change_log":
+            existing = prop
+            break
+
+    if existing is not None:
+        payload = list(existing.value or [])
+        payload.extend(entries)
+        existing.value = payload
+    else:
+        props.append(CustomProperty(property="draft_change_log", value=entries))
+
+    contract.customProperties = props
 
 
 def draft_from_observations(
@@ -30,24 +403,69 @@ def draft_from_observations(
 ) -> OpenDataContractStandard:
     """Create a draft ODCS document using schema & metric observations."""
 
-    props = []
-    for name, info in schema.items():
-        if not name:
-            continue
-        odcs_type = str(
-            info.get("odcs_type")
-            or info.get("type")
-            or info.get("backend_type")
-            or "string"
-        )
-        required = not bool(info.get("nullable", True))
-        props.append(
-            SchemaProperty(
-                name=name,
-                physicalType=odcs_type,
-                required=required,
+    schema_map: Dict[str, Dict[str, Any]] = {k: dict(v) for k, v in (schema or {}).items()}
+    metrics_map: Dict[str, Any] = dict(metrics or {})
+
+    change_log: List[Dict[str, Any]] = []
+
+    schema_payloads: List[Dict[str, Any]] = []
+    observed_fields = set()
+
+    for obj in list(base_contract.schema_ or []):
+        obj_data = obj.model_dump()
+        prop_payloads: List[Dict[str, Any]] = []
+        for field in list(obj.properties or []):
+            field_payload = _build_field_draft(
+                field=field,
+                schema_info=schema_map.get(field.name or ""),
+                metrics=metrics_map,
+                change_log=change_log,
             )
-        )
+            prop_payloads.append(field_payload)
+            if field.name:
+                observed_fields.add(field.name)
+        obj_data["properties"] = prop_payloads
+        schema_payloads.append(obj_data)
+
+    remaining = [
+        (name, schema_map[name])
+        for name in schema_map.keys()
+        if name and name not in observed_fields
+    ]
+
+    if remaining:
+        target_obj: Optional[Dict[str, Any]] = None
+        if schema_payloads:
+            target_obj = schema_payloads[0]
+        else:
+            target_obj = {
+                "name": base_contract.id or "dataset",
+                "properties": [],
+            }
+            schema_payloads.append(target_obj)
+
+        props = list(target_obj.get("properties") or [])
+        for name, info in remaining:
+            observed_type, observed_nullable = _resolve_observed_type(info, None)
+            props.append(
+                {
+                    "name": name,
+                    "physicalType": observed_type,
+                    "required": observed_nullable is False,
+                }
+            )
+            change_log.append(
+                {
+                    "scope": f"field:{name}",
+                    "kind": "field",
+                    "status": "added",
+                    "details": {
+                        "physicalType": observed_type,
+                        "nullable": bool(observed_nullable),
+                    },
+                }
+            )
+        target_obj["properties"] = props
 
     contract_id, current_version = contract_identity(base_contract)
     semver = SemVer.parse(current_version)
@@ -68,10 +486,19 @@ def draft_from_observations(
     if metrics:
         custom_props.append(CustomProperty(property="observed_metrics", value=dict(metrics)))
 
+    if change_log:
+        custom_props.append(CustomProperty(property="draft_change_log", value=change_log))
+
     schema_name = contract_id
-    if base_contract.schema_:
-        first = base_contract.schema_[0]
-        schema_name = first.name or contract_id
+    schema_objects: List[SchemaObject] = []
+    if schema_payloads:
+        for payload in schema_payloads:
+            schema_objects.append(SchemaObject(**payload))
+        schema_name = schema_objects[0].name or contract_id
+    else:
+        schema_objects = [
+            SchemaObject(name=schema_name, properties=[]),
+        ]
 
     servers = base_contract.servers
     if dataset_id:
@@ -93,7 +520,7 @@ def draft_from_observations(
         name=base_contract.name or contract_id,
         description=base_contract.description,
         status="draft",
-        schema=[SchemaObject(name=schema_name, properties=props)],
+        schema=schema_objects,
         servers=servers,
         customProperties=custom_props,
     )
@@ -113,7 +540,7 @@ def draft_from_validation_result(
 
     schema_payload: Mapping[str, Mapping[str, Any]] | None = validation.schema or None
     metrics_payload: Mapping[str, Any] | None = validation.metrics or None
-    return draft_from_observations(
+    draft = draft_from_observations(
         schema=schema_payload or {},
         metrics=metrics_payload or None,
         base_contract=base_contract,
@@ -123,6 +550,10 @@ def draft_from_validation_result(
         data_format=data_format,
         dq_feedback=dict(dq_feedback) if dq_feedback else None,
     )
+
+    _append_validation_feedback(draft, validation)
+
+    return draft
 
 
 __all__ = ["draft_from_observations", "draft_from_validation_result"]

--- a/src/dc43/demo_app/templates/contract_detail.html
+++ b/src/dc43/demo_app/templates/contract_detail.html
@@ -18,6 +18,9 @@
     <button class="nav-link" id="quality-tab" data-bs-toggle="tab" data-bs-target="#quality" type="button" role="tab">Quality</button>
   </li>
   <li class="nav-item" role="presentation">
+    <button class="nav-link" id="change-log-tab" data-bs-toggle="tab" data-bs-target="#change-log" type="button" role="tab">Change Log</button>
+  </li>
+  <li class="nav-item" role="presentation">
     <button class="nav-link" id="json-tab" data-bs-toggle="tab" data-bs-target="#json" type="button" role="tab">JSON</button>
   </li>
 </ul>
@@ -65,7 +68,76 @@
     {% endfor %}
   </div>
   <div class="tab-pane fade" id="quality" role="tabpanel" aria-labelledby="quality-tab">
+    {% if field_quality %}
+    <h5>Field quality rules</h5>
+    {% for field in field_quality %}
+    <div class="card mb-3">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <div>
+          <strong>{{ field.name }}</strong>
+          {% if field.type %}<span class="text-muted">({{ field.type }})</span>{% endif %}
+        </div>
+        <span class="badge {{ 'bg-success' if field.required else 'bg-secondary' }}">{{ 'Required' if field.required else 'Optional' }}</span>
+      </div>
+      <div class="card-body">
+        {% if field.rules %}
+          {% for rule in field.rules %}
+          <div class="mb-3">
+            <h6 class="mb-1">{{ rule.title }}</h6>
+            <ul class="small mb-2">
+              {% for text in rule.conditions %}
+              <li>{{ text }}</li>
+              {% endfor %}
+            </ul>
+            {% if rule.severity or rule.dimension %}
+            <p class="small text-muted mb-0">
+              {% if rule.severity %}<span class="me-3">Severity: {{ rule.severity }}</span>{% endif %}
+              {% if rule.dimension %}<span>Dimension: {{ rule.dimension }}</span>{% endif %}
+            </p>
+            {% endif %}
+          </div>
+          {% endfor %}
+        {% else %}
+        <p class="text-muted mb-0">No quality rules defined for this field.</p>
+        {% endif %}
+      </div>
+    </div>
+    {% endfor %}
+    {% else %}
+    <p>No field-level quality rules defined.</p>
+    {% endif %}
+
+    {% if dataset_quality %}
+    <h5>Dataset-level quality rules</h5>
+    {% for section in dataset_quality %}
+    <div class="card mb-3">
+      <div class="card-header">
+        <strong>{{ section.name }}</strong>
+      </div>
+      <div class="card-body">
+        {% for rule in section.rules %}
+        <div class="mb-3">
+          <h6 class="mb-1">{{ rule.title }}</h6>
+          <ul class="small mb-2">
+            {% for text in rule.conditions %}
+            <li>{{ text }}</li>
+            {% endfor %}
+          </ul>
+          {% if rule.severity or rule.dimension %}
+          <p class="small text-muted mb-0">
+            {% if rule.severity %}<span class="me-3">Severity: {{ rule.severity }}</span>{% endif %}
+            {% if rule.dimension %}<span>Dimension: {{ rule.dimension }}</span>{% endif %}
+          </p>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    {% endfor %}
+    {% endif %}
+
     {% if expectations %}
+    <h5>SQL predicates</h5>
     <table class="table table-sm">
       <thead><tr><th>Name</th><th>Predicate</th></tr></thead>
       <tbody>
@@ -74,8 +146,39 @@
       {% endfor %}
       </tbody>
     </table>
+    {% endif %}
+  </div>
+  <div class="tab-pane fade" id="change-log" role="tabpanel" aria-labelledby="change-log-tab">
+    {% if change_log %}
+    <div class="list-group">
+      {% for entry in change_log %}
+      <div class="list-group-item">
+        <div class="d-flex justify-content-between align-items-start">
+          <div>
+            <span class="badge {{ status_badges.get(entry.status, 'bg-secondary') }}">{{ entry.status_label }}</span>
+            <strong class="ms-2">{{ entry.scope_label }}</strong>
+          </div>
+          {% if entry.kind %}
+          <small class="text-muted text-uppercase">{{ entry.kind }}</small>
+          {% endif %}
+        </div>
+        {% if entry.summary %}
+        <p class="mb-1 mt-2">{{ entry.summary }}</p>
+        {% endif %}
+        {% if entry.constraint %}
+        <p class="mb-1 small text-muted"><strong>Constraint:</strong> {{ entry.constraint }}</p>
+        {% endif %}
+        {% if entry.rule %}
+        <p class="mb-1 small text-muted"><strong>Rule:</strong> {{ entry.rule }}</p>
+        {% endif %}
+        {% if entry.details_text %}
+        <pre class="small bg-light p-2 rounded">{{ entry.details_text }}</pre>
+        {% endif %}
+      </div>
+      {% endfor %}
+    </div>
     {% else %}
-    <p>No quality rules defined.</p>
+    <p class="text-muted">No change log entries available.</p>
     {% endif %}
   </div>
   <div class="tab-pane fade" id="json" role="tabpanel" aria-labelledby="json-tab">

--- a/tests/test_contract_drafter.py
+++ b/tests/test_contract_drafter.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from open_data_contract_standard.model import (  # type: ignore
+    CustomProperty,
+    DataQuality,
+    Description,
+    OpenDataContractStandard,
+    SchemaObject,
+    SchemaProperty,
+)
+
+from dc43.components.contract_drafter import draft_from_validation_result
+from dc43.components.data_quality.engine import ValidationResult
+
+
+def _build_contract() -> OpenDataContractStandard:
+    return OpenDataContractStandard(
+        version="1.0.0",
+        kind="DataContract",
+        apiVersion="3.0.2",
+        id="test.orders",
+        name="Orders",
+        description=Description(usage="Orders facts"),
+        schema=[
+            SchemaObject(
+                name="orders",
+                properties=[
+                    SchemaProperty(name="order_id", physicalType="bigint", required=True),
+                    SchemaProperty(
+                        name="customer_id",
+                        physicalType="bigint",
+                        required=True,
+                    ),
+                    SchemaProperty(
+                        name="amount",
+                        physicalType="double",
+                        required=True,
+                        quality=[DataQuality(mustBeGreaterThan=0)],
+                    ),
+                    SchemaProperty(
+                        name="currency",
+                        physicalType="string",
+                        required=True,
+                        quality=[DataQuality(rule="enum", mustBe=["EUR", "USD"])],
+                    ),
+                ],
+            )
+        ],
+        customProperties=[CustomProperty(property="draft", value=False)],
+    )
+
+
+def _get_property(contract: OpenDataContractStandard, name: str) -> SchemaProperty:
+    for obj in contract.schema_ or []:
+        for prop in obj.properties or []:
+            if prop.name == name:
+                return prop
+    raise AssertionError(f"Property {name} not found")
+
+
+def _change_log(contract: OpenDataContractStandard) -> List[Dict[str, object]]:
+    for prop in contract.customProperties or []:
+        if prop.property == "draft_change_log":
+            value = prop.value or []
+            return list(value)
+    return []
+
+
+def test_draft_preserves_and_updates_quality_rules() -> None:
+    base = _build_contract()
+    validation = ValidationResult(
+        ok=False,
+        errors=["column customer_id contains 2 null value(s)"],
+        warnings=[],
+        metrics={
+            "violations.not_null_customer_id": 2,
+            "violations.gt_amount": 3,
+            "violations.enum_currency": 0,
+        },
+        schema={
+            "order_id": {"odcs_type": "bigint", "nullable": False},
+            "customer_id": {"odcs_type": "bigint", "nullable": True},
+            "amount": {"odcs_type": "double", "nullable": False},
+            "currency": {"odcs_type": "string", "nullable": False},
+        },
+    )
+
+    draft = draft_from_validation_result(validation=validation, base_contract=base)
+
+    customer = _get_property(draft, "customer_id")
+    amount = _get_property(draft, "amount")
+    currency = _get_property(draft, "currency")
+
+    assert customer.required is False
+    assert amount.quality is None or len(amount.quality) == 0
+    assert currency.quality and len(currency.quality) == 1
+    assert currency.quality[0].rule == "enum"
+
+    log = _change_log(draft)
+    assert any(entry.get("status") == "relaxed" and entry.get("constraint") == "required" for entry in log)
+    assert any(
+        entry.get("status") == "removed" and "mustBeGreaterThan" in str(entry.get("rule"))
+        for entry in log
+    )
+    assert any(entry.get("status") == "kept" and entry.get("rule") == "enum" for entry in log)
+    assert any(entry.get("status") == "error" and entry.get("kind") == "validation" for entry in log)
+
+
+def test_draft_extends_enum_with_new_values() -> None:
+    base = _build_contract()
+    validation = ValidationResult(
+        ok=False,
+        errors=["column currency contains unexpected value(s)"],
+        warnings=[],
+        metrics={
+            "violations.enum_currency": 3,
+            "observed.enum_currency": ["CAD", "EUR"],
+        },
+        schema={
+            "order_id": {"odcs_type": "bigint", "nullable": False},
+            "customer_id": {"odcs_type": "bigint", "nullable": False},
+            "amount": {"odcs_type": "double", "nullable": False},
+            "currency": {"odcs_type": "string", "nullable": False},
+        },
+    )
+
+    draft = draft_from_validation_result(validation=validation, base_contract=base)
+
+    currency = _get_property(draft, "currency")
+    assert currency.quality and len(currency.quality) == 1
+    enum_rule = currency.quality[0]
+    assert enum_rule.mustBe == ["EUR", "USD", "CAD"]
+
+    log = _change_log(draft)
+    assert any(
+        entry.get("status") == "updated"
+        and entry.get("rule") == "enum"
+        and ["CAD"] == list(entry.get("details", {}).get("added_values", []))
+        for entry in log
+    )


### PR DESCRIPTION
## Summary
- update draft contract generation to reuse the base schema, evaluate quality rule metrics, and record detailed change-log entries for retained, relaxed, or removed expectations
- capture additional observed columns, keep validated rules in place, and append validation feedback directly into the draft contract metadata
- add regression coverage for the new drafting behaviour around required fields, quality rules, and change-log output
- extend enum quality rules in drafts with newly observed values and record the additions in the change log

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68d4eef02fac832ebcf4e5688e5b2878