### PR TITLE
Streamline package releases and targeted tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,13 +72,60 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Install dependencies
+      - name: Prepare build tooling
         run: |
           python -m pip install --upgrade pip
-          pip install -e '.[test]' build
+          pip install packaging build
+
+      - name: Wait for internal dependencies
+        run: |
+          python scripts/wait_for_internal_deps.py \
+            --pyproject "${{ steps.meta.outputs.pyproject }}" \
+            --package "${{ steps.meta.outputs.package }}"
+
+      - name: Install package under test
+        run: |
+          case "${{ steps.meta.outputs.package }}" in
+            dc43)
+              pip install -e '.[test]'
+              ;;
+            dc43-service-clients)
+              pip install -e packages/dc43-service-clients
+              ;;
+            dc43-service-backends)
+              pip install -e packages/dc43-service-clients
+              pip install -e packages/dc43-service-backends
+              ;;
+            dc43-integrations)
+              pip install -e packages/dc43-service-clients
+              pip install -e packages/dc43-integrations
+              ;;
+            *)
+              echo "Unknown package: ${{ steps.meta.outputs.package }}" >&2
+              exit 1
+              ;;
+          esac
 
       - name: Run tests
-        run: pytest
+        run: |
+          case "${{ steps.meta.outputs.package }}" in
+            dc43)
+              pytest
+              ;;
+            dc43-service-clients)
+              pytest packages/dc43-service-clients/tests
+              ;;
+            dc43-service-backends)
+              pytest packages/dc43-service-backends/tests
+              ;;
+            dc43-integrations)
+              pytest packages/dc43-integrations/tests
+              ;;
+            *)
+              echo "Unknown package: ${{ steps.meta.outputs.package }}" >&2
+              exit 1
+              ;;
+          esac
 
       - name: Check version matches tag
         env:

--- a/packages/dc43-integrations/src/dc43_integrations/__init__.py
+++ b/packages/dc43-integrations/src/dc43_integrations/__init__.py
@@ -1,5 +1,20 @@
 """Runtime integrations for execution engines and external systems."""
 
-from . import spark
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
 
 __all__ = ["spark"]
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        module = import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/packages/dc43-integrations/tests/test_violation_strategy.py
+++ b/packages/dc43-integrations/tests/test_violation_strategy.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, Mapping, Optional
+
+from dc43_service_clients.data_quality import ValidationResult
+from dc43_integrations.spark.violation_strategy import (
+    NoOpWriteViolationStrategy,
+    SplitWriteViolationStrategy,
+    WriteStrategyContext,
+)
+
+
+@dataclass
+class FakeRow:
+    valid: bool
+
+
+class FakeDataFrame:
+    def __init__(self, rows: Iterable[FakeRow]):
+        self._rows = list(rows)
+
+    def filter(self, predicate: str) -> "FakeDataFrame":
+        predicate = predicate.strip()
+        if predicate.startswith("NOT"):
+            return FakeDataFrame(row for row in self._rows if not row.valid)
+        return FakeDataFrame(row for row in self._rows if row.valid)
+
+    def limit(self, count: int) -> "FakeDataFrame":
+        return FakeDataFrame(self._rows[:count])
+
+    def count(self) -> int:
+        return len(self._rows)
+
+
+class FakeValidation(ValidationResult):
+    def __init__(
+        self,
+        warnings: Optional[list[str]] = None,
+        metrics: Optional[dict[str, int]] = None,
+    ) -> None:
+        super().__init__(
+            ok=False,
+            warnings=warnings or ["violation"],
+            metrics=metrics or {"violations.total": 1},
+            status="warn",
+        )
+
+
+def make_context(
+    *,
+    rows: Iterable[FakeRow],
+    revalidate: Optional[Callable[[FakeDataFrame], ValidationResult]] = None,
+    expectation_predicates: Optional[Mapping[str, str]] = None,
+) -> WriteStrategyContext:
+    df = FakeDataFrame(rows)
+    aligned = FakeDataFrame(rows)
+    validation = FakeValidation()
+    predicates = {"valid": "valid"} if expectation_predicates is None else expectation_predicates
+
+    return WriteStrategyContext(
+        df=df,
+        aligned_df=aligned,
+        contract=None,
+        path="/tmp/dataset",
+        table="analytics.orders",
+        format="delta",
+        options={"mergeSchema": "true"},
+        mode="append",
+        validation=validation,
+        dataset_id="orders",
+        dataset_version="v1",
+        revalidate=revalidate or (lambda _: validation),
+        expectation_predicates=predicates,
+        pipeline_context=None,
+    )
+
+
+def test_noop_strategy_returns_base_request():
+    context = make_context(rows=[FakeRow(valid=True)])
+    plan = NoOpWriteViolationStrategy().plan(context)
+
+    assert plan.primary is not None
+    assert plan.primary.df is context.aligned_df
+    assert plan.additional == ()
+
+
+def test_split_strategy_creates_reject_request_when_invalid_rows_present():
+    context = make_context(rows=[FakeRow(True), FakeRow(False)])
+    strategy = SplitWriteViolationStrategy(write_primary_on_violation=False)
+    plan = strategy.plan(context)
+
+    assert plan.primary is None
+    assert plan.additional
+    reject = {req.dataset_id for req in plan.additional}
+    assert "orders::reject" in reject
+
+
+def test_split_strategy_returns_base_request_when_no_predicates():
+    context = make_context(rows=[FakeRow(False)], expectation_predicates={})
+    plan = SplitWriteViolationStrategy().plan(context)
+
+    assert plan.primary is not None
+    assert not plan.additional

