### PR TITLE
feat: add multi-package release helper

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,46 +3,112 @@ name: release
 on:
   push:
     tags:
-      - 'v*'
+      - "dc43-v*"
+      - "dc43-service-clients-v*"
+      - "dc43-service-backends-v*"
+      - "dc43-integrations-v*"
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      package: ${{ steps.meta.outputs.package }}
+      package_dir: ${{ steps.meta.outputs.package_dir }}
+      dist_path: ${{ steps.meta.outputs.dist_path }}
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0   # fetch full history
+          fetch-depth: 0
           tags: true
+
+      - name: Derive package metadata
+        id: meta
+        run: |
+          ref="${GITHUB_REF_NAME}"
+          case "$ref" in
+            dc43-v*)
+              package="dc43"
+              package_dir="."
+              ;;
+            dc43-service-clients-v*)
+              package="dc43-service-clients"
+              package_dir="packages/dc43-service-clients"
+              ;;
+            dc43-service-backends-v*)
+              package="dc43-service-backends"
+              package_dir="packages/dc43-service-backends"
+              ;;
+            dc43-integrations-v*)
+              package="dc43-integrations"
+              package_dir="packages/dc43-integrations"
+              ;;
+            *)
+              echo "Unknown tag prefix: $ref" >&2
+              exit 1
+              ;;
+          esac
+
+          if [ "$package_dir" = "." ]; then
+            dist_path="dist"
+            pyproject="pyproject.toml"
+          else
+            dist_path="$package_dir/dist"
+            pyproject="$package_dir/pyproject.toml"
+          fi
+
+          {
+            echo "package=$package"
+            echo "package_dir=$package_dir"
+            echo "dist_path=$dist_path"
+            echo "pyproject=$pyproject"
+          } >> "$GITHUB_OUTPUT"
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e '.[test]' build
+
       - name: Run tests
         run: pytest
+
       - name: Check version matches tag
+        env:
+          PYPROJECT_PATH: ${{ steps.meta.outputs.pyproject }}
         run: |
           python - <<'PY'
-          import tomllib, os, sys
-          with open('pyproject.toml','rb') as f:
-              version = tomllib.load(f)['project']['version']
-          tag = os.environ['GITHUB_REF'].split('/')[-1]
-          if f"v{version}" != tag:
+          import os
+          import sys
+          import tomllib
+
+          pyproject_path = os.environ["PYPROJECT_PATH"]
+          with open(pyproject_path, 'rb') as f:
+              version = tomllib.load(f)["project"]["version"]
+
+          tag = os.environ["GITHUB_REF_NAME"]
+          expected_tag = f"dc43-v{version}" if pyproject_path == "pyproject.toml" else f"{os.path.basename(os.path.dirname(pyproject_path))}-v{version}"
+
+          if tag != expected_tag:
               print(f"Tag {tag} does not match version {version}")
               sys.exit(1)
           PY
+
       - name: Build package
+        working-directory: ${{ steps.meta.outputs.package_dir }}
         run: python -m build
+
       - uses: actions/upload-artifact@v4
         with:
           name: dist
-          path: dist
+          path: ${{ steps.meta.outputs.dist_path }}
 
   publish:
     needs: build
