### PR TITLE
Record DQ status when invalid input blocks pipeline

### DIFF
--- a/src/dc43/demo_app/server.py
+++ b/src/dc43/demo_app/server.py
@@ -501,6 +501,7 @@ class DatasetRecord:
     dq_details: Dict[str, Any] = field(default_factory=dict)
     run_type: str = "infer"
     violations: int = 0
+    reason: str = ""
     draft_contract_version: str | None = None
     scenario_key: str | None = None
 


### PR DESCRIPTION
## Summary
- record blocked read failures as dataset records so the UI can surface DQ details
- capture the failure reason on dataset records and expose the blocking verdict in the stored payload
- extend the invalid-read scenario test to assert the run history includes the blocking status

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68d8d314d1b8832eaa7efdfe174ff619