--- a/packages/dc43-service-backends/src/dc43_service_backends/__init__.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/__init__.py
@@ -1,5 +1,20 @@
 """Service backend implementations for dc43."""
 
-from . import contracts, data_quality, governance
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
 
 __all__ = ["contracts", "data_quality", "governance"]
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        module = import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/packages/dc43-service-backends/tests/test_local_contract_backend.py
+++ b/packages/dc43-service-backends/tests/test_local_contract_backend.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+from dc43_service_backends.contracts.backend.local import LocalContractServiceBackend
+from dc43_service_backends.contracts.backend.stores.interface import ContractStore
+
+
+@dataclass
+class _StoredContract:
+    contract_id: str
+    version: str
+
+
+class InMemoryStore(ContractStore):
+    def __init__(self) -> None:
+        self._data: Dict[tuple[str, str], _StoredContract] = {}
+
+    def put(self, contract: _StoredContract) -> None:  # type: ignore[override]
+        self._data[(contract.contract_id, contract.version)] = contract
+
+    def get(self, contract_id: str, version: str) -> _StoredContract:  # type: ignore[override]
+        return self._data[(contract_id, version)]
+
+    def list_contracts(self) -> List[str]:  # type: ignore[override]
+        return sorted({contract_id for contract_id, _ in self._data})
+
+    def list_versions(self, contract_id: str) -> List[str]:  # type: ignore[override]
+        return sorted(version for (cid, version) in self._data if cid == contract_id)
+
+
+def make_contract(contract_id: str, version: str) -> _StoredContract:
+    return _StoredContract(contract_id=contract_id, version=version)
+
+
+def test_local_backend_delegates_to_store():
+    store = InMemoryStore()
+    backend = LocalContractServiceBackend(store)
+    contract = make_contract("orders", "1.0.0")
+    store.put(contract)
+
+    assert backend.get("orders", "1.0.0") == contract
+    assert backend.list_versions("orders") == ["1.0.0"]
+    assert backend.latest("orders") == contract
+
+
+def test_link_dataset_contract_keeps_contract_available():
+    store = InMemoryStore()
+    backend = LocalContractServiceBackend(store)
+    store.put(make_contract("orders", "1.0.0"))
+
+    backend.link_dataset_contract(
+        dataset_id="table.orders",
+        dataset_version="current",
+        contract_id="orders",
+        contract_version="1.0.0",
+    )
+
+    assert backend.get("orders", "1.0.0").contract_id == "orders"
+    assert backend.get_linked_contract_version(dataset_id="table.orders") is None

--- a/packages/dc43-service-clients/setup.cfg
+++ b/packages/dc43-service-clients/setup.cfg
@@ -1,0 +1,2 @@
+[egg_info]
+egg_base = src

--- a/packages/dc43-service-clients/src/dc43_service_clients/__init__.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/__init__.py
@@ -1,5 +1,20 @@
 """Client-facing service APIs and shared models for dc43."""
 
-from . import contracts, data_quality, governance
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
 
 __all__ = ["contracts", "data_quality", "governance"]
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        module = import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/packages/dc43-service-clients/tests/test_validation_models.py
+++ b/packages/dc43-service-clients/tests/test_validation_models.py
@@ -1,0 +1,37 @@
+from dc43_service_clients.data_quality import ObservationPayload, ValidationResult, coerce_details
+
+
+def test_validation_result_flags_errors_and_status():
+    result = ValidationResult(
+        ok=True,
+        errors=["missing contract"],
+        metrics={"rows": 10},
+        status="block",
+        reason="validation failed",
+    )
+
+    assert not result.ok
+    assert result.status == "block"
+    assert result.reason == "validation failed"
+    assert result.details["errors"] == ["missing contract"]
+
+
+def test_merge_details_preserves_existing_information():
+    result = ValidationResult(ok=True, warnings=["initial"], metrics={"rows": 5})
+    result.merge_details({"extra": True})
+
+    assert result.details["extra"] is True
+    assert result.details["metrics"] == {"rows": 5}
+
+
+def test_coerce_details_handles_iterables():
+    details = coerce_details([("reason", "ok"), ("status", "warn")])
+
+    assert details == {"reason": "ok", "status": "warn"}
+
+
+def test_observation_payload_defaults():
+    payload = ObservationPayload(metrics={"rows": 1})
+
+    assert payload.schema is None
+    assert payload.reused is False

