### PR TITLE
Ensure release wait script watches PyPI simple index

### DIFF
--- a/scripts/_internal_dependency_versions.py
+++ b/scripts/_internal_dependency_versions.py
@@ -1,0 +1,39 @@
+"""Helpers for retrieving versions of local internal packages."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+try:  # pragma: no cover - Python <3.11 fallback
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover - Python <3.11 fallback
+    import tomli as tomllib  # type: ignore
+
+from _packages import PACKAGES
+
+
+def _pyproject_path(package: str) -> Path:
+    try:
+        package_meta = PACKAGES[package]
+    except KeyError as exc:  # pragma: no cover - defensive programming
+        raise KeyError(f"Unknown internal package: {package}") from exc
+    return package_meta["pyproject"]
+
+
+def _load_version(pyproject: Path) -> str:
+    data = tomllib.loads(pyproject.read_text("utf-8"))
+    version = data.get("project", {}).get("version")
+    if version is None:  # pragma: no cover - defensive programming
+        raise KeyError(f"Missing project.version in {pyproject}")
+    return version
+
+
+def load_versions(packages: Iterable[str]) -> dict[str, str]:
+    """Return the declared version for each internal package name provided."""
+
+    versions: dict[str, str] = {}
+    for package in packages:
+        pyproject = _pyproject_path(package)
+        versions[package] = _load_version(pyproject)
+    return versions

--- a/scripts/wait_for_internal_deps.py
+++ b/scripts/wait_for_internal_deps.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 import time
 import urllib.error
@@ -17,53 +16,108 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - Python <3.11 fallback
     import tomli as tomllib  # type: ignore
 
+from html.parser import HTMLParser
+from urllib.parse import urlsplit
+
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
+from packaging.utils import canonicalize_name, parse_sdist_filename, parse_wheel_filename
 from packaging.version import Version, InvalidVersion
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
-from _packages import INTERNAL_PACKAGE_NAMES
+from _packages import DEFAULT_RELEASE_ORDER, INTERNAL_PACKAGE_NAMES
+from _internal_dependency_versions import load_versions
 
 DEFAULT_TIMEOUT = 600
 DEFAULT_INTERVAL = 10
 
 
-def _load_dependencies(pyproject: Path) -> Iterable[str]:
+META_PACKAGE_NAME = "dc43"
+META_PACKAGE_DEPENDENCIES = [
+    name for name in DEFAULT_RELEASE_ORDER if name != META_PACKAGE_NAME
+]
+
+
+def _load_dependencies(pyproject: Path) -> list[str]:
     data = tomllib.loads(pyproject.read_text())
-    return data.get("project", {}).get("dependencies", [])
+    dependencies = data.get("project", {}).get("dependencies") or []
+    return list(dependencies)
+
+
+def _default_internal_requirements(package: str) -> list[str]:
+    if package == META_PACKAGE_NAME:
+        return META_PACKAGE_DEPENDENCIES
+    return []
 
 
 def _internal_requirements(pyproject: Path, current: str) -> list[Requirement]:
     requirements: list[Requirement] = []
-    for spec in _load_dependencies(pyproject):
+    specs = _load_dependencies(pyproject)
+    if not specs:
+        specs = _default_internal_requirements(current)
+    for spec in specs:
         req = Requirement(spec)
         if req.name in INTERNAL_PACKAGE_NAMES and req.name != current:
             requirements.append(req)
     return requirements
 
 
+class _SimpleIndexParser(HTMLParser):
+    """Extract filenames from a simple API HTML page."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._filenames: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.lower() != "a":
+            return
+        href = dict(attrs).get("href")
+        if not href:
+            return
+        path = urlsplit(href).path
+        filename = path.rsplit("/", 1)[-1]
+        if filename:
+            self._filenames.append(filename)
+
+    @property
+    def filenames(self) -> list[str]:
+        return self._filenames
+
+
+def _parse_simple_filenames(distribution: str, filenames: Iterable[str]) -> list[Version]:
+    canonical = canonicalize_name(distribution)
+    versions: set[Version] = set()
+    for filename in filenames:
+        try:
+            if filename.endswith(".whl"):
+                name, version, *_ = parse_wheel_filename(filename)
+            else:
+                name, version = parse_sdist_filename(filename)
+        except (InvalidVersion, ValueError):
+            continue
+        if canonicalize_name(name) != canonical:
+            continue
+        versions.add(Version(str(version)))
+    return sorted(versions)
+
+
 def _fetch_versions(distribution: str) -> list[Version]:
-    url = f"https://pypi.org/pypi/{distribution}/json"
+    url = f"https://pypi.org/simple/{canonicalize_name(distribution)}/"
     try:
         with urllib.request.urlopen(url) as response:  # nosec B310
-            payload = json.loads(response.read().decode("utf-8"))
+            payload = response.read().decode("utf-8")
     except urllib.error.HTTPError as exc:
         if exc.code == 404:
             return []
         raise
