### PR TITLE
Delegate expectation plans to the data-quality service

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,13 +158,16 @@ write_with_contract(
 
 ```python
 import dlt
-from dc43.integration.spark.dlt import expectations_from_contract
+from collections.abc import Mapping
+from dc43.integration.spark.dlt import apply_dlt_expectations
 
 @dlt.table(name="orders")
 def orders():
     df = spark.read.stream.table("bronze.sales_orders_raw")
-    exps = expectations_from_contract(contract)
-    dlt.expect_all(exps)
+    # Retrieve predicates from your configured data-quality service.
+    predicates = dq_status.details.get("expectation_predicates")
+    if isinstance(predicates, Mapping):
+        apply_dlt_expectations(dlt, predicates)
     return df.select("order_id", "customer_id", "order_ts", "amount", "currency")
 ```
 

--- a/docs/component-write-violation-strategies.md
+++ b/docs/component-write-violation-strategies.md
@@ -65,7 +65,7 @@ Strategies receive a `WriteStrategyContext` with the aligned dataframe, validati
 re-run validation on derived subsets. From this context they can:
 
 - Inspect whether the initial validation recorded violations.
-- Compute Spark filters using expectation predicates gathered from the contract.
+- Compute Spark filters using expectation predicates gathered from the data-quality service.
 - Derive new dataset identifiers (`dataset_id::suffix`) and storage paths.
 - Re-validate each subset via `context.revalidate` to capture row counts and violation metrics for downstream governance.
 

--- a/src/dc43/integration/spark/dlt.py
+++ b/src/dc43/integration/spark/dlt.py
@@ -1,26 +1,18 @@
 from __future__ import annotations
 
-"""Delta Live Tables helpers from ODCS contracts.
+"""Delta Live Tables helpers."""
 
-Translate ODCS DataQuality rules to DLT expectations.
-"""
-
-from typing import Dict
-from open_data_contract_standard.model import OpenDataContractStandard  # type: ignore
-
-from .data_quality import (
-    expectations_from_contract as _expectations_from_contract,
-)
+from typing import Mapping
 
 
-def expectations_from_contract(contract: OpenDataContractStandard) -> Dict[str, str]:
-    """Return expectation_name -> SQL predicate derived from DataQuality rules."""
-    return _expectations_from_contract(contract)
-
-
-def apply_dlt_expectations(dlt_module, expectations: Dict[str, str], *, drop: bool = False) -> None:
+def apply_dlt_expectations(
+    dlt_module,
+    expectations: Mapping[str, str],
+    *,
+    drop: bool = False,
+) -> None:
     """Apply expectations using a provided `dlt` module inside a pipeline function."""
     if drop:
-        dlt_module.expect_all_or_drop(expectations)
+        dlt_module.expect_all_or_drop(dict(expectations))
     else:
-        dlt_module.expect_all(expectations)
+        dlt_module.expect_all(dict(expectations))

--- a/src/dc43/integration/spark/io.py
+++ b/src/dc43/integration/spark/io.py
@@ -1526,6 +1526,13 @@ def _execute_write_request(
         writer.save(request.path)
 
     validation = request.validation_factory() if request.validation_factory else None
+    expectation_plan: list[Mapping[str, Any]] = []
+    if validation is not None:
+        raw_plan = validation.details.get("expectation_plan")
+        if isinstance(raw_plan, Iterable):
+            expectation_plan = [
+                item for item in raw_plan if isinstance(item, Mapping)
+            ]
     if validation is not None and request.warnings:
         for message in request.warnings:
             if message not in validation.warnings:

--- a/src/dc43/services/data_quality/backend/interface.py
+++ b/src/dc43/services/data_quality/backend/interface.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Mapping, Protocol, Sequence
 
 from open_data_contract_standard.model import OpenDataContractStandard  # type: ignore
 
@@ -19,6 +19,11 @@ class DataQualityServiceBackend(Protocol):
         payload: ObservationPayload,
     ) -> ValidationResult:
         """Return the validation outcome for the provided observations."""
+
+    def describe_expectations(
+        self, *, contract: OpenDataContractStandard
+    ) -> Sequence[Mapping[str, object]]:
+        """Return serialisable descriptors for contract expectations."""
 
 
 __all__ = ["DataQualityServiceBackend"]

--- a/src/dc43/services/data_quality/backend/local.py
+++ b/src/dc43/services/data_quality/backend/local.py
@@ -24,5 +24,10 @@ class LocalDataQualityServiceBackend(DataQualityServiceBackend):
     ) -> ValidationResult:
         return self._manager.evaluate(contract, payload)
 