--- a/scripts/_packages.py
+++ b/scripts/_packages.py
@@ -1,0 +1,47 @@
+"""Shared package metadata for release tooling and workflows."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+PACKAGES = {
+    "dc43": {
+        "paths": [ROOT / "src" / "dc43", ROOT / "pyproject.toml"],
+        "pyproject": ROOT / "pyproject.toml",
+        "pypi": "dc43",
+        "tag_prefix": "dc43",
+        "package_dir": ".",
+    },
+    "dc43-service-clients": {
+        "paths": [ROOT / "packages" / "dc43-service-clients"],
+        "pyproject": ROOT / "packages" / "dc43-service-clients" / "pyproject.toml",
+        "pypi": "dc43-service-clients",
+        "tag_prefix": "dc43-service-clients",
+        "package_dir": "packages/dc43-service-clients",
+    },
+    "dc43-service-backends": {
+        "paths": [ROOT / "packages" / "dc43-service-backends"],
+        "pyproject": ROOT / "packages" / "dc43-service-backends" / "pyproject.toml",
+        "pypi": "dc43-service-backends",
+        "tag_prefix": "dc43-service-backends",
+        "package_dir": "packages/dc43-service-backends",
+    },
+    "dc43-integrations": {
+        "paths": [ROOT / "packages" / "dc43-integrations"],
+        "pyproject": ROOT / "packages" / "dc43-integrations" / "pyproject.toml",
+        "pypi": "dc43-integrations",
+        "tag_prefix": "dc43-integrations",
+        "package_dir": "packages/dc43-integrations",
+    },
+}
+
+DEFAULT_RELEASE_ORDER = [
+    "dc43-service-clients",
+    "dc43-service-backends",
+    "dc43-integrations",
+    "dc43",
+]
+
+INTERNAL_PACKAGE_NAMES = set(PACKAGES)

--- a/scripts/wait_for_internal_deps.py
+++ b/scripts/wait_for_internal_deps.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Poll PyPI until internal package dependencies are available."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Iterable
+
+try:
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover - Python <3.11 fallback
+    import tomli as tomllib  # type: ignore
+
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version, InvalidVersion
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from _packages import INTERNAL_PACKAGE_NAMES
+
+DEFAULT_TIMEOUT = 600
+DEFAULT_INTERVAL = 10
+
+
+def _load_dependencies(pyproject: Path) -> Iterable[str]:
+    data = tomllib.loads(pyproject.read_text())
+    return data.get("project", {}).get("dependencies", [])
+
+
+def _internal_requirements(pyproject: Path, current: str) -> list[Requirement]:
+    requirements: list[Requirement] = []
+    for spec in _load_dependencies(pyproject):
+        req = Requirement(spec)
+        if req.name in INTERNAL_PACKAGE_NAMES and req.name != current:
+            requirements.append(req)
+    return requirements
+
+
+def _fetch_versions(distribution: str) -> list[Version]:
+    url = f"https://pypi.org/pypi/{distribution}/json"
+    try:
+        with urllib.request.urlopen(url) as response:  # nosec B310
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return []
+        raise
+    releases = payload.get("releases", {})
+    versions: list[Version] = []
+    for version, files in releases.items():
+        if not files:
+            continue
+        try:
+            versions.append(Version(version))
+        except InvalidVersion:
+            continue
+    return versions
+
+
+def _specifier_satisfied(specifier: SpecifierSet, versions: Iterable[Version]) -> bool:
+    if not specifier:
+        return True if list(versions) else False
+    for version in versions:
+        if version in specifier:
+            return True
+    return False
+
+
+def wait_for_dependencies(pyproject: Path, package: str, timeout: int, interval: int) -> None:
+    requirements = _internal_requirements(pyproject, package)
+    if not requirements:
+        return
+
+    deadline = time.monotonic() + timeout
+    pending = {req.name: req for req in requirements}
+
+    while pending:
+        resolved = []
+        for name, requirement in pending.items():
+            versions = _fetch_versions(name)
+            if _specifier_satisfied(requirement.specifier, versions):
+                resolved.append(name)
+        for name in resolved:
+            pending.pop(name, None)
+        if not pending:
+            return
+        if time.monotonic() >= deadline:
+            missing = ", ".join(sorted(pending))
+            raise TimeoutError(f"Timed out waiting for dependencies: {missing}")
+        time.sleep(interval)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pyproject", type=Path, required=True, help="Path to the package pyproject")
+    parser.add_argument("--package", required=True, help="Package name being released")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT, help="Seconds to wait before failing")
+    parser.add_argument("--interval", type=int, default=DEFAULT_INTERVAL, help="Polling interval in seconds")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        wait_for_dependencies(args.pyproject, args.package, args.timeout, args.interval)
+    except TimeoutError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    except urllib.error.HTTPError as exc:
+        print(f"ERROR querying PyPI: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- share package metadata so the release helper operates in dependency order
- update the release workflow to wait for internal dependencies, install local packages, and run only the relevant test suites per package
- add lightweight tests for each package and make their top-level modules lazily import subpackages to avoid circular imports

## Testing
- pytest packages/dc43-service-clients/tests -q
- pytest packages/dc43-service-backends/tests -q
- pytest packages/dc43-integrations/tests -q

------
https://chatgpt.com/codex/tasks/task_b_68da52d5ffec832e874579cd43d09c5a