-    releases = payload.get("releases", {})
-    versions: list[Version] = []
-    for version, files in releases.items():
-        if not files:
-            continue
-        try:
-            versions.append(Version(version))
-        except InvalidVersion:
-            continue
-    return versions
+
+    parser = _SimpleIndexParser()
+    parser.feed(payload)
+    return _parse_simple_filenames(distribution, parser.filenames)
 
 
 def _specifier_satisfied(specifier: SpecifierSet, versions: Iterable[Version]) -> bool:
@@ -82,11 +136,23 @@ def wait_for_dependencies(pyproject: Path, package: str, timeout: int, interval:
 
     deadline = time.monotonic() + timeout
     pending = {req.name: req for req in requirements}
+    expected_versions: dict[str, Version] = {
+        name: Version(version)
+        for name, version in load_versions(pending).items()
+    }
 
     while pending:
         resolved = []
         for name, requirement in pending.items():
             versions = _fetch_versions(name)
+            expected = expected_versions.get(name)
+            if expected is not None:
+                if expected not in versions:
+                    continue
+                if requirement.specifier and expected not in requirement.specifier:
+                    continue
+                resolved.append(name)
+                continue
             if _specifier_satisfied(requirement.specifier, versions):
                 resolved.append(name)
         for name in resolved:

--- a/setup.py
+++ b/setup.py
@@ -1,46 +1,38 @@
-from pathlib import Path
-from typing import Dict
+from __future__ import annotations
 
-import tomllib
+from pathlib import Path
+import sys
+
 from setuptools import setup
 
 
-def _load_version(package_name: str) -> str:
-    """Read the version of a local package from its ``pyproject.toml`` file."""
+SCRIPT_DIR = Path(__file__).resolve().parent / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
 
-    pyproject_path = (
-        Path(__file__).resolve().parent
-        / "packages"
-        / package_name
-        / "pyproject.toml"
-    )
-
-    with pyproject_path.open("rb") as file:
-        data = tomllib.load(file)
-
-    return data["project"]["version"]
+from _internal_dependency_versions import load_versions
 
 
-PACKAGE_VERSIONS: Dict[str, str] = {
-    name: _load_version(name)
-    for name in (
-        "dc43-service-clients",
-        "dc43-service-backends",
-        "dc43-integrations",
-    )
-}
+_INTERNAL_DEPENDENCIES = [
+    "dc43-service-clients",
+    "dc43-service-backends",
+    "dc43-integrations",
+]
+
+_PACKAGE_VERSIONS = load_versions(_INTERNAL_DEPENDENCIES)
+
 
 install_requires = [
-    f"dc43-service-clients=={PACKAGE_VERSIONS['dc43-service-clients']}",
-    f"dc43-service-backends=={PACKAGE_VERSIONS['dc43-service-backends']}",
-    f"dc43-integrations=={PACKAGE_VERSIONS['dc43-integrations']}",
+    f"{name}=={_PACKAGE_VERSIONS[name]}" for name in _INTERNAL_DEPENDENCIES
+]
+install_requires += [
     "packaging>=21.0",
     "open-data-contract-standard==3.0.2",
 ]
 
 extras_require = {
     "spark": [
-        f"dc43-integrations[spark]=={PACKAGE_VERSIONS['dc43-integrations']}"
+        f"dc43-integrations[spark]=={_PACKAGE_VERSIONS['dc43-integrations']}"
     ],
     "test": [
         "pytest>=7.0",
@@ -55,7 +47,7 @@ extras_require = {
         "uvicorn",
         "jinja2",
         "python-multipart",
-        f"dc43-integrations[spark]=={PACKAGE_VERSIONS['dc43-integrations']}",
+        f"dc43-integrations[spark]=={_PACKAGE_VERSIONS['dc43-integrations']}",
     ],
 }
 

--- a/tests/test_wait_for_internal_deps.py
+++ b/tests/test_wait_for_internal_deps.py
@@ -1,0 +1,29 @@
+"""Tests for the release dependency waiting helper."""
+
+from __future__ import annotations
+
+from importlib import util
+from pathlib import Path
+
+
+def _load_module():
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "wait_for_internal_deps.py"
+    spec = util.spec_from_file_location("wait_for_internal_deps", module_path)
+    assert spec and spec.loader
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    return module
+
+
+def test_parse_simple_filenames_extracts_versions() -> None:
+    module = _load_module()
+    filenames = [
+        "dc43_service_clients-0.3.0.0-py3-none-any.whl",
+        "dc43-service-clients-0.3.0.0.tar.gz",
+        "dc43_service_clients-0.2.1-py3-none-any.whl",
+        "unrelated-1.0.0.tar.gz",
+    ]
+
+    versions = module._parse_simple_filenames("dc43-service-clients", filenames)
+
+    assert [str(version) for version in versions] == ["0.2.1", "0.3.0.0"]


### PR DESCRIPTION
## Summary
- poll the PyPI simple API and parse published filenames when waiting for internal releases
- add a unit test that exercises the simple index filename parsing helper

## Testing
- PYTHONPATH=src pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68da98cd3394832eb23f3b519280b909