+    def describe_expectations(
+        self, *, contract: OpenDataContractStandard
+    ) -> list[dict[str, object]]:
+        return self._manager.describe_expectations(contract)
+
 
 __all__ = ["LocalDataQualityServiceBackend"]

--- a/src/dc43/services/data_quality/backend/predicates.py
+++ b/src/dc43/services/data_quality/backend/predicates.py
@@ -1,0 +1,90 @@
+"""Helpers to project expectation specs into serialisable plans."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Mapping
+
+from open_data_contract_standard.model import OpenDataContractStandard  # type: ignore
+
+from .engine import ExpectationSpec, expectation_specs
+
+
+def _sql_literal(value: Any) -> str:
+    if isinstance(value, str):
+        escaped = value.replace("'", "\\'")
+        return f"'{escaped}'"
+    if value is None:
+        return "NULL"
+    return str(value)
+
+
+def sql_predicate(spec: ExpectationSpec) -> str | None:
+    """Return a Spark SQL predicate for the provided expectation spec."""
+
+    column = spec.column
+    if not column:
+        return None
+    if spec.rule in {"not_null", "required"}:
+        return f"{column} IS NOT NULL"
+    if spec.rule == "gt":
+        return f"{column} > {_sql_literal(spec.params.get('threshold'))}"
+    if spec.rule == "ge":
+        return f"{column} >= {_sql_literal(spec.params.get('threshold'))}"
+    if spec.rule == "lt":
+        return f"{column} < {_sql_literal(spec.params.get('threshold'))}"
+    if spec.rule == "le":
+        return f"{column} <= {_sql_literal(spec.params.get('threshold'))}"
+    if spec.rule == "enum":
+        values = spec.params.get("values") or []
+        if not isinstance(values, (list, tuple, set)):
+            return None
+        literals = ", ".join(_sql_literal(v) for v in values)
+        return f"{column} IN ({literals})" if literals else None
+    if spec.rule == "regex":
+        pattern = spec.params.get("pattern")
+        if pattern is None:
+            return None
+        pattern_str = str(pattern).replace("'", "\\'")
+        return f"{column} RLIKE '{pattern_str}'"
+    return None
+
+
+def expectation_plan(contract: OpenDataContractStandard) -> List[Dict[str, Any]]:
+    """Return serialisable expectation descriptors derived from ``contract``."""
+
+    plan: List[Dict[str, Any]] = []
+    for spec in expectation_specs(contract):
+        entry: Dict[str, Any] = {
+            "key": spec.key,
+            "rule": spec.rule,
+            "column": spec.column,
+            "optional": bool(spec.optional),
+        }
+        if spec.params:
+            entry["params"] = dict(spec.params)
+        predicate = sql_predicate(spec)
+        if predicate:
+            entry["predicate"] = predicate
+        plan.append(entry)
+    return plan
+
+
+def expectation_predicates_from_plan(
+    plan: Iterable[Mapping[str, Any]]
+) -> Dict[str, str]:
+    """Return ``expectation -> predicate`` from a plan when available."""
+
+    mapping: Dict[str, str] = {}
+    for item in plan:
+        key = item.get("key")
+        predicate = item.get("predicate")
+        if isinstance(key, str) and isinstance(predicate, str):
+            mapping[key] = predicate
+    return mapping
+
+
+__all__ = [
+    "expectation_plan",
+    "expectation_predicates_from_plan",
+    "sql_predicate",
+]

--- a/src/dc43/services/data_quality/client/interface.py
+++ b/src/dc43/services/data_quality/client/interface.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Mapping, Protocol, Sequence
 
 from open_data_contract_standard.model import OpenDataContractStandard  # type: ignore
 
@@ -19,6 +19,11 @@ class DataQualityServiceClient(Protocol):
         payload: ObservationPayload,
     ) -> ValidationResult:
         """Return the validation outcome for the provided observations."""
+
+    def describe_expectations(
+        self, *, contract: OpenDataContractStandard
+    ) -> Sequence[Mapping[str, object]]:
+        """Return serialisable descriptors for contract expectations."""
 
 
 __all__ = ["DataQualityServiceClient"]

--- a/src/dc43/services/data_quality/client/local.py
+++ b/src/dc43/services/data_quality/client/local.py
@@ -24,5 +24,11 @@ class LocalDataQualityServiceClient(DataQualityServiceClient):
     ) -> ValidationResult:
         return self._backend.evaluate(contract=contract, payload=payload)
 
+    def describe_expectations(
+        self, *, contract: OpenDataContractStandard
+    ) -> list[dict[str, object]]:
+        descriptors = self._backend.describe_expectations(contract=contract)
+        return list(descriptors)
+
 
 __all__ = ["LocalDataQualityServiceClient"]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -58,8 +58,13 @@ def test_validate_ok(spark):
         (2, 102, datetime(2024, 1, 2, 10, 0, 0), 20.5, "USD"),
     ]
     df = spark.createDataFrame(data, ["order_id", "customer_id", "order_ts", "amount", "currency"])
-    schema, metrics = collect_observations(df, contract)
     client = LocalDataQualityServiceClient()
+    expectations = client.describe_expectations(contract=contract)
+    schema, metrics = collect_observations(
+        df,
+        contract,
+        expectations=expectations,
+    )
     res = client.evaluate(
         contract=contract,
         payload=ObservationPayload(metrics=metrics, schema=schema),
@@ -77,8 +82,13 @@ def test_validate_type_mismatch(spark):
         (1, 101, datetime(2024, 1, 1, 10, 0, 0), "not-a-double", "EUR"),
     ]
     df = spark.createDataFrame(data, ["order_id", "customer_id", "order_ts", "amount", "currency"])
-    schema, metrics = collect_observations(df, contract)
     client = LocalDataQualityServiceClient()
+    expectations = client.describe_expectations(contract=contract)
+    schema, metrics = collect_observations(
+        df,
+        contract,
+        expectations=expectations,
+    )
     res = client.evaluate(
         contract=contract,
         payload=ObservationPayload(metrics=metrics, schema=schema),
@@ -104,8 +114,13 @@ def test_validate_required_nulls(spark):
         ]
     )
     df = spark.createDataFrame(data, schema=schema)
-    schema_obs, metrics = collect_observations(df, contract)
     client = LocalDataQualityServiceClient()
+    expectations = client.describe_expectations(contract=contract)
+    schema_obs, metrics = collect_observations(
+        df,
+        contract,
+        expectations=expectations,
+    )
     res = client.evaluate(
         contract=contract,
         payload=ObservationPayload(metrics=metrics, schema=schema_obs),


### PR DESCRIPTION
## Summary
- expose a describe_expectations API on the data-quality service so backends can hand pipelines serialisable expectation plans
- update the Spark integration to request those plans when computing metrics, revalidating writes, and forwarding observations to governance
- refresh demo helpers and documentation to reference service-supplied predicates instead of deriving them locally

## Testing
- pytest -q *(fails: pyspark required for dc43 tests)*

------
https://chatgpt.com/codex/tasks/task_b_68d98adf8d54832eb768d380307a6d98