### PR TITLE
Teach dataset locator to read server versioning hints

### DIFF
--- a/src/dc43/components/data_quality/governance/interface.py
+++ b/src/dc43/components/data_quality/governance/interface.py
@@ -66,7 +66,12 @@ class DQClient(Protocol):
     ) -> None:
         ...
 
-    def get_linked_contract_version(self, *, dataset_id: str) -> Optional[str]:
+    def get_linked_contract_version(
+        self,
+        *,
+        dataset_id: str,
+        dataset_version: Optional[str] = None,
+    ) -> Optional[str]:
         """Return contract version associated to dataset if tracked (format: "<contract_id>:<version>")."""
         ...
 

--- a/src/dc43/components/data_quality/governance/stubs/filesystem.py
+++ b/src/dc43/components/data_quality/governance/stubs/filesystem.py
@@ -101,8 +101,14 @@ class StubDQClient(DQClient):
 
         path = self._status_path(dataset_id, dataset_version)
         logger.info("Persisting DQ status %s for %s@%s to %s", status, dataset_id, dataset_version, path)
+        payload = {
+            "status": status,
+            "details": details,
+            "dataset_id": dataset_id,
+            "dataset_version": dataset_version,
+        }
         with open(path, "w", encoding="utf-8") as f:
-            json.dump({"status": status, "details": details}, f)
+            json.dump(payload, f)
 
         self.link_dataset_contract(
             dataset_id=dataset_id,

--- a/src/dc43/components/data_quality/manager.py
+++ b/src/dc43/components/data_quality/manager.py
@@ -95,12 +95,20 @@ class DataQualityManager:
             metrics=dict(metrics),
         )
 
-    def get_linked_contract_version(self, *, dataset_id: str) -> Optional[str]:
+    def get_linked_contract_version(
+        self,
+        *,
+        dataset_id: str,
+        dataset_version: str | None = None,
+    ) -> Optional[str]:
         """Return the contract currently associated to ``dataset_id``."""
 
         if not self._client:
             return None
