### PR TITLE
Add pytest extra to service clients package

### DIFF
--- a/packages/dc43-service-clients/pyproject.toml
+++ b/packages/dc43-service-clients/pyproject.toml
@@ -20,6 +20,11 @@ dependencies = [
   "open-data-contract-standard==3.0.2",
 ]
 
+[project.optional-dependencies]
+test = [
+  "pytest>=7.0",
+]
+
 [tool.setuptools]
 package-dir = {"" = "src"}
 


### PR DESCRIPTION
## Summary
- add a test optional dependency set for dc43-service-clients so pytest installs with the extra

## Testing
- pytest -q packages/dc43-service-clients/tests

------
https://chatgpt.com/codex/tasks/task_b_68da7fe73f7c832e959cf95bc68cce03