### PR TITLE
Bundle governance handles to forward pipeline context

### DIFF
--- a/docs/implementations/contract-store/fs.md
+++ b/docs/implementations/contract-store/fs.md
@@ -20,7 +20,7 @@ through pull requests.
     ├── 0.1.0.json
     ├── 0.2.0.json
     └── drafts/
-        └── 0.2.0-draft-20240601T1015Z.json
+        └── 0.2.0-draft-20240601T101500Z-1a2b3c4d.json
 ```
 
 * **Version resolution** – `latest("sales.orders")` orders files
@@ -53,3 +53,11 @@ latest = store.latest("sales.orders")
 
 Document additional file-based variations (Git, S3, ADLS) in this folder if you
 extend the implementation with extra capabilities.
+
+### Governance metadata
+
+When combined with the demo governance stub, a sibling directory named
+`pipeline_activity/` persists JSON payloads describing which pipeline contexts
+read or wrote each dataset version. Entries capture the triggering operation,
+the resolved contract identifiers, and the caller-provided context so the demo
+UI can surface provenance alongside contract drafts and compatibility status.

--- a/src/dc43/components/data_quality/__init__.py
+++ b/src/dc43/components/data_quality/__init__.py
@@ -11,13 +11,21 @@ if TYPE_CHECKING:  # pragma: no cover - import cycle guard
         attach_failed_expectations,
         validate_dataframe,
     )
-    from .manager import DataQualityManager, QualityAssessment, QualityDraftContext  # noqa: F401
+    from .manager import (  # noqa: F401
+        DataQualityManager,
+        GovernanceHandles,
+        PipelineContext,
+        QualityAssessment,
+        QualityDraftContext,
+    )
     from .validation import apply_contract  # noqa: F401
 
 __all__ = [
     "DataQualityManager",
+    "GovernanceHandles",
     "QualityAssessment",
     "QualityDraftContext",
+    "PipelineContext",
     "DQClient",
     "DQStatus",
     "apply_contract",
@@ -29,8 +37,10 @@ _EXPORT_MAP = {
     "DQClient": ("governance", "DQClient"),
     "DQStatus": ("governance", "DQStatus"),
     "DataQualityManager": ("manager", "DataQualityManager"),
+    "GovernanceHandles": ("manager", "GovernanceHandles"),
     "QualityAssessment": ("manager", "QualityAssessment"),
     "QualityDraftContext": ("manager", "QualityDraftContext"),
+    "PipelineContext": ("manager", "PipelineContext"),
     "apply_contract": ("validation", "apply_contract"),
     "validate_dataframe": ("integration", "validate_dataframe"),
     "attach_failed_expectations": ("integration", "attach_failed_expectations"),

--- a/src/dc43/components/data_quality/governance/interface.py
+++ b/src/dc43/components/data_quality/governance/interface.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, Mapping, Optional, Protocol
+from typing import Any, Dict, Mapping, Optional, Protocol, Sequence
 
 from open_data_contract_standard.model import OpenDataContractStandard  # type: ignore
 
@@ -52,6 +52,7 @@ class DQClient(Protocol):
         dataset_version: Optional[str] = None,
         data_format: Optional[str] = None,
         dq_feedback: Optional[Mapping[str, Any]] = None,
+        draft_context: Optional[Mapping[str, Any]] = None,
     ) -> Optional[OpenDataContractStandard]:
         """Return a draft contract proposal based on a validation outcome."""
         ...
@@ -73,6 +74,27 @@ class DQClient(Protocol):
         dataset_version: Optional[str] = None,
     ) -> Optional[str]:
         """Return contract version associated to dataset if tracked (format: "<contract_id>:<version>")."""
+        ...
+
+    def record_pipeline_activity(
+        self,
+        *,
+        dataset_id: str,
+        dataset_version: str,
+        contract_id: Optional[str],
+        contract_version: Optional[str],
+        activity: Mapping[str, Any],
+    ) -> None:
+        """Persist pipeline activity metadata for governance insights."""
+        ...
+
+    def get_pipeline_activity(
+        self,
+        *,
+        dataset_id: str,
+        dataset_version: Optional[str] = None,
+    ) -> Sequence[Mapping[str, Any]]:
+        """Return recorded pipeline metadata for the supplied dataset."""
         ...
 
 

--- a/src/dc43/components/data_quality/manager.py
+++ b/src/dc43/components/data_quality/manager.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass
-from typing import Callable, Mapping, Optional, Tuple
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple, Union
 
 from open_data_contract_standard.model import OpenDataContractStandard  # type: ignore
 
 from dc43.components.contract_drafter import draft_from_validation_result
 from dc43.components.contract_store.interface import ContractStore
+from dc43.odcs import contract_identity
 
 from .engine import ValidationResult
 from .governance import DQClient, DQStatus
@@ -22,6 +24,37 @@ class QualityDraftContext:
     dataset_version: Optional[str]
     data_format: Optional[str]
     dq_feedback: Optional[Mapping[str, object]]
+    draft_context: Optional[Mapping[str, object]] = None
+    pipeline_context: Optional[Mapping[str, object]] = None
+
+
+@dataclass
+class PipelineContext:
+    """Descriptor describing the pipeline triggering a DQ interaction."""
+
+    pipeline: Optional[str] = None
+    label: Optional[str] = None
+    metadata: Optional[Mapping[str, object]] = None
+
+    def as_dict(self) -> Dict[str, object]:
+        """Return the pipeline context as a dictionary."""
+
+        payload: Dict[str, object] = {}
+        if self.metadata:
+            payload.update(self.metadata)
+        if self.label:
+            payload.setdefault("label", self.label)
+        if self.pipeline:
+            payload.setdefault("pipeline", self.pipeline)
+        return payload
+
+
+PipelineContextSpec = Union[
+    PipelineContext,
+    Mapping[str, object],
+    Sequence[tuple[str, object]],
+    str,
+]
 
 
 @dataclass
@@ -141,6 +174,7 @@ class DataQualityManager:
         dq_status: DQStatus | None = None,
         dq_feedback: Mapping[str, object] | None = None,
         context: QualityDraftContext | None = None,
+        pipeline_context: PipelineContextSpec | None = None,
         draft_requested: bool = False,
     ) -> Optional[OpenDataContractStandard]:
         """Return a draft proposal when a validation mismatch requires it."""
@@ -156,11 +190,13 @@ class DataQualityManager:
             payload.setdefault("status", dq_status.status)
             feedback = payload or None
 
-        effective_context = context or QualityDraftContext(
+        effective_context = _build_quality_context(
+            context,
             dataset_id=dataset_id,
             dataset_version=dataset_version,
             data_format=data_format,
             dq_feedback=feedback,
+            pipeline_context=pipeline_context,
         )
 
         draft = self.propose_draft(
@@ -168,6 +204,7 @@ class DataQualityManager:
             base_contract=base_contract,
             bump=bump,
             context=effective_context,
+            pipeline_context=effective_context.pipeline_context,
         )
 
         return draft
@@ -182,12 +219,23 @@ class DataQualityManager:
         observations: Optional[Callable[[], Tuple[Mapping[str, object], bool]]] = None,
         bump: str = "minor",
         context: QualityDraftContext | None = None,
+        pipeline_context: PipelineContextSpec | None = None,
+        operation: str = "read",
         draft_on_violation: bool = False,
     ) -> QualityAssessment:
         """Evaluate the dataset status and optionally return a draft proposal."""
 
         if not self._client:
             return QualityAssessment(status=None, draft=None, observations_reused=False)
+
+        effective_context = _build_quality_context(
+            context,
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
+            data_format=context.data_format if context else None,
+            dq_feedback=context.dq_feedback if context else None,
+            pipeline_context=pipeline_context,
+        )
 
         status = self._client.get_status(
             contract_id=contract.id,
@@ -220,7 +268,18 @@ class DataQualityManager:
                 dq_status=status,
                 dq_feedback=context.dq_feedback if context else None,
                 draft_requested=True,
+                pipeline_context=effective_context.pipeline_context,
             )
+
+        self._record_pipeline_activity(
+            contract=contract,
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
+            operation=operation,
+            pipeline_context=effective_context.pipeline_context,
+            status=status,
+            observations_reused=reused,
+        )
 
         return QualityAssessment(status=status, draft=draft, observations_reused=reused)
 
@@ -231,13 +290,23 @@ class DataQualityManager:
         base_contract: OpenDataContractStandard,
         bump: str = "minor",
         context: QualityDraftContext | None = None,
+        pipeline_context: PipelineContextSpec | None = None,
     ) -> OpenDataContractStandard:
         """Generate a draft proposal for the supplied validation result."""
 
-        dataset_id = context.dataset_id if context else None
-        dataset_version = context.dataset_version if context else None
-        data_format = context.data_format if context else None
-        dq_feedback = context.dq_feedback if context else None
+        base_dataset_id = context.dataset_id if context else None
+        base_dataset_version = context.dataset_version if context else None
+        base_data_format = context.data_format if context else None
+        base_feedback = context.dq_feedback if context else None
+
+        effective_context = _build_quality_context(
+            context,
+            dataset_id=base_dataset_id,
+            dataset_version=base_dataset_version,
+            data_format=base_data_format,
+            dq_feedback=base_feedback,
+            pipeline_context=pipeline_context,
+        )
 
         draft: Optional[OpenDataContractStandard] = None
 
@@ -246,10 +315,11 @@ class DataQualityManager:
                 validation=validation,
                 base_contract=base_contract,
                 bump=bump,
-                dataset_id=dataset_id,
-                dataset_version=dataset_version,
-                data_format=data_format,
-                dq_feedback=dq_feedback,
+                dataset_id=effective_context.dataset_id,
+                dataset_version=effective_context.dataset_version,
+                data_format=effective_context.data_format,
+                dq_feedback=effective_context.dq_feedback,
+                draft_context=effective_context.draft_context,
             )
             if draft is not None:
                 if self._draft_store is not None:
@@ -260,10 +330,11 @@ class DataQualityManager:
             validation=validation,
             base_contract=base_contract,
             bump=bump,
-            dataset_id=dataset_id,
-            dataset_version=dataset_version,
-            data_format=data_format,
-            dq_feedback=dq_feedback,
+            dataset_id=effective_context.dataset_id,
+            dataset_version=effective_context.dataset_version,
+            data_format=effective_context.data_format,
+            dq_feedback=effective_context.dq_feedback,
+            draft_context=effective_context.draft_context,
         )
 
         if draft is not None and self._draft_store is not None:
@@ -271,5 +342,265 @@ class DataQualityManager:
 
         return draft
 
+    def get_pipeline_activity(
+        self,
+        *,
+        dataset_id: str,
+        dataset_version: Optional[str] = None,
+    ) -> Sequence[Mapping[str, Any]]:
+        """Return recorded pipeline activity for ``dataset_id``."""
 
-__all__ = ["DataQualityManager", "QualityAssessment", "QualityDraftContext"]
+        if not self._client:
+            return []
+
+        fetcher = getattr(self._client, "get_pipeline_activity", None)
+        if not callable(fetcher):
+            return []
+
+        try:
+            return fetcher(dataset_id=dataset_id, dataset_version=dataset_version) or []
+        except TypeError:
+            # Gracefully handle clients that expose a positional signature.
+            return fetcher(dataset_id, dataset_version) or []  # type: ignore[misc]
+
+    def _record_pipeline_activity(
+        self,
+        *,
+        contract: OpenDataContractStandard,
+        dataset_id: str,
+        dataset_version: str,
+        operation: str,
+        pipeline_context: Optional[Mapping[str, Any]],
+        status: Optional[DQStatus],
+        observations_reused: bool,
+    ) -> None:
+        """Persist pipeline provenance for governance-aware clients."""
+
+        if not self._client:
+            return
+
+        recorder = getattr(self._client, "record_pipeline_activity", None)
+        if not callable(recorder):
+            return
+
+        contract_id: Optional[str] = None
+        contract_version: Optional[str] = None
+        if contract.id or contract.version:
+            contract_id, contract_version = contract_identity(contract)
+
+        payload: Dict[str, Any] = {
+            "operation": operation,
+            "pipeline_context": dict(pipeline_context or {}),
+            "observations_reused": observations_reused,
+        }
+        if status is not None:
+            payload["dq_status"] = status.status
+            if status.reason:
+                payload["dq_reason"] = status.reason
+            if status.details:
+                payload["dq_details"] = status.details
+
+        try:
+            recorder(
+                dataset_id=dataset_id,
+                dataset_version=dataset_version,
+                contract_id=contract_id,
+                contract_version=contract_version,
+                activity=payload,
+            )
+        except TypeError:
+            recorder(  # type: ignore[misc]
+                dataset_id,
+                dataset_version,
+                contract_id,
+                contract_version,
+                payload,
+            )
+
+
+@dataclass
+class GovernanceHandles:
+    """Bundle governance dependencies so callers can share context once."""
+
+    dq_client: DataQualityManager | DQClient | None = None
+    contract_store: ContractStore | None = None
+
+    def as_manager(self) -> DataQualityManager:
+        """Return a :class:`DataQualityManager` instance configured with the bundle."""
+
+        candidate = self.dq_client
+        store = self.contract_store
+
+        if isinstance(candidate, DataQualityManager):
+            manager = candidate
+            if store and manager.draft_store is not store:
+                manager = DataQualityManager(manager.client, draft_store=store)
+            elif store is None or manager.draft_store is store:
+                return manager
+            return manager
+
+        return DataQualityManager(candidate, draft_store=store)
+
+
+__all__ = [
+    "DataQualityManager",
+    "QualityAssessment",
+    "QualityDraftContext",
+    "PipelineContext",
+    "GovernanceHandles",
+]
+
+
+def _infer_pipeline_context() -> Optional[Dict[str, str]]:
+    """Return context identifying the caller requesting a contract draft."""
+
+    frame = inspect.currentframe()
+    if frame is None:
+        return None
+
+    ignored_prefixes = (
+        "dc43.components.integration",
+        "dc43.components.data_quality",
+    )
+
+    try:
+        frame = frame.f_back
+        while frame is not None:
+            module_name = frame.f_globals.get("__name__", "")
+            if not module_name.startswith(ignored_prefixes):
+                function_name = frame.f_code.co_name
+                qualname = getattr(frame.f_code, "co_qualname", function_name)
+                context: Dict[str, str] = {}
+                if module_name:
+                    context["module"] = module_name
+                if function_name:
+                    context["function"] = function_name
+                if qualname:
+                    context.setdefault("qualname", qualname)
+                if module_name and qualname:
+                    context.setdefault("pipeline", f"{module_name}.{qualname}")
+                elif module_name and function_name:
+                    context.setdefault("pipeline", f"{module_name}.{function_name}")
+                elif qualname:
+                    context.setdefault("pipeline", qualname)
+                filename = frame.f_code.co_filename
+                if filename:
+                    context.setdefault("source", filename)
+                return context or None
+            frame = frame.f_back
+    finally:
+        del frame
+
+    return None
+
+
+def _normalise_pipeline_context(
+    candidate: PipelineContextSpec | Mapping[str, object] | None,
+) -> Optional[Dict[str, Any]]:
+    """Return a dictionary representation for ``candidate`` when possible."""
+
+    if candidate is None:
+        return None
+    if isinstance(candidate, PipelineContext):
+        return candidate.as_dict()
+    if isinstance(candidate, str):
+        value = candidate.strip()
+        return {"pipeline": value} if value else None
+    if isinstance(candidate, Mapping):
+        return dict(candidate)
+    if isinstance(candidate, Sequence):
+        context: Dict[str, Any] = {}
+        for item in candidate:
+            if not isinstance(item, tuple) or len(item) != 2:
+                continue
+            key, value = item
+            context[str(key)] = value
+        return context or None
+    return None
+
+
+def _collect_pipeline_context(
+    *candidates: PipelineContextSpec | Mapping[str, object] | None,
+) -> Optional[Dict[str, Any]]:
+    """Combine provided pipeline hints with inferred metadata."""
+
+    explicit: Dict[str, Any] = {}
+    for candidate in candidates:
+        resolved = _normalise_pipeline_context(candidate)
+        if resolved:
+            explicit.update(resolved)
+
+    inferred = _infer_pipeline_context()
+    context: Dict[str, Any] = {}
+    if inferred:
+        context.update(inferred)
+    if explicit:
+        context.update(explicit)
+    return context or None
+
+
+def _merge_draft_context(
+    base: Optional[Mapping[str, Any]],
+    *,
+    dataset_id: Optional[str],
+    dataset_version: Optional[str],
+    data_format: Optional[str],
+    pipeline_context: Optional[Mapping[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """Combine the supplied draft context with inferred metadata."""
+
+    context: Dict[str, Any] = {}
+    if pipeline_context:
+        context.update(pipeline_context)
+    if base:
+        context.update(base)
+
+    if dataset_id and "dataset_id" not in context:
+        context["dataset_id"] = dataset_id
+    if dataset_version and "dataset_version" not in context:
+        context["dataset_version"] = dataset_version
+    if data_format and "data_format" not in context:
+        context["data_format"] = data_format
+
+    return context or None
+
+
+def _build_quality_context(
+    context: QualityDraftContext | None,
+    *,
+    dataset_id: Optional[str],
+    dataset_version: Optional[str],
+    data_format: Optional[str],
+    dq_feedback: Optional[Mapping[str, object]],
+    pipeline_context: Optional[PipelineContextSpec] = None,
+) -> QualityDraftContext:
+    """Return a :class:`QualityDraftContext` populated with inferred metadata."""
+
+    resolved_dataset_id = context.dataset_id if context and context.dataset_id else dataset_id
+    resolved_dataset_version = (
+        context.dataset_version if context and context.dataset_version else dataset_version
+    )
+    resolved_data_format = context.data_format if context and context.data_format else data_format
+    resolved_feedback = context.dq_feedback if context and context.dq_feedback else dq_feedback
+
+    pipeline_metadata = _collect_pipeline_context(
+        context.pipeline_context if context else None,
+        pipeline_context,
+    )
+
+    merged_context = _merge_draft_context(
+        context.draft_context if context else None,
+        dataset_id=resolved_dataset_id,
+        dataset_version=resolved_dataset_version,
+        data_format=resolved_data_format,
+        pipeline_context=pipeline_metadata,
+    )
+
+    return QualityDraftContext(
+        dataset_id=resolved_dataset_id,
+        dataset_version=resolved_dataset_version,
+        data_format=resolved_data_format,
+        dq_feedback=resolved_feedback,
+        draft_context=merged_context,
+        pipeline_context=pipeline_metadata,
+    )

--- a/src/dc43/demo_app/templates/dataset_detail.html
+++ b/src/dc43/demo_app/templates/dataset_detail.html
@@ -75,6 +75,55 @@
   </ul>
 </div>
 {% endif %}
+{% set pipeline_activity = output_details.get('pipeline_activity', []) %}
+{% if pipeline_activity %}
+<h2>Pipeline activity</h2>
+{% for entry in pipeline_activity %}
+  <div class="card mb-3">
+    <div class="card-header">
+      <strong>Dataset version:</strong> {{ entry.dataset_version or 'unknown' }}
+      {% if entry.contract_id and entry.contract_version %}
+        <span class="ms-2 text-muted">Contract {{ entry.contract_id }}:{{ entry.contract_version }}</span>
+      {% endif %}
+    </div>
+    <div class="card-body p-0">
+      {% set events = entry.events or [] %}
+      {% if events %}
+      <div class="table-responsive">
+        <table class="table table-sm mb-0">
+          <thead>
+            <tr>
+              <th scope="col">Recorded at</th>
+              <th scope="col">Operation</th>
+              <th scope="col">DQ Status</th>
+              <th scope="col">Context</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for event in events %}
+            <tr>
+              <td><code>{{ event.recorded_at or 'n/a' }}</code></td>
+              <td>{{ event.operation or 'unknown' }}</td>
+              <td>
+                {% if event.dq_status %}
+                  <span class="badge bg-secondary text-uppercase">{{ event.dq_status }}</span>
+                {% else %}
+                  <span class="text-muted">n/a</span>
+                {% endif %}
+              </td>
+              <td><pre class="small mb-0">{{ event.pipeline_context or {} | tojson(indent=2) }}</pre></td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% else %}
+        <p class="m-3 text-muted">No activity recorded.</p>
+      {% endif %}
+    </div>
+  </div>
+{% endfor %}
+{% endif %}
 <h2>Details</h2>
 <pre class="small">{{ output_details | tojson(indent=2) }}</pre>
 {% if data_preview %}


### PR DESCRIPTION
## Summary
- add a `GovernanceHandles` helper so callers can pass both the DQ client and contract store, ensuring pipeline context is attached when drafts are persisted
- teach the Spark integration wrappers to accept the new bundle and cover it with an integration scenario that verifies stored draft metadata
- merge dataset identifiers into `draft_from_validation_result` contexts and tidy the demo pipeline test to read the captured activity

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68d69d3919d0832eb0ea4ee85697b01f