@@ -59,6 +125,7 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_TOKEN }}
+          packages-dir: dist
       - uses: softprops/action-gh-release@v1
         with:
           files: dist/*

--- a/docs/release-versioning.md
+++ b/docs/release-versioning.md
@@ -1,0 +1,120 @@
+# Release and Versioning Guide
+
+This repository ships four Python distributions:
+
+- `dc43-service-clients`
+- `dc43-service-backends`
+- `dc43-integrations`
+- `dc43` (meta package aggregating the other three)
+
+Each package keeps its own version in its `pyproject.toml`. Use the following workflow to manage
+releases without forcing synchronized bumps across the whole stack.
+
+## Tagging strategy
+
+1. **Use annotated tags per package.** Prefix tags with the distribution name to avoid collisions
+   and to keep the Git history navigable, e.g. `dc43-service-clients-v0.8.0`.
+2. **Tag after merging the release commit.** Update the package version (and changelog if
+   applicable), merge to `main`, then tag that merge commit with the appropriate package-prefixed
+   tag. This keeps `main` as the canonical source of released artifacts while still letting you
+   rewind to any package version with `git checkout dc43-service-clients-v0.8.0`.
+3. **Keep the meta package independent.** Only create a `dc43-vX.Y.Z` tag when the aggregate
+   package actually changes (e.g. dependency pin updates or CLI tweaks). The three component
+   packages can evolve on their own cadence.
+
+This mirrors mono-repo projects such as Kubernetes and the AWS SDKs where a single repository hosts
+many release trains.
+
+## GitHub Actions automation
+
+The [`release.yml`](../.github/workflows/release.yml) workflow already watches for each package's
+prefix:
+
+```yaml
+on:
+  push:
+    tags:
+      - "dc43-v*"
+      - "dc43-service-clients-v*"
+      - "dc43-service-backends-v*"
+      - "dc43-integrations-v*"
+```
+
+When a tag fires the workflow, the first step resolves which package directory owns the tag and
+produces helper outputs (`package_dir`, `pyproject`, `dist_path`). The subsequent steps then:
+
+1. Install the repo's test dependencies and run the full test suite.
+2. Validate that the pushed tag matches the package version declared in the resolved `pyproject.toml`.
+3. Change into that package directory and run `python -m build`, producing `dist/` artifacts only for
+   the tagged distribution.
+4. Publish those artifacts to PyPI and attach them to the GitHub Release.
+
+Because the build and publish stages point at the derived `dist_path`, the workflow only pushes the
+package that owns the tag. You do **not** need to retag the other distributions—just bump the version
+for the package you changed, push a matching tag, and the automation handles the rest. If you push
+multiple package-prefixed tags in the same `git push` command, GitHub Actions starts an independent
+workflow run for each tag so you can release several packages from a single commit.
+
+### Multi-package release CLI
+
+To make tagging easier—especially when several packages need a release—you can use the helper
+script at [`scripts/release.py`](../scripts/release.py). The CLI inspects the repository to work out
+which packages changed since their most recent release tag, verifies that the version in each
+`pyproject.toml` is new, checks whether the version is already on PyPI, and then (optionally)
+creates and pushes the corresponding tags.
+
+Common workflows:
+
+- **Dry run:** list all packages, highlighting those that have changed and the tag that would be
+  created.
+
+  ```bash
+  python scripts/release.py
+  ```
+
+- **Release everything that changed:** create annotated tags for all packages that need a release
+  and push them to `origin` to trigger GitHub Actions.
+
+  ```bash
+  python scripts/release.py --apply --push
+  ```
+
+- **Release a subset:** specify the packages explicitly. You can also target a specific commit if
+  you need to cut a release from an older point in history (the script still validates that the
+  versions are new compared with PyPI).
+
+  ```bash
+  python scripts/release.py --packages dc43-service-clients dc43-integrations --commit <sha> --apply
+  ```
+
+The script prints the plan before taking any action and aborts if the working tree is dirty or if a
+tag/version already exists on PyPI. This ensures that every tagged commit has the full set of
+expected releases.
+
+## Release checklist
+
+For a package bump (example: `dc43-service-backends`):
+
+1. Update the version in `packages/dc43-service-backends/pyproject.toml`.
+2. Update changelog notes (either a shared CHANGELOG or one per package).
+3. Commit the changes with a message such as `chore(backends): release 0.9.0`.
+4. Merge to `main` via PR.
+5. Tag the merge commit: `git tag -a dc43-service-backends-v0.9.0 && git push origin dc43-service-backends-v0.9.0`.
+6. Let GitHub Actions publish the new wheel/sdist to PyPI.
+
+Only repeat the steps for other packages when they change. The meta package can be bumped less
+frequently, e.g. when you need a curated bundle of the latest component versions.
+
+## Handling concurrent work
+
+When two packages evolve simultaneously:
+
+- Cut separate release commits so that the version bumps stay isolated.
+- Merge them in any order; each tag points to the same `main` history but a different release
+  commit.
+- If you need to patch an older release, branch from the corresponding tag (`git checkout -b
+  backport/dc43-service-clients-0.7.x dc43-service-clients-v0.7.3`) and cherry-pick fixes.
+
+Avoid git submodules—they complicate dependency management and require independent repos for each
+package. Keeping everything in this mono-repo plus prefixed tags and conditional workflows gives you
+per-package releases without sacrificing shared development.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Release helper CLI for dc43 packages.
+
+This script automates tagging and pushing releases for one or more packages. It
+figures out which packages changed since their last release, validates that the
+version in each `pyproject.toml` is new, verifies that the version is not
+already published on PyPI, and optionally creates and pushes annotated tags.
+
+Usage examples:
+
+* Preview which packages changed and would be released:
+
+    python scripts/release.py
+
+* Release the packages that changed, creating and pushing tags off the current
+  HEAD commit:
+
+    python scripts/release.py --apply --push
+
+* Release a specific subset of packages from a particular commit:
+
+    python scripts/release.py --packages dc43-service-clients dc43-integrations \
+        --commit 0123abcd --apply
+
+By default the script only prints the plan (dry run). Use ``--apply`` to create
+local tags and ``--push`` to push them to ``origin``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+try:  # Python >=3.11
+    import tomllib  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback for older runtimes
+    import tomli as tomllib  # type: ignore
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGES = {
+    "dc43": {
+        "paths": [ROOT / "src" / "dc43", ROOT / "pyproject.toml"],
+        "pyproject": ROOT / "pyproject.toml",
+        "pypi": "dc43",
+        "tag_prefix": "dc43",
+    },
+    "dc43-service-clients": {
+        "paths": [ROOT / "packages" / "dc43-service-clients"],
+        "pyproject": ROOT / "packages" / "dc43-service-clients" / "pyproject.toml",
+        "pypi": "dc43-service-clients",
+        "tag_prefix": "dc43-service-clients",
+    },
+    "dc43-service-backends": {
+        "paths": [ROOT / "packages" / "dc43-service-backends"],
+        "pyproject": ROOT / "packages" / "dc43-service-backends" / "pyproject.toml",
+        "pypi": "dc43-service-backends",
+        "tag_prefix": "dc43-service-backends",
+    },
+    "dc43-integrations": {
+        "paths": [ROOT / "packages" / "dc43-integrations"],
+        "pyproject": ROOT / "packages" / "dc43-integrations" / "pyproject.toml",
+        "pypi": "dc43-integrations",
+        "tag_prefix": "dc43-integrations",
+    },
+}
+
+
+@dataclass
+class ReleasePlan:
+    package: str
+    version: str
+    tag: str
+    commit: str
+    changed_files: List[str] = field(default_factory=list)
+    last_tag: Optional[str] = None
+    pypi_exists: Optional[bool] = None
+    will_tag: bool = False
+    warnings: List[str] = field(default_factory=list)
+
+    @property
+    def needs_release(self) -> bool:
+        if self.pypi_exists:
+            return False
+        if self.last_tag is None:
+            return True
+        if not self.changed_files:
+            return False
+        return True
+
+
+class ReleaseError(RuntimeError):
+    """Fatal error when preparing a release."""
+
+
+def run_git(*args: str, check: bool = True) -> str:
+    result = subprocess.run(["git", *args], cwd=ROOT, check=check, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def ensure_clean_worktree() -> None:
+    status = run_git("status", "--porcelain")
+    if status:
+        raise ReleaseError("Your working tree has uncommitted changes. Commit or stash them before releasing.")
+
+
+def package_version(package: str) -> str:
+    pyproject = PACKAGES[package]["pyproject"]
+    try:
+        data = tomllib.loads(pyproject.read_text())
+    except FileNotFoundError as exc:  # pragma: no cover - guard for misconfiguration
+        raise ReleaseError(f"Missing pyproject for {package}: {pyproject}") from exc
+    try:
+        return data["project"]["version"]
+    except KeyError as exc:  # pragma: no cover
+        raise ReleaseError(f"project.version missing in {pyproject}") from exc
+
+
+def planned_tag(package: str, version: str) -> str:
+    prefix = PACKAGES[package]["tag_prefix"]
+    return f"{prefix}-v{version}"
+
+
+def latest_tag(package: str) -> Optional[str]:
+    prefix = PACKAGES[package]["tag_prefix"]
+    pattern = f"{prefix}-v*"
+    output = run_git("tag", "--list", pattern, "--sort=-creatordate")
+    tags = [line.strip() for line in output.splitlines() if line.strip()]
+    return tags[0] if tags else None
+
+
+def changed_since(package: str, ref: Optional[str], commit: str) -> List[str]:
+    rel_paths = [path.relative_to(ROOT) for path in PACKAGES[package]["paths"]]
+    if not rel_paths:
+        return []
+    if ref is None:
+        output = run_git("ls-tree", "--name-only", "-r", commit, *map(str, rel_paths))
+    else:
+        output = run_git("diff", "--name-only", f"{ref}..{commit}", *map(str, rel_paths))
+    entries = {line.strip() for line in output.splitlines() if line.strip()}
+    return sorted(entries)
+
+
+def version_on_pypi(distribution: str, version: str) -> Optional[bool]:
+    url = f"https://pypi.org/pypi/{distribution}/json"
+    try:
+        with urllib.request.urlopen(url) as response:  # nosec B310 - read-only GET
+            payload = json.loads(response.read().decode())
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return False
+        raise ReleaseError(f"Failed to query PyPI for {distribution}: {exc}") from exc
+    releases = payload.get("releases", {})
+    return version in releases and bool(releases[version])
+
+
+def build_plan(packages: Iterable[str], commit: str, skip_pypi: bool) -> List[ReleasePlan]:
+    plans: List[ReleasePlan] = []
+    for package in packages:
+        version = package_version(package)
+        tag = planned_tag(package, version)
+        last = latest_tag(package)
+        changed = changed_since(package, last, commit)
+        plan = ReleasePlan(
+            package=package,
+            version=version,
+            tag=tag,
+            commit=commit,
+            changed_files=changed,
+            last_tag=last,
+        )
+        try:
+            existing = run_git("rev-parse", tag)
+        except subprocess.CalledProcessError:
+            existing = ""
+        if existing:
+            plan.warnings.append(f"Tag {tag} already exists (commit {existing}). Bump the version before releasing.")
+        if not skip_pypi:
+            try:
+                exists = version_on_pypi(PACKAGES[package]["pypi"], version)
+            except ReleaseError as exc:
+                plan.warnings.append(str(exc))
+                exists = None
+            plan.pypi_exists = exists
+            if exists:
+                plan.warnings.append(f"Version {version} is already published on PyPI. Bump the version before releasing.")
+        plans.append(plan)
+    return plans
+
+
+def apply_plan(plans: Iterable[ReleasePlan], push: bool) -> None:
+    for plan in plans:
+        if plan.warnings:
+            raise ReleaseError(
+                f"Cannot tag {plan.package}:\n" + "\n".join(f"  - {message}" for message in plan.warnings)
+            )
+        if not plan.needs_release:
+            continue
+        message = f"Release {plan.package} {plan.version}"
+        subprocess.run(
+            ["git", "tag", "-a", plan.tag, plan.commit, "-m", message],
+            cwd=ROOT,
+            check=True,
+        )
+        plan.will_tag = True
+        if push:
+            subprocess.run(["git", "push", "origin", plan.tag], cwd=ROOT, check=True)
+
+
+def format_plan(plan: ReleasePlan) -> str:
+    lines = [f"Package: {plan.package}"]
+    lines.append(f"  version: {plan.version}")
+    lines.append(f"  tag: {plan.tag}")
+    lines.append(f"  commit: {plan.commit}")
+    if plan.last_tag:
+        lines.append(f"  last tag: {plan.last_tag}")
+    if plan.pypi_exists is True:
+        lines.append("  PyPI: already published")
+    elif plan.pypi_exists is False:
+        lines.append("  PyPI: available")
+    elif plan.pypi_exists is None:
+        lines.append("  PyPI: unknown (skipped)")
+    if plan.changed_files:
+        lines.append("  changed files:")
+        lines.extend(f"    - {path}" for path in plan.changed_files)
+    else:
+        lines.append("  changed files: none detected")
+    if plan.warnings:
+        lines.append("  warnings:")
+        lines.extend(f"    - {message}" for message in plan.warnings)
+    lines.append(f"  needs release: {'yes' if plan.needs_release else 'no'}")
+    if plan.will_tag:
+        lines.append("  status: tagged")
+    return "\n".join(lines)
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--packages",
+        nargs="+",
+        choices=sorted(PACKAGES.keys()),
+        help="Specific packages to evaluate. Defaults to all packages.",
+    )
+    parser.add_argument(
+        "--commit",
+        default="HEAD",
+        help="Commit to tag. Defaults to HEAD.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Create the annotated tags for packages that need a release.",
+    )
+    parser.add_argument(
+        "--push",
+        action="store_true",
+        help="Push newly created tags to origin (implies --apply).",
+    )
+    parser.add_argument(
+        "--skip-pypi",
+        action="store_true",
+        help="Skip PyPI version checks (useful when offline).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    packages = args.packages or sorted(PACKAGES.keys())
+    if args.push:
+        args.apply = True
+    if args.apply:
+        ensure_clean_worktree()
+    plans = build_plan(packages, args.commit, skip_pypi=args.skip_pypi)
+    for plan in plans:
+        print(format_plan(plan))
+        print()
+    actionable = [plan for plan in plans if plan.needs_release]
+    if not actionable:
+        print("No packages require a release.")
+    else:
+        print("Packages requiring release:")
+        for plan in actionable:
+            print(f"  - {plan.package} ({plan.tag})")
+    if args.apply:
+        try:
+            apply_plan(actionable, push=args.push)
+        except ReleaseError as exc:
+            print(f"\nERROR: {exc}", file=sys.stderr)
+            return 1
+        except subprocess.CalledProcessError as exc:
+            print(f"\nERROR: {exc}", file=sys.stderr)
+            return exc.returncode
+        print("\nTagging complete.")
+        if args.push:
+            print("Tags pushed to origin.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a scripts/release.py helper that inspects package changes, checks PyPI, and tags multiple releases in one run
- document how to push multiple prefixed tags at once and how to use the new CLI to automate multi-package releases

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68da0bdfae68832e859483e1f5b5b356