### PR TITLE
Fix root package metadata for PyPI distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,47 @@
 from pathlib import Path
+from typing import Dict
 
+import tomllib
 from setuptools import setup
 
-ROOT = Path(__file__).resolve().parent
 
-clients = ROOT / "packages" / "dc43-service-clients"
-backends = ROOT / "packages" / "dc43-service-backends"
-integrations = ROOT / "packages" / "dc43-integrations"
+def _load_version(package_name: str) -> str:
+    """Read the version of a local package from its ``pyproject.toml`` file."""
+
+    pyproject_path = (
+        Path(__file__).resolve().parent
+        / "packages"
+        / package_name
+        / "pyproject.toml"
+    )
+
+    with pyproject_path.open("rb") as file:
+        data = tomllib.load(file)
+
+    return data["project"]["version"]
+
+
+PACKAGE_VERSIONS: Dict[str, str] = {
+    name: _load_version(name)
+    for name in (
+        "dc43-service-clients",
+        "dc43-service-backends",
+        "dc43-integrations",
+    )
+}
 
 install_requires = [
-    f"dc43-service-clients @ {clients.as_uri()}",
-    f"dc43-service-backends @ {backends.as_uri()}",
-    f"dc43-integrations @ {integrations.as_uri()}",
+    f"dc43-service-clients=={PACKAGE_VERSIONS['dc43-service-clients']}",
+    f"dc43-service-backends=={PACKAGE_VERSIONS['dc43-service-backends']}",
+    f"dc43-integrations=={PACKAGE_VERSIONS['dc43-integrations']}",
     "packaging>=21.0",
     "open-data-contract-standard==3.0.2",
 ]
 
 extras_require = {
-    "spark": [f"dc43-integrations[spark] @ {integrations.as_uri()}"],
+    "spark": [
+        f"dc43-integrations[spark]=={PACKAGE_VERSIONS['dc43-integrations']}"
+    ],
     "test": [
         "pytest>=7.0",
         "pyspark>=3.4",
@@ -31,7 +55,7 @@ extras_require = {
         "uvicorn",
         "jinja2",
         "python-multipart",
-        f"dc43-integrations[spark] @ {integrations.as_uri()}",
+        f"dc43-integrations[spark]=={PACKAGE_VERSIONS['dc43-integrations']}",
     ],
 }
 


### PR DESCRIPTION
## Summary
- derive local package versions from their pyproject files when building the root package
- depend on the published versions of the dc43 sub-packages instead of local file URIs so the wheel can be uploaded to PyPI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68da95775fc4832e8fd326440cc420d2