-        return self._client.get_linked_contract_version(dataset_id=dataset_id)
+        return self._client.get_linked_contract_version(
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
+        )
 
     def link_dataset_contract(
         self,

--- a/src/dc43/demo_app/demo_data/contracts/customers/1.0.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/customers/1.0.0.json
@@ -11,7 +11,22 @@
       "server": "local",
       "type": "filesystem",
       "path": "data/customers",
-      "format": "json"
+      "format": "json",
+      "customProperties": [
+        {
+          "property": "dc43.versioning",
+          "value": {
+            "mode": "snapshot",
+            "includePriorVersions": false,
+            "subfolder": "{version}",
+            "filePattern": "customers.json"
+          }
+        },
+        {
+          "property": "dc43.pathPattern",
+          "value": "data/customers/{==version}/customers.json"
+        }
+      ]
     }
   ],
   "schema": [

--- a/src/dc43/demo_app/demo_data/contracts/orders/1.0.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/orders/1.0.0.json
@@ -11,7 +11,23 @@
       "server": "local",
       "type": "filesystem",
       "path": "data/orders",
-      "format": "json"
+      "format": "json",
+      "customProperties": [
+        {
+          "property": "dc43.versioning",
+          "value": {
+            "mode": "delta",
+            "includePriorVersions": true,
+            "subfolder": "{version}",
+            "filePattern": "orders.json",
+            "readOptions": {"recursiveFileLookup": true}
+          }
+        },
+        {
+          "property": "dc43.pathPattern",
+          "value": "data/orders/{<=version}/orders.json"
+        }
+      ]
     }
   ],
   "schema": [

--- a/src/dc43/demo_app/demo_data/contracts/orders/1.1.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/orders/1.1.0.json
@@ -11,7 +11,23 @@
       "server": "local",
       "type": "filesystem",
       "path": "data/orders",
-      "format": "json"
+      "format": "json",
+      "customProperties": [
+        {
+          "property": "dc43.versioning",
+          "value": {
+            "mode": "delta",
+            "includePriorVersions": true,
+            "subfolder": "{version}",
+            "filePattern": "orders.json",
+            "readOptions": {"recursiveFileLookup": true}
+          }
+        },
+        {
+          "property": "dc43.pathPattern",
+          "value": "data/orders/{<=version}/orders.json"
+        }
+      ]
     }
   ],
   "schema": [

--- a/src/dc43/demo_app/demo_data/contracts/orders_enriched/1.0.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/orders_enriched/1.0.0.json
@@ -11,7 +11,21 @@
       "server": "local",
       "type": "filesystem",
       "path": "data/orders_enriched.parquet",
-      "format": "parquet"
+      "format": "parquet",
+      "customProperties": [
+        {
+          "property": "dc43.versioning",
+          "value": {
+            "mode": "delta",
+            "timeTravel": "versionAsOf",
+            "notes": "Use dataset_version as Delta time travel hint"
+          }
+        },
+        {
+          "property": "dc43.pathPattern",
+          "value": "delta.`data/orders_enriched.parquet` versionAsOf={version}"
+        }
+      ]
     }
   ],
   "schema": [

--- a/src/dc43/demo_app/demo_data/contracts/orders_enriched/1.1.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/orders_enriched/1.1.0.json
@@ -11,7 +11,21 @@
       "server": "local",
       "type": "filesystem",
       "path": "data/orders_enriched.parquet",
-      "format": "parquet"
+      "format": "parquet",
+      "customProperties": [
+        {
+          "property": "dc43.versioning",
+          "value": {
+            "mode": "delta",
+            "timeTravel": "versionAsOf",
+            "notes": "Use dataset_version as Delta time travel hint"
+          }
+        },
+        {
+          "property": "dc43.pathPattern",
+          "value": "delta.`data/orders_enriched.parquet` versionAsOf={version}"
+        }
+      ]
     }
   ],
   "schema": [

--- a/src/dc43/demo_app/demo_data/contracts/orders_enriched/2.0.0.json
+++ b/src/dc43/demo_app/demo_data/contracts/orders_enriched/2.0.0.json
@@ -11,7 +11,21 @@
       "server": "local",
       "type": "filesystem",
       "path": "data/orders_enriched.parquet",
-      "format": "parquet"
+      "format": "parquet",
+      "customProperties": [
+        {
+          "property": "dc43.versioning",
+          "value": {
+            "mode": "delta",
+            "timeTravel": "versionAsOf",
+            "notes": "Use dataset_version as Delta time travel hint"
+          }
+        },
+        {
+          "property": "dc43.pathPattern",
+          "value": "delta.`data/orders_enriched.parquet` versionAsOf={version}"
+        }
+      ]
     }
   ],
   "schema": [

--- a/src/dc43/demo_app/demo_data/records/dq_state/status/orders/2025-09-28.json
+++ b/src/dc43/demo_app/demo_data/records/dq_state/status/orders/2025-09-28.json
@@ -1,6 +1,8 @@
 {
   "status": "block",
   "reason": "violations-found",
+  "dataset_id": "orders",
+  "dataset_version": "2025-09-28",
   "details": {
     "status": "block",
     "violations": 1,

--- a/src/dc43/demo_app/demo_data/records/dq_state/status/orders/2025-09-28.json
+++ b/src/dc43/demo_app/demo_data/records/dq_state/status/orders/2025-09-28.json
@@ -3,6 +3,9 @@
   "reason": "violations-found",
   "dataset_id": "orders",
   "dataset_version": "2025-09-28",
+  "contract_id": "orders",
+  "contract_version": "1.1.0",
+  "recorded_at": "2025-09-28T13:28:23Z",
   "details": {
     "status": "block",
     "violations": 1,

--- a/src/dc43/demo_app/demo_data/records/dq_state/status/orders__reject/2025-09-28.json
+++ b/src/dc43/demo_app/demo_data/records/dq_state/status/orders__reject/2025-09-28.json
@@ -1,6 +1,8 @@
 {
   "status": "warn",
   "reason": "quality-issues",
+  "dataset_id": "orders::reject",
+  "dataset_version": "2025-09-28",
   "details": {
     "status": "warn",
     "violations": 1,

--- a/src/dc43/demo_app/demo_data/records/dq_state/status/orders__reject/2025-09-28.json
+++ b/src/dc43/demo_app/demo_data/records/dq_state/status/orders__reject/2025-09-28.json
@@ -3,6 +3,9 @@
   "reason": "quality-issues",
   "dataset_id": "orders::reject",
   "dataset_version": "2025-09-28",
+  "contract_id": "orders",
+  "contract_version": "1.1.0",
+  "recorded_at": "2025-09-28T13:28:23Z",
   "details": {
     "status": "warn",
     "violations": 1,

--- a/src/dc43/demo_app/demo_data/records/dq_state/status/orders__valid/2025-09-28.json
+++ b/src/dc43/demo_app/demo_data/records/dq_state/status/orders__valid/2025-09-28.json
@@ -1,6 +1,8 @@
 {
   "status": "ok",
   "reason": "quality-pass",
+  "dataset_id": "orders::valid",
+  "dataset_version": "2025-09-28",
   "details": {
     "status": "ok",
     "violations": 0,

--- a/src/dc43/demo_app/demo_data/records/dq_state/status/orders__valid/2025-09-28.json
+++ b/src/dc43/demo_app/demo_data/records/dq_state/status/orders__valid/2025-09-28.json
@@ -3,6 +3,9 @@
   "reason": "quality-pass",
   "dataset_id": "orders::valid",
   "dataset_version": "2025-09-28",
+  "contract_id": "orders",
+  "contract_version": "1.1.0",
+  "recorded_at": "2025-09-28T13:28:23Z",
   "details": {
     "status": "ok",
     "violations": 0,

--- a/src/dc43/demo_app/server.py
+++ b/src/dc43/demo_app/server.py
@@ -153,6 +153,15 @@ def _safe_fs_name(value: str) -> str:
     return "".join(ch if ch.isalnum() or ch in ("_", "-", ".") else "_" for ch in value)
 
 
+def _read_json_file(path: Path) -> Optional[Dict[str, Any]]:
+    """Return decoded JSON for ``path`` or ``None`` on failure."""
+
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
 def _version_sort_key(value: str) -> tuple[int, Tuple[int, int, int] | float | str, str]:
     """Sort versions treating ISO timestamps and SemVer intelligently."""
 
@@ -196,20 +205,124 @@ def _dq_status_payload(dataset_id: str, dataset_version: str) -> Optional[Dict[s
     path = _dq_status_path(dataset_id, dataset_version)
     if not path.exists():
         return None
+    return _read_json_file(path)
+
+
+def _dataset_root_for(dataset_id: str, dataset_path: Optional[str] = None) -> Optional[Path]:
+    """Return the directory that should contain materialised versions."""
+
+    base: Optional[Path] = None
+    if dataset_path:
+        try:
+            path = Path(dataset_path)
+        except (TypeError, ValueError):
+            path = None
+        if path is not None:
+            if path.suffix:
+                path = path.parent / path.stem
+            if not path.is_absolute():
+                path = (Path(DATA_DIR).parent / path).resolve()
+            base = path
+    if base is None and dataset_id:
+        base = DATA_DIR / dataset_id.replace("::", "__")
+    return base
+
+
+def _version_marker_value(folder: Path) -> str:
+    """Return the canonical version value for ``folder`` if annotated."""
+
+    marker = folder / ".dc43_version"
+    if marker.exists():
+        try:
+            text = marker.read_text().strip()
+        except OSError:
+            text = ""
+        if text:
+            return text
+    return folder.name
+
+
+def _candidate_version_paths(dataset_dir: Path, version: str) -> List[Path]:
+    """Return directories that may correspond to ``version``."""
+
+    candidates: List[Path] = []
+    direct = dataset_dir / version
+    candidates.append(direct)
+    safe = dataset_dir / _safe_fs_name(version)
+    if safe != direct:
+        candidates.append(safe)
     try:
-        return json.loads(path.read_text())
-    except json.JSONDecodeError:
-        return None
+        for entry in dataset_dir.iterdir():
+            if not entry.is_dir():
+                continue
+            if _version_marker_value(entry) == version and entry not in candidates:
+                candidates.append(entry)
+    except FileNotFoundError:
+        return []
+    return candidates
+
+
+def _has_version_materialisation(dataset_dir: Path, version: str) -> bool:
+    """Return ``True`` if ``dataset_dir`` contains files for ``version``."""
+
+    lowered = version.lower()
+    if lowered in {"latest", "current"} or lowered.startswith("latest__"):
+        return True
+    for candidate in _candidate_version_paths(dataset_dir, version):
+        if candidate.exists():
+            return True
+    return False
+
+
+def _existing_version_dir(dataset_dir: Path, version: str) -> Optional[Path]:
+    """Return an existing directory matching ``version`` if available."""
+
+    for candidate in _candidate_version_paths(dataset_dir, version):
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _target_version_dir(dataset_dir: Path, version: str) -> Path:
+    """Return the directory path where ``version`` should be materialised."""
+
+    safe = _safe_fs_name(version)
+    if not safe:
+        safe = "version"
+    return dataset_dir / safe
+
+
+def _ensure_version_marker(path: Path, version: str) -> None:
+    """Record ``version`` inside ``path`` for lookup when sanitised."""
+
+    if not path.exists() or not path.is_dir():
+        return
+    marker = path / ".dc43_version"
+    try:
+        marker.write_text(version)
+    except OSError:
+        pass
+
+
+def _dq_status_entries(dataset_id: str) -> List[Tuple[str, str, Dict[str, Any]]]:
+    """Return (display_version, stored_version, payload) tuples."""
+
+    directory = _dq_status_dir_for(dataset_id)
+    entries: List[Tuple[str, str, Dict[str, Any]]] = []
+    if not directory.exists():
+        return entries
+    for path in directory.glob("*.json"):
+        payload = _read_json_file(path) or {}
+        display_version = str(payload.get("dataset_version") or path.stem)
+        entries.append((display_version, path.stem, payload))
+    entries.sort(key=lambda item: _version_sort_key(item[0]))
+    return entries
 
 
 def _dq_status_versions(dataset_id: str) -> List[str]:
     """Return known dataset versions recorded by the governance stub."""
 
-    directory = _dq_status_dir_for(dataset_id)
-    if not directory.exists():
-        return []
-    versions = [path.stem for path in directory.glob("*.json")]
-    return _sort_versions(versions)
+    return [entry[0] for entry in _dq_status_entries(dataset_id)]
 
 
 def _link_path(target: Path, source: Path) -> None:
@@ -285,7 +398,9 @@ def set_active_version(dataset: str, version: str) -> None:
     """Point the ``latest`` alias of ``dataset`` (and derivatives) to ``version``."""
 
     dataset_dir = DATA_DIR / dataset
-    target = dataset_dir / version
+    target = _existing_version_dir(dataset_dir, version)
+    if target is None:
+        target = _target_version_dir(dataset_dir, version)
     if not target.exists():
         raise FileNotFoundError(f"Unknown dataset version: {dataset} {version}")
 
@@ -294,15 +409,16 @@ def set_active_version(dataset: str, version: str) -> None:
     if "__" not in dataset:
         for derived_dir in DATA_DIR.glob(f"{dataset}__*"):
             suffix = derived_dir.name.split("__", 1)[1]
-            derived_target = derived_dir / version
-            if derived_target.exists():
-                _link_path((dataset_dir / version) / suffix, derived_target)
-                _link_path(dataset_dir / f"latest__{suffix}", derived_target)
+            derived_target = _existing_version_dir(derived_dir, version)
+            if derived_target is None:
+                continue
+            _link_path(target / suffix, derived_target)
+            _link_path(dataset_dir / f"latest__{suffix}", derived_target)
     else:
         base, suffix = dataset.split("__", 1)
         base_dir = DATA_DIR / base
-        version_dir = base_dir / version
-        if version_dir.exists():
+        version_dir = _existing_version_dir(base_dir, version)
+        if version_dir is not None and version_dir.exists():
             _link_path(version_dir / suffix, target)
             _link_path(base_dir / f"latest__{suffix}", target)
 
@@ -310,8 +426,11 @@ def set_active_version(dataset: str, version: str) -> None:
 def register_dataset_version(dataset: str, version: str, source: Path) -> None:
     """Expose ``source`` under ``data/<dataset>/<version>`` via symlink."""
 
-    target = DATA_DIR / dataset / version
+    dataset_dir = DATA_DIR / dataset
+    dataset_dir.mkdir(parents=True, exist_ok=True)
+    target = _target_version_dir(dataset_dir, version)
     _link_path(target, source)
+    _ensure_version_marker(target, version)
 
 
 refresh_dataset_aliases()
@@ -410,16 +529,36 @@ _DQ_STATUS_BADGES: Dict[str, str] = {
 }
 
 
-def _dq_version_records(dataset_id: str) -> List[Dict[str, Any]]:
+def _dq_version_records(
+    dataset_id: str,
+    *,
+    contract: Optional[OpenDataContractStandard] = None,
+    dataset_path: Optional[str] = None,
+) -> List[Dict[str, Any]]:
     """Return version → status entries for the supplied dataset id."""
 
     records: List[Dict[str, Any]] = []
-    for version in _dq_status_versions(dataset_id):
-        payload = _dq_status_payload(dataset_id, version) or {}
+    entries = _dq_status_entries(dataset_id)
+    if not entries:
+        return records
+
+    dataset_dir = _dataset_root_for(dataset_id, dataset_path)
+    skip_fs_check = False
+    if contract and contract.servers:
+        server = contract.servers[0]
+        fmt = (getattr(server, "format", "") or "").lower()
+        if fmt == "delta":
+            skip_fs_check = True
+
+    for display_version, stored_version, payload in entries:
+        if not skip_fs_check and dataset_dir is not None:
+            if not _has_version_materialisation(dataset_dir, display_version):
+                continue
         status_value = str(payload.get("status", "unknown") or "unknown")
         records.append(
             {
-                "version": version,
+                "version": display_version,
+                "stored_version": stored_version,
                 "status": status_value,
                 "status_label": status_value.replace("_", " ").title(),
                 "badge": _DQ_STATUS_BADGES.get(status_value, "bg-secondary"),
@@ -1154,8 +1293,18 @@ async def api_contract_preview(
         raise HTTPException(status_code=404, detail=str(exc))
 
     effective_dataset_id = str(dataset_id or contract.id or cid)
-    known_versions = _dq_status_versions(effective_dataset_id)
-    selected_version = str(dataset_version or (known_versions[-1] if known_versions else "latest"))
+    server = (contract.servers or [None])[0]
+    dataset_path_hint = getattr(server, "path", None) if server else None
+    version_contract = contract if effective_dataset_id == (contract.id or cid) else None
+    version_records = _dq_version_records(
+        effective_dataset_id,
+        contract=version_contract,
+        dataset_path=dataset_path_hint if version_contract else None,
+    )
+    known_versions = [entry["version"] for entry in version_records]
+    if not known_versions:
+        known_versions = ["latest"]
+    selected_version = str(dataset_version or known_versions[-1])
     if selected_version not in known_versions:
         known_versions = _sort_versions([*known_versions, selected_version])
     limit = max(1, min(limit, 500))
@@ -1275,7 +1424,12 @@ async def contract_detail(request: Request, cid: str, ver: str) -> HTMLResponse:
     change_log = _contract_change_log(contract)
     server_info = _server_details(contract)
     dataset_id = server_info.get("dataset_id") if server_info else contract.id or cid
-    version_records = _dq_version_records(dataset_id or cid)
+    dataset_path_hint = server_info.get("path") if server_info else None
+    version_records = _dq_version_records(
+        dataset_id or cid,
+        contract=contract,
+        dataset_path=dataset_path_hint,
+    )
     version_list = [entry["version"] for entry in version_records]
     status_map = {
         entry["version"]: {

--- a/src/dc43/demo_app/templates/contract_detail.html
+++ b/src/dc43/demo_app/templates/contract_detail.html
@@ -18,6 +18,9 @@
     <button class="nav-link" id="quality-tab" data-bs-toggle="tab" data-bs-target="#quality" type="button" role="tab">Quality</button>
   </li>
   <li class="nav-item" role="presentation">
+    <button class="nav-link" id="access-tab" data-bs-toggle="tab" data-bs-target="#access" type="button" role="tab">Access</button>
+  </li>
+  <li class="nav-item" role="presentation">
     <button class="nav-link" id="change-log-tab" data-bs-toggle="tab" data-bs-target="#change-log" type="button" role="tab">Change Log</button>
   </li>
   <li class="nav-item" role="presentation">
@@ -148,6 +151,106 @@
     </table>
     {% endif %}
   </div>
+  <div class="tab-pane fade" id="access" role="tabpanel" aria-labelledby="access-tab">
+    {% if server_info %}
+    <div class="card mb-3">
+      <div class="card-header">Server definition</div>
+      <div class="card-body">
+        <dl class="row mb-0">
+          <dt class="col-sm-3">Server</dt><dd class="col-sm-9">{{ server_info.server or '—' }}</dd>
+          <dt class="col-sm-3">Type</dt><dd class="col-sm-9">{{ server_info.type or '—' }}</dd>
+          <dt class="col-sm-3">Format</dt><dd class="col-sm-9">{{ server_info.format or '—' }}</dd>
+          {% if server_info.path %}
+          <dt class="col-sm-3">Path</dt><dd class="col-sm-9"><code>{{ server_info.path }}</code></dd>
+          {% endif %}
+          {% if server_info.dataset %}
+          <dt class="col-sm-3">Dataset</dt><dd class="col-sm-9"><code>{{ server_info.dataset }}</code></dd>
+          {% endif %}
+          {% if server_info.dataset_id %}
+          <dt class="col-sm-3">Dataset ID</dt><dd class="col-sm-9"><code>{{ server_info.dataset_id }}</code></dd>
+          {% endif %}
+        </dl>
+      </div>
+      {% if server_info.path_pattern or server_info.versioning or server_info.custom %}
+      <div class="card-footer">
+        {% if server_info.path_pattern %}
+        <p class="mb-2"><strong>Path pattern:</strong> <code>{{ server_info.path_pattern }}</code></p>
+        {% endif %}
+        {% if server_info.versioning %}
+        <div class="mb-2">
+          <strong>Versioning guidance</strong>
+          <pre class="small bg-light p-2 rounded mb-0">{{ server_info.versioning | tojson(indent=2) }}</pre>
+        </div>
+        {% endif %}
+        {% if server_info.custom %}
+        <details>
+          <summary class="small text-muted">View raw custom properties</summary>
+          <pre class="small bg-light p-2 mt-2 rounded">{{ server_info.custom | tojson(indent=2) }}</pre>
+        </details>
+        {% endif %}
+      </div>
+      {% endif %}
+    </div>
+    {% endif %}
+
+    <div class="mb-3">
+      <h5>Compatibility matrix</h5>
+      {% if compatibility_versions %}
+      <ul class="list-unstyled mb-0">
+        {% for entry in compatibility_versions %}
+        <li class="mb-1"><span class="badge {{ entry.badge }} me-2">{{ entry.status_label }}</span>{{ entry.version }}</li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <p class="text-muted mb-0">No compatibility verdicts recorded for this dataset yet.</p>
+      {% endif %}
+    </div>
+
+    {% if preview_versions %}
+    <div class="card" id="contract-data-panel"
+         data-contract-id="{{ contract.id }}"
+         data-contract-version="{{ contract.version }}"
+         data-dataset-id="{{ preview_dataset_id }}"
+         data-versions='{{ preview_versions | tojson | safe }}'
+         data-status-map='{{ preview_status_map | tojson | safe }}'
+         {% if preview_default_index is not none %}data-default-index="{{ preview_default_index }}"{% endif %}>
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <div>
+          <strong>Data preview</strong>
+          {% if preview_dataset_id %}<div class="small text-muted">Dataset <code>{{ preview_dataset_id }}</code></div>{% endif %}
+        </div>
+        <div class="small text-muted">Showing first <span class="preview-limit-display">100</span> rows</div>
+      </div>
+      <div class="card-body">
+        <div class="mb-3">
+          <label for="data-version-slider" class="form-label">Select version</label>
+          <input type="range" class="form-range data-version-slider" id="data-version-slider" min="0" max="{{ preview_versions|length - 1 }}" step="1" value="{{ preview_default_index if preview_default_index is not none else 0 }}" {% if preview_versions|length <= 1 %}disabled{% endif %}>
+          <div class="d-flex justify-content-between small text-muted">
+            <span>{{ preview_versions[0] }}</span>
+            <span>{{ preview_versions[-1] }}</span>
+          </div>
+          <div class="mt-2">
+            <span class="fw-semibold data-version-label"></span>
+            <span class="badge bg-secondary ms-2 data-status-badge"></span>
+          </div>
+        </div>
+        <div class="mb-3">
+          <label for="data-limit-input" class="form-label">Rows to display</label>
+          <input type="number" class="form-control form-control-sm data-limit-input" id="data-limit-input" value="100" min="1" max="500">
+        </div>
+        <div class="table-responsive">
+          <table class="table table-sm table-striped data-preview-table">
+            <thead></thead>
+            <tbody></tbody>
+          </table>
+        </div>
+        <p class="small text-muted data-preview-placeholder"></p>
+      </div>
+    </div>
+    {% else %}
+    <p class="text-muted">No dataset versions available for preview.</p>
+    {% endif %}
+  </div>
   <div class="tab-pane fade" id="change-log" role="tabpanel" aria-labelledby="change-log-tab">
     {% if change_log %}
     <div class="list-group">
@@ -185,5 +288,185 @@
     <pre class="small">{{ contract | tojson(indent=2) }}</pre>
   </div>
 </div>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const panel = document.getElementById('contract-data-panel');
+  if (!panel) {
+    return;
+  }
+  const contractId = panel.dataset.contractId || '';
+  const contractVersion = panel.dataset.contractVersion || '';
+  const datasetId = panel.dataset.datasetId || '';
+  let versions = [];
+  try {
+    versions = JSON.parse(panel.dataset.versions || '[]');
+  } catch (err) {
+    versions = [];
+  }
+  let statusMap = {};
+  try {
+    statusMap = JSON.parse(panel.dataset.statusMap || '{}');
+  } catch (err) {
+    statusMap = {};
+  }
+  const slider = panel.querySelector('.data-version-slider');
+  const label = panel.querySelector('.data-version-label');
+  const badge = panel.querySelector('.data-status-badge');
+  const limitInput = panel.querySelector('.data-limit-input');
+  const limitDisplay = panel.querySelector('.preview-limit-display');
+  const table = panel.querySelector('.data-preview-table');
+  const thead = table ? table.querySelector('thead') : null;
+  const tbody = table ? table.querySelector('tbody') : null;
+  const placeholder = panel.querySelector('.data-preview-placeholder');
+
+  if (!slider || !label || !badge || !table || !thead || !tbody || !limitInput || versions.length === 0) {
+    return;
+  }
+
+  const applyStatus = (version) => {
+    const info = statusMap[version] || {};
+    badge.className = 'badge ' + (info.badge || 'bg-secondary');
+    badge.textContent = info.label || (info.status ? info.status.replace(/_/g, ' ').replace(/^./, c => c.toUpperCase()) : 'Unknown');
+  };
+
+  const updateLabel = (index) => {
+    const safeIndex = Math.max(0, Math.min(index, versions.length - 1));
+    const version = versions[safeIndex];
+    label.textContent = version || '';
+    applyStatus(version);
+  };
+
+  const formatValue = (value) => {
+    if (value === null || value === undefined) {
+      return '';
+    }
+    if (typeof value === 'object') {
+      try {
+        return JSON.stringify(value);
+      } catch (err) {
+        return String(value);
+      }
+    }
+    return String(value);
+  };
+
+  const renderTable = (columns, rows) => {
+    if (!thead || !tbody) {
+      return;
+    }
+    thead.innerHTML = '';
+    tbody.innerHTML = '';
+    const resolvedColumns = Array.isArray(columns) && columns.length ? columns : (rows[0] ? Object.keys(rows[0]) : []);
+    if (resolvedColumns.length) {
+      const headerRow = document.createElement('tr');
+      resolvedColumns.forEach((col) => {
+        const th = document.createElement('th');
+        th.textContent = col;
+        headerRow.appendChild(th);
+      });
+      thead.appendChild(headerRow);
+    }
+    if (!rows.length) {
+      if (placeholder) {
+        placeholder.textContent = 'No rows available for this version.';
+      }
+      return;
+    }
+    rows.forEach((row) => {
+      const tr = document.createElement('tr');
+      resolvedColumns.forEach((col) => {
+        const td = document.createElement('td');
+        td.textContent = formatValue(row[col]);
+        tr.appendChild(td);
+      });
+      tbody.appendChild(tr);
+    });
+    if (placeholder) {
+      placeholder.textContent = '';
+    }
+  };
+
+  const setVersions = (nextVersions, currentVersion) => {
+    if (!Array.isArray(nextVersions) || !nextVersions.length) {
+      return;
+    }
+    versions = nextVersions;
+    slider.max = String(Math.max(versions.length - 1, 0));
+    if (versions.length > 1) {
+      slider.removeAttribute('disabled');
+    } else {
+      slider.setAttribute('disabled', 'disabled');
+    }
+    const idx = currentVersion ? versions.indexOf(currentVersion) : -1;
+    const targetIndex = idx >= 0 ? idx : versions.length - 1;
+    slider.value = String(Math.max(0, targetIndex));
+    updateLabel(Number(slider.value));
+  };
+
+  const fetchPreview = async () => {
+    const index = Number(slider.value) || 0;
+    const version = versions[Math.max(0, Math.min(index, versions.length - 1))];
+    if (placeholder) {
+      placeholder.textContent = 'Loading preview…';
+    }
+    const limit = Number(limitInput.value) || 100;
+    if (limitDisplay) {
+      limitDisplay.textContent = String(limit);
+    }
+    const params = new URLSearchParams();
+    params.set('dataset_version', version);
+    params.set('limit', String(limit));
+    if (datasetId) {
+      params.set('dataset_id', datasetId);
+    }
+    let response;
+    try {
+      response = await fetch(`/api/contracts/${encodeURIComponent(contractId)}/${encodeURIComponent(contractVersion)}/preview?${params.toString()}`);
+    } catch (err) {
+      if (placeholder) {
+        placeholder.textContent = 'Preview unavailable.';
+      }
+      return;
+    }
+    if (!response.ok) {
+      if (placeholder) {
+        placeholder.textContent = `Preview unavailable (status ${response.status}).`;
+      }
+      thead.innerHTML = '';
+      tbody.innerHTML = '';
+      return;
+    }
+    const data = await response.json();
+    if (Array.isArray(data.known_versions) && data.known_versions.length) {
+      setVersions(data.known_versions, data.dataset_version || version);
+    }
+    if (data.status && data.status.status) {
+      statusMap[data.dataset_version] = {
+        status: data.status.status,
+        label: data.status.status_label,
+        badge: data.status.badge,
+      };
+      applyStatus(data.dataset_version);
+    }
+    renderTable(data.columns || [], Array.isArray(data.rows) ? data.rows : []);
+    if (!Array.isArray(data.rows) || !data.rows.length) {
+      if (placeholder) {
+        placeholder.textContent = 'No rows available for this version.';
+      }
+    }
+  };
+
+  slider.addEventListener('input', () => {
+    updateLabel(Number(slider.value));
+  });
+  slider.addEventListener('change', fetchPreview);
+  limitInput.addEventListener('change', fetchPreview);
+
+  const defaultIndex = Number(panel.dataset.defaultIndex || slider.max || 0);
+  slider.value = String(Math.max(0, Math.min(defaultIndex, versions.length - 1)));
+  updateLabel(Number(slider.value));
+  fetchPreview();
+});
+</script>
 {% endblock %}
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Optional
 
 import pytest
 
@@ -16,6 +17,8 @@ from dc43.components.integration.spark_io import (
     read_with_contract,
     write_with_contract,
     StaticDatasetLocator,
+    ContractVersionLocator,
+    DatasetResolution,
 )
 from dc43.components.integration.violation_strategy import SplitWriteViolationStrategy
 from dc43.components.data_quality.governance.stubs import StubDQClient
@@ -357,6 +360,168 @@ def test_write_keeps_existing_link_for_contract_upgrade(spark, tmp_path: Path):
         == f"{contract_v1.id}:{contract_v1.version}"
     )
 
+
+class _DummyLocator:
+    def __init__(self, resolution: DatasetResolution) -> None:
+        self._resolution = resolution
+
+    def for_read(
+        self,
+        *,
+        contract: Optional[OpenDataContractStandard],
+        spark,
+        format: Optional[str],
+        path: Optional[str],
+        table: Optional[str],
+    ) -> DatasetResolution:
+        return self._resolution
+
+    def for_write(
+        self,
+        *,
+        contract: Optional[OpenDataContractStandard],
+        df,
+        format: Optional[str],
+        path: Optional[str],
+        table: Optional[str],
+    ) -> DatasetResolution:
+        return self._resolution
+
+
+def test_contract_version_locator_sets_delta_version_option():
+    base_resolution = DatasetResolution(
+        path="/tmp/delta/orders",
+        table=None,
+        format="delta",
+        dataset_id="orders",
+        dataset_version=None,
+    )
+    locator = ContractVersionLocator(dataset_version="7", base=_DummyLocator(base_resolution))
+    merged = locator.for_read(
+        contract=None,
+        spark=None,
+        format="delta",
+        path=base_resolution.path,
+        table=None,
+    )
+    assert merged.path == base_resolution.path
+    assert merged.read_options == {"versionAsOf": "7"}
+
+
+def test_contract_version_locator_timestamp_sets_delta_option():
+    base_resolution = DatasetResolution(
+        path="/tmp/delta/orders",
+        table=None,
+        format="delta",
+        dataset_id="orders",
+        dataset_version=None,
+    )
+    locator = ContractVersionLocator(
+        dataset_version="2024-05-31T10:00:00Z",
+        base=_DummyLocator(base_resolution),
+    )
+    merged = locator.for_read(
+        contract=None,
+        spark=None,
+        format="delta",
+        path=base_resolution.path,
+        table=None,
+    )
+    assert merged.read_options == {"timestampAsOf": "2024-05-31T10:00:00Z"}
+
+
+def test_contract_version_locator_latest_skips_delta_option():
+    base_resolution = DatasetResolution(
+        path="/tmp/delta/orders",
+        table=None,
+        format="delta",
+        dataset_id="orders",
+        dataset_version=None,
+    )
+    locator = ContractVersionLocator(dataset_version="latest", base=_DummyLocator(base_resolution))
+    merged = locator.for_read(
+        contract=None,
+        spark=None,
+        format="delta",
+        path=base_resolution.path,
+        table=None,
+    )
+    assert merged.read_options is None
+
+
+def test_contract_version_locator_expands_versioning_paths(tmp_path: Path) -> None:
+    base_dir = tmp_path / "orders"
+    (base_dir / "2024-01-01").mkdir(parents=True)
+    (base_dir / "2024-01-02").mkdir()
+    for version in ("2024-01-01", "2024-01-02"):
+        target = base_dir / version / "orders.json"
+        target.write_text("[]", encoding="utf-8")
+
+    resolution = DatasetResolution(
+        path=str(base_dir),
+        table=None,
+        format="json",
+        dataset_id="orders",
+        dataset_version=None,
+        custom_properties={
+            "dc43.versioning": {
+                "mode": "delta",
+                "includePriorVersions": True,
+                "subfolder": "{version}",
+                "filePattern": "orders.json",
+                "readOptions": {"recursiveFileLookup": True},
+            }
+        },
+    )
+    locator = ContractVersionLocator(dataset_version="2024-01-02", base=_DummyLocator(resolution))
+    merged = locator.for_read(
+        contract=None,
+        spark=None,
+        format="json",
+        path=str(base_dir),
+        table=None,
+    )
+    assert merged.path == str(base_dir)
+    assert merged.load_paths
+    assert set(merged.load_paths) == {
+        str(base_dir / "2024-01-01" / "orders.json"),
+        str(base_dir / "2024-01-02" / "orders.json"),
+    }
+    assert merged.read_options and merged.read_options.get("recursiveFileLookup") == "true"
+
+
+def test_contract_version_locator_snapshot_paths(tmp_path: Path) -> None:
+    base_dir = tmp_path / "customers"
+    (base_dir / "2024-01-01").mkdir(parents=True)
+    (base_dir / "2024-02-01").mkdir()
+    for version in ("2024-01-01", "2024-02-01"):
+        target = base_dir / version / "customers.json"
+        target.write_text("[]", encoding="utf-8")
+
+    resolution = DatasetResolution(
+        path=str(base_dir),
+        table=None,
+        format="json",
+        dataset_id="customers",
+        dataset_version=None,
+        custom_properties={
+            "dc43.versioning": {
+                "mode": "snapshot",
+                "includePriorVersions": False,
+                "subfolder": "{version}",
+                "filePattern": "customers.json",
+            }
+        },
+    )
+    locator = ContractVersionLocator(dataset_version="2024-02-01", base=_DummyLocator(resolution))
+    merged = locator.for_read(
+        contract=None,
+        spark=None,
+        format="json",
+        path=str(base_dir),
+        table=None,
+    )
+    assert merged.load_paths == [str(base_dir / "2024-02-01" / "customers.json")]
     contract_v2 = make_contract(str(dest_dir))
     contract_v2.version = "0.2.0"
     contract_v2.schema_[0].properties[3].quality = [DataQuality(mustBeGreaterThan=800)]


### PR DESCRIPTION
## Summary
- enrich dataset resolution with server custom properties so `ContractVersionLocator` can glob versioned folders and merge locator-provided read options
- update demo contracts to document incremental versus snapshot layouts and delta time-travel expectations via `dc43.versioning` metadata
- extend integration docs and tests to cover the new folder semantics and ensure cumulative inputs expand to multiple paths

## Testing
- pytest tests/test_integration.py::test_contract_version_locator_expands_versioning_paths -q *(fails: pyspark required for dc43 tests)*

------
https://chatgpt.com/codex/tasks/task_b_68d608dfa6f0832eaed3e15c85ba4070