### PR TITLE
Add editor actions to dataset and contract listings

### DIFF
--- a/src/dc43/demo_app/templates/base.html
+++ b/src/dc43/demo_app/templates/base.html
@@ -12,7 +12,8 @@
     <a class="navbar-brand" href="/">DC43 Demo</a>
     <div class="navbar-nav">
       <a class="nav-link" href="/contracts">Contracts</a>
-      <a class="nav-link" href="/datasets">Pipeline Runs</a>
+      <a class="nav-link" href="/datasets">Datasets</a>
+      <a class="nav-link" href="/pipeline-runs">Pipeline Runs</a>
     </div>
   </div>
 </nav>

--- a/src/dc43/demo_app/templates/contract_versions.html
+++ b/src/dc43/demo_app/templates/contract_versions.html
@@ -1,17 +1,51 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Contract {{ contract_id }}</h1>
-<table class="table table-striped">
-  <thead><tr><th>Version</th><th>Dataset Path</th><th>Actions</th></tr></thead>
+<table class="table table-striped align-middle">
+  <thead>
+    <tr>
+      <th scope="col">Version</th>
+      <th scope="col">Status</th>
+      <th scope="col">Server</th>
+      <th scope="col" class="text-end">Actions</th>
+    </tr>
+  </thead>
   <tbody>
   {% for c in contracts %}
-  <tr>
-    <td><a href="/contracts/{{ contract_id }}/{{ c.version }}">{{ c.version }}</a></td>
-    <td>{{ c.path or '' }}</td>
-    <td>
-      <a class="btn btn-sm btn-primary" href="/contracts/{{ contract_id }}/{{ c.version }}/edit">Edit</a>
-    </td>
-  </tr>
+    <tr>
+      <th scope="row">
+        <a href="/contracts/{{ contract_id }}/{{ c.version }}">{{ c.version }}</a>
+      </th>
+      <td>
+        <span class="badge {{ c.status_badge }}">{{ c.status_label }}</span>
+      </td>
+      <td>
+        {% if c.server %}
+          <div class="fw-semibold">{{ c.server.dataset_id or c.dataset_hint }}</div>
+          <div class="small text-muted">
+            {{ c.server.type or 'Unknown type' }}{% if c.server.format %} · {{ c.server.format | upper }}{% endif %}
+          </div>
+          {% if c.server.path %}
+            <div class="small text-muted">Path: {{ c.server.path }}</div>
+          {% endif %}
+          {% if c.server.path_pattern %}
+            <div class="small text-muted">Pattern: <code>{{ c.server.path_pattern }}</code></div>
+          {% endif %}
+        {% else %}
+          <span class="text-muted">No server info</span>
+        {% endif %}
+        {% if c.latest_run %}
+          <div class="small mt-2">
+            Latest run: <a href="/datasets/{{ c.latest_run.dataset_name }}/{{ c.latest_run.dataset_version }}">{{ c.latest_run.dataset_version }}</a>
+            ({{ c.latest_run.status }})
+          </div>
+        {% endif %}
+      </td>
+      <td class="text-end">
+        <a class="btn btn-sm btn-outline-primary" href="/contracts/{{ contract_id }}/{{ c.version }}">View</a>
+        <a class="btn btn-sm btn-primary ms-2" href="/contracts/{{ contract_id }}/{{ c.version }}/edit">Open editor</a>
+      </td>
+    </tr>
   {% endfor %}
   </tbody>
 </table>

--- a/src/dc43/demo_app/templates/datasets.html
+++ b/src/dc43/demo_app/templates/datasets.html
@@ -1,331 +1,118 @@
 {% extends "base.html" %}
 {% block content %}
-<h1>Pipeline Scenarios</h1>
-{% if message %}<div class="alert alert-success">{{ message }}</div>{% endif %}
-{% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
-<table class="table table-striped align-middle" id="scenario-table">
+<h1>Datasets</h1>
+<table class="table table-striped align-middle">
   <thead>
     <tr>
-      <th scope="col">Scenario</th>
-      <th scope="col">Latest run</th>
+      <th scope="col">Dataset</th>
+      <th scope="col">Latest Version</th>
       <th scope="col">Status</th>
-      <th scope="col">Violations</th>
-      <th scope="col">DQ details</th>
-      <th scope="col" class="text-center">Runs</th>
-      <th scope="col" class="text-end">Action</th>
+      <th scope="col">Contract</th>
+      <th scope="col">Drafts</th>
+      <th scope="col" class="text-end">Actions</th>
     </tr>
   </thead>
   <tbody>
-  {% for scenario in scenario_rows %}
-    {% set record = scenario.latest %}
-    {% set output_details = record.dq_details.get('output', {}) if record else {} %}
-    {% set fails = output_details.get('failed_expectations', {}) if output_details else {} %}
-    {% set schema_errors = output_details.get('errors', []) if output_details else [] %}
-    {% set dq_aux = output_details.get('dq_auxiliary_statuses', []) if output_details else [] %}
+  {% for entry in datasets %}
     <tr>
-      <th scope="row" class="w-25">
-        <div class="d-flex align-items-start gap-2">
-          <div>
-            <div class="fw-semibold">{{ scenario.label }}</div>
-            <div class="text-muted small">{{ scenario.key }}</div>
-          </div>
-          {% if scenario.description or scenario.diagram %}
-          <button type="button" class="btn btn-outline-secondary btn-sm scenario-info" data-scenario-popover="scenario-popover-{{ scenario.key }}" data-popover-title="{{ scenario.label }}">
-            Details
-          </button>
-          {% endif %}
-        </div>
-        {% if scenario.description or scenario.diagram %}
-        <div id="scenario-popover-{{ scenario.key }}" class="d-none">
-          {% if scenario.description %}
-          <div class="mb-2">{{ scenario.description | safe }}</div>
-          {% endif %}
-          {% if scenario.diagram %}
-          {{ scenario.diagram | safe }}
-          {% endif %}
-        </div>
-        {% endif %}
+      <th scope="row">
+        <a href="/datasets/{{ entry.dataset_name }}">{{ entry.dataset_name }}</a>
       </th>
-      <td class="w-25">
-        <div class="small text-muted">Contract</div>
-        {% if record and record.contract_id %}
-          <div>
-            <a href="/contracts/{{ record.contract_id }}">{{ record.contract_id }}</a>
-            {% if record.contract_version %}
-              <span class="text-muted">/</span>
-              <a href="/contracts/{{ record.contract_id }}/{{ record.contract_version }}">{{ record.contract_version }}</a>
-            {% endif %}
-          </div>
-        {% elif scenario.contract_id %}
-          <div>
-            <a href="/contracts/{{ scenario.contract_id }}">{{ scenario.contract_id }}</a>
-            {% if scenario.contract_version %}
-              <span class="text-muted">/</span>
-              <a href="/contracts/{{ scenario.contract_id }}/{{ scenario.contract_version }}">{{ scenario.contract_version }}</a>
-            {% endif %}
-          </div>
+      <td>
+        {% if entry.latest_version %}
+          <a href="/datasets/{{ entry.dataset_name }}/{{ entry.latest_version }}">{{ entry.latest_version }}</a>
         {% else %}
-          <div><span class="text-muted">No contract</span></div>
-        {% endif %}
-        <div class="small text-muted mt-2">Dataset</div>
-        {% if scenario.dataset_name %}
-          {% if record and record.dataset_version %}
-            <div>
-              <a href="/datasets/{{ scenario.dataset_name }}/{{ record.dataset_version }}">{{ scenario.dataset_name }}</a>
-              <span class="text-muted">/</span>
-              {{ record.dataset_version }}
-            </div>
-          {% else %}
-            <div><a href="/datasets/{{ scenario.dataset_name }}">{{ scenario.dataset_name }}</a></div>
-          {% endif %}
-        {% elif record and record.dataset_version %}
-          <div>{{ record.dataset_version }}</div>
-        {% else %}
-          <div><span class="text-muted">Not recorded</span></div>
-        {% endif %}
-        <div class="small text-muted mt-2">Run type</div>
-        <div>{{ record.run_type if record else scenario.run_type }}</div>
-        {% if record and record.draft_contract_version %}
-          <div class="small text-muted mt-2">Draft
-            {% if record.contract_id %}
-              <a href="/contracts/{{ record.contract_id }}/{{ record.draft_contract_version }}">{{ record.draft_contract_version }}</a>
-            {% else %}
-              {{ record.draft_contract_version }}
-            {% endif %}
-          </div>
-        {% endif %}
-      </td>
-      <td data-status-cell aria-live="polite">
-        {% if record %}
-          <div>
-            {{ record.status }}
-            {% if output_details.get('warnings') %}
-              <span class="text-warning ms-1" title="Validation warnings">&#9888;</span>
-            {% endif %}
-            {% if output_details.get('errors') %}
-              <span class="text-danger ms-1" title="Schema errors">&#10060;</span>
-            {% endif %}
-          </div>
-          {% if record.reason %}
-            <div class="small text-muted">{{ record.reason }}</div>
-          {% endif %}
-        {% else %}
-          <span class="text-muted">No runs yet</span>
-        {% endif %}
-      </td>
-      <td data-violations-cell>
-        {% if record %}
-          {% if output_details.get('violation_strategy') %}
-            <div>Strategy: {{ output_details.get('violation_strategy') }}</div>
-          {% endif %}
-          {% if schema_errors %}
-            <div>Schema errors: {{ schema_errors | length }}</div>
-          {% endif %}
-          {% if fails %}
-            {% for key, info in fails.items() %}
-              <div>{{ key }} ({{ info.count }})</div>
-            {% endfor %}
-          {% endif %}
-          {% set aux = output_details.get('auxiliary_datasets', []) %}
-          {% if aux %}
-            <div class="small text-muted">
-              {% for entry in aux %}
-                <div>{{ entry.kind | capitalize }} → <code>{{ entry.dataset }}</code></div>
-              {% endfor %}
-            </div>
-          {% endif %}
-          {% if dq_aux %}
-            <div class="small text-muted">
-              {% for entry in dq_aux %}
-                {% set details = entry.get('details') if entry.get('details') is mapping else {} %}
-                <div>
-                  <code>{{ entry.get('dataset_id') }}</code> status → {{ entry.get('status') }}
-                  {% if details.get('draft_contract_version') %}
-                    (draft {{ details.get('draft_contract_version') }})
-                  {% endif %}
-                </div>
-              {% endfor %}
-            </div>
-          {% endif %}
-          {% if not fails and not schema_errors %}
-            {% if record.violations %}
-              {{ record.violations }}
-            {% else %}
-              <span class="text-muted">0</span>
-            {% endif %}
-          {% endif %}
-        {% else %}
-          <span class="text-muted">—</span>
+          <span class="text-muted">No versions</span>
         {% endif %}
       </td>
       <td>
-        {% if record %}
-        <details>
-          <summary>Show</summary>
-          <div class="accordion mt-2" id="dq-{{ scenario.key }}">
-            <div class="accordion-item">
-              <h2 class="accordion-header" id="dq-input-{{ scenario.key }}-h">
-                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#dq-input-{{ scenario.key }}">Input</button>
-              </h2>
-              <div id="dq-input-{{ scenario.key }}" class="accordion-collapse collapse">
-                <div class="accordion-body">
-                  {% for key in ['orders', 'customers'] %}
-                    {% if record.dq_details.get(key) %}
-                      <h6 class="text-capitalize">{{ key }}</h6>
-                      <pre class="small">{{ record.dq_details.get(key) | tojson(indent=2) }}</pre>
-                    {% endif %}
-                  {% endfor %}
-                </div>
-              </div>
-            </div>
-            <div class="accordion-item">
-              <h2 class="accordion-header" id="dq-output-{{ scenario.key }}-h">
-                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#dq-output-{{ scenario.key }}">Output</button>
-              </h2>
-              <div id="dq-output-{{ scenario.key }}" class="accordion-collapse collapse">
-                <div class="accordion-body">
-                  {% if fails %}
-                    {% for key, info in fails.items() %}
-                      <div class="mb-2"><strong>{{ key }}</strong>: <code>{{ info.expression }}</code> ({{ info.count }})
-                      {% if info.examples %}
-                        <details class="small"><summary>Examples</summary><pre class="small mb-0">{{ info.examples | tojson(indent=2) }}</pre></details>
-                      {% endif %}
-                      </div>
-                    {% endfor %}
-                  {% endif %}
-                  {% if schema_errors %}
-                    <div class="mb-2">
-                      <strong>Schema errors</strong>
-                      <ul class="small mb-0 ps-3">
-                        {% for err in schema_errors %}
-                          <li>{{ err }}</li>
-                        {% endfor %}
-                      </ul>
-                    </div>
-                  {% endif %}
-                  {% set warnings = output_details.get('warnings', []) %}
-                  {% if warnings %}
-                    <div class="mb-2">
-                      <strong>Warnings</strong>
-                      <ul class="small mb-0 ps-3">
-                        {% for warning in warnings %}
-                          <li>{{ warning }}</li>
-                        {% endfor %}
-                      </ul>
-                    </div>
-                  {% endif %}
-                  {% set aux = output_details.get('auxiliary_datasets', []) %}
-                  {% if aux %}
-                    <div class="mb-2">
-                      <strong>Auxiliary datasets</strong>
-                      <ul class="small mb-0 ps-3">
-                        {% for entry in aux %}
-                          <li><span class="text-capitalize">{{ entry.kind }}</span>: <code>{{ entry.dataset }}</code>{% if entry.path %} ({{ entry.path }}){% endif %}</li>
-                        {% endfor %}
-                      </ul>
-                    </div>
-                  {% endif %}
-                  {% if dq_aux %}
-                    <div class="mb-2">
-                      <strong>Auxiliary DQ statuses</strong>
-                      <ul class="small mb-0 ps-3">
-                        {% for entry in dq_aux %}
-                          {% set details = entry.get('details') if entry.get('details') is mapping else {} %}
-                          <li>
-                            <code>{{ entry.get('dataset_id') }}</code> → {{ entry.get('status') }}
-                            {% if details.get('reason') %}
-                              <span class="text-muted">({{ details.get('reason') }})</span>
-                            {% endif %}
-                          </li>
-                        {% endfor %}
-                      </ul>
-                    </div>
-                  {% endif %}
-                </div>
-              </div>
-            </div>
-          </div>
-        </details>
+        {% if entry.latest_status %}
+          <span class="badge {{ entry.latest_status_badge }}">{{ entry.latest_status_label }}</span>
+          {% if entry.latest_record_reason %}
+            <div class="small text-muted">{{ entry.latest_record_reason }}</div>
+          {% endif %}
         {% else %}
-          <span class="text-muted">—</span>
+          <span class="text-muted">No runs</span>
         {% endif %}
       </td>
-      <td class="text-center">{{ scenario.run_count }}</td>
+      <td>
+        {% if entry.contract_summaries %}
+          {% for contract in entry.contract_summaries %}
+            <div>
+              <a href="/contracts/{{ contract.id }}">{{ contract.id }}</a>
+              {% if contract.latest_version %}
+                <span class="text-muted">/</span>
+                <a href="/contracts/{{ contract.id }}/{{ contract.latest_version }}">{{ contract.latest_version }}</a>
+              {% endif %}
+            </div>
+            <div class="small text-muted">Status: {{ contract.latest_status_label }}</div>
+            {% if contract.other_versions %}
+              <div class="small text-muted">Other versions: {{ contract.other_versions | join(', ') }}</div>
+            {% endif %}
+          {% endfor %}
+        {% else %}
+          <span class="text-muted">No contract</span>
+        {% endif %}
+      </td>
+      <td>
+        {% set draft_details = [] %}
+        {% for contract in entry.contract_summaries %}
+          {% if contract.drafts_count %}
+            {% set draft_label = contract.drafts_count ~ ' draft' ~ ('s' if contract.drafts_count != 1 else '') %}
+            {% if contract.latest_draft_version %}
+              {% set draft_label = draft_label ~ ' (latest ' ~ contract.latest_draft_version ~ ')' %}
+            {% endif %}
+            {% set _ = draft_details.append(contract.id ~ ': ' ~ draft_label) %}
+          {% endif %}
+        {% endfor %}
+        {% if entry.run_drafts_count %}
+          {% set label = entry.run_drafts_count ~ ' draft run' ~ ('s' if entry.run_drafts_count != 1 else '') %}
+          {% if entry.run_latest_draft_version %}
+            {% set label = label ~ ' (latest ' ~ entry.run_latest_draft_version ~ ')' %}
+          {% endif %}
+          {% set _ = draft_details.append('Runs: ' ~ label) %}
+        {% endif %}
+        {% if draft_details %}
+          <div class="small">{% for line in draft_details %}<div>{{ line }}</div>{% endfor %}</div>
+        {% else %}
+          <span class="text-muted">None</span>
+        {% endif %}
+      </td>
       <td class="text-end">
-        <form class="d-inline" method="post" action="/pipeline/run">
-          <input type="hidden" name="scenario" value="{{ scenario.key }}"/>
-          <button class="btn btn-primary btn-sm" type="submit">Run</button>
-        </form>
+        <a class="btn btn-sm btn-outline-primary" href="/datasets/{{ entry.dataset_name }}">View versions</a>
+        {% set editable_contracts = [] %}
+        {% for contract in entry.contract_summaries %}
+          {% if contract.latest_version %}
+            {% set _ = editable_contracts.append(contract) %}
+          {% endif %}
+        {% endfor %}
+        {% if editable_contracts %}
+          {% if editable_contracts | length == 1 %}
+            {% set target = editable_contracts[0] %}
+            <a class="btn btn-sm btn-primary ms-2" href="/contracts/{{ target.id }}/{{ target.latest_version }}/edit">Open editor</a>
+          {% else %}
+            <div class="btn-group ms-2">
+              <button type="button" class="btn btn-sm btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+                Open editor
+              </button>
+              <ul class="dropdown-menu dropdown-menu-end">
+                {% for contract in editable_contracts %}
+                  <li>
+                    <a class="dropdown-item" href="/contracts/{{ contract.id }}/{{ contract.latest_version }}/edit">
+                      {{ contract.id }} / {{ contract.latest_version }}
+                    </a>
+                  </li>
+                {% endfor %}
+              </ul>
+            </div>
+          {% endif %}
+        {% endif %}
       </td>
     </tr>
   {% endfor %}
   </tbody>
 </table>
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    const buttons = document.querySelectorAll('.scenario-info');
-    buttons.forEach((btn) => {
-      const contentId = btn.getAttribute('data-scenario-popover');
-      if (!contentId) {
-        return;
-      }
-      const source = document.getElementById(contentId);
-      if (!source) {
-        return;
-      }
-      const popover = new bootstrap.Popover(btn, {
-        html: true,
-        sanitize: false,
-        trigger: 'focus',
-        container: 'body',
-        title: btn.getAttribute('data-popover-title') || '',
-        content: source.innerHTML,
-      });
-      btn.addEventListener('shown.bs.popover', () => {
-        if (window.mermaid && typeof window.mermaid.run === 'function') {
-          window.mermaid.run({ nodes: document.querySelectorAll('.popover .mermaid') });
-        } else if (window.mermaid && typeof window.mermaid.init === 'function') {
-          window.mermaid.init(undefined, document.querySelectorAll('.popover .mermaid'));
-        }
-      });
-    });
-
-    const forms = document.querySelectorAll('#scenario-table form');
-    forms.forEach((form) => {
-      form.addEventListener('submit', () => {
-        if (form.dataset.submitting === 'true') {
-          return;
-        }
-        form.dataset.submitting = 'true';
-
-        const button = form.querySelector('button[type="submit"]');
-        if (button) {
-          button.disabled = true;
-          button.innerHTML = '';
-          const spinner = document.createElement('span');
-          spinner.className = 'spinner-border spinner-border-sm me-2';
-          spinner.setAttribute('role', 'status');
-          spinner.setAttribute('aria-hidden', 'true');
-          button.appendChild(spinner);
-          const label = document.createElement('span');
-          label.textContent = 'Running…';
-          button.appendChild(label);
-        }
-
-        const row = form.closest('tr');
-        if (!row) {
-          return;
-        }
-        const statusCell = row.querySelector('[data-status-cell]');
-        if (statusCell) {
-          statusCell.innerHTML = '<span class="text-muted">Running…</span>';
-        }
-        const violationsCell = row.querySelector('[data-violations-cell]');
-        if (violationsCell) {
-          violationsCell.innerHTML = '<span class="text-muted">—</span>';
-        }
-      });
-    });
-  });
-</script>
+{% if not datasets %}
+  <p class="text-muted">No datasets recorded yet.</p>
+{% endif %}
 {% endblock %}

--- a/src/dc43/demo_app/templates/index.html
+++ b/src/dc43/demo_app/templates/index.html
@@ -3,6 +3,7 @@
 <h1>DC43 Demo</h1>
 <div class="list-group">
   <a class="list-group-item list-group-item-action" href="/contracts">Browse Contracts</a>
-  <a class="list-group-item list-group-item-action" href="/datasets">Pipeline Runs</a>
+  <a class="list-group-item list-group-item-action" href="/datasets">Datasets</a>
+  <a class="list-group-item list-group-item-action" href="/pipeline-runs">Pipeline Runs</a>
 </div>
 {% endblock %}

--- a/src/dc43/demo_app/templates/pipeline_runs.html
+++ b/src/dc43/demo_app/templates/pipeline_runs.html
@@ -1,0 +1,331 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Pipeline Scenarios</h1>
+{% if message %}<div class="alert alert-success">{{ message }}</div>{% endif %}
+{% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
+<table class="table table-striped align-middle" id="scenario-table">
+  <thead>
+    <tr>
+      <th scope="col">Scenario</th>
+      <th scope="col">Latest run</th>
+      <th scope="col">Status</th>
+      <th scope="col">Violations</th>
+      <th scope="col">DQ details</th>
+      <th scope="col" class="text-center">Runs</th>
+      <th scope="col" class="text-end">Action</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for scenario in scenario_rows %}
+    {% set record = scenario.latest %}
+    {% set output_details = record.dq_details.get('output', {}) if record else {} %}
+    {% set fails = output_details.get('failed_expectations', {}) if output_details else {} %}
+    {% set schema_errors = output_details.get('errors', []) if output_details else [] %}
+    {% set dq_aux = output_details.get('dq_auxiliary_statuses', []) if output_details else [] %}
+    <tr>
+      <th scope="row" class="w-25">
+        <div class="d-flex align-items-start gap-2">
+          <div>
+            <div class="fw-semibold">{{ scenario.label }}</div>
+            <div class="text-muted small">{{ scenario.key }}</div>
+          </div>
+          {% if scenario.description or scenario.diagram %}
+          <button type="button" class="btn btn-outline-secondary btn-sm scenario-info" data-scenario-popover="scenario-popover-{{ scenario.key }}" data-popover-title="{{ scenario.label }}">
+            Details
+          </button>
+          {% endif %}
+        </div>
+        {% if scenario.description or scenario.diagram %}
+        <div id="scenario-popover-{{ scenario.key }}" class="d-none">
+          {% if scenario.description %}
+          <div class="mb-2">{{ scenario.description | safe }}</div>
+          {% endif %}
+          {% if scenario.diagram %}
+          {{ scenario.diagram | safe }}
+          {% endif %}
+        </div>
+        {% endif %}
+      </th>
+      <td class="w-25">
+        <div class="small text-muted">Contract</div>
+        {% if record and record.contract_id %}
+          <div>
+            <a href="/contracts/{{ record.contract_id }}">{{ record.contract_id }}</a>
+            {% if record.contract_version %}
+              <span class="text-muted">/</span>
+              <a href="/contracts/{{ record.contract_id }}/{{ record.contract_version }}">{{ record.contract_version }}</a>
+            {% endif %}
+          </div>
+        {% elif scenario.contract_id %}
+          <div>
+            <a href="/contracts/{{ scenario.contract_id }}">{{ scenario.contract_id }}</a>
+            {% if scenario.contract_version %}
+              <span class="text-muted">/</span>
+              <a href="/contracts/{{ scenario.contract_id }}/{{ scenario.contract_version }}">{{ scenario.contract_version }}</a>
+            {% endif %}
+          </div>
+        {% else %}
+          <div><span class="text-muted">No contract</span></div>
+        {% endif %}
+        <div class="small text-muted mt-2">Dataset</div>
+        {% if scenario.dataset_name %}
+          {% if record and record.dataset_version %}
+            <div>
+              <a href="/datasets/{{ scenario.dataset_name }}/{{ record.dataset_version }}">{{ scenario.dataset_name }}</a>
+              <span class="text-muted">/</span>
+              {{ record.dataset_version }}
+            </div>
+          {% else %}
+            <div><a href="/datasets/{{ scenario.dataset_name }}">{{ scenario.dataset_name }}</a></div>
+          {% endif %}
+        {% elif record and record.dataset_version %}
+          <div>{{ record.dataset_version }}</div>
+        {% else %}
+          <div><span class="text-muted">Not recorded</span></div>
+        {% endif %}
+        <div class="small text-muted mt-2">Run type</div>
+        <div>{{ record.run_type if record else scenario.run_type }}</div>
+        {% if record and record.draft_contract_version %}
+          <div class="small text-muted mt-2">Draft
+            {% if record.contract_id %}
+              <a href="/contracts/{{ record.contract_id }}/{{ record.draft_contract_version }}">{{ record.draft_contract_version }}</a>
+            {% else %}
+              {{ record.draft_contract_version }}
+            {% endif %}
+          </div>
+        {% endif %}
+      </td>
+      <td data-status-cell aria-live="polite">
+        {% if record %}
+          <div>
+            {{ record.status }}
+            {% if output_details.get('warnings') %}
+              <span class="text-warning ms-1" title="Validation warnings">&#9888;</span>
+            {% endif %}
+            {% if output_details.get('errors') %}
+              <span class="text-danger ms-1" title="Schema errors">&#10060;</span>
+            {% endif %}
+          </div>
+          {% if record.reason %}
+            <div class="small text-muted">{{ record.reason }}</div>
+          {% endif %}
+        {% else %}
+          <span class="text-muted">No runs yet</span>
+        {% endif %}
+      </td>
+      <td data-violations-cell>
+        {% if record %}
+          {% if output_details.get('violation_strategy') %}
+            <div>Strategy: {{ output_details.get('violation_strategy') }}</div>
+          {% endif %}
+          {% if schema_errors %}
+            <div>Schema errors: {{ schema_errors | length }}</div>
+          {% endif %}
+          {% if fails %}
+            {% for key, info in fails.items() %}
+              <div>{{ key }} ({{ info.count }})</div>
+            {% endfor %}
+          {% endif %}
+          {% set aux = output_details.get('auxiliary_datasets', []) %}
+          {% if aux %}
+            <div class="small text-muted">
+              {% for entry in aux %}
+                <div>{{ entry.kind | capitalize }} → <code>{{ entry.dataset }}</code></div>
+              {% endfor %}
+            </div>
+          {% endif %}
+          {% if dq_aux %}
+            <div class="small text-muted">
+              {% for entry in dq_aux %}
+                {% set details = entry.get('details') if entry.get('details') is mapping else {} %}
+                <div>
+                  <code>{{ entry.get('dataset_id') }}</code> status → {{ entry.get('status') }}
+                  {% if details.get('draft_contract_version') %}
+                    (draft {{ details.get('draft_contract_version') }})
+                  {% endif %}
+                </div>
+              {% endfor %}
+            </div>
+          {% endif %}
+          {% if not fails and not schema_errors %}
+            {% if record.violations %}
+              {{ record.violations }}
+            {% else %}
+              <span class="text-muted">0</span>
+            {% endif %}
+          {% endif %}
+        {% else %}
+          <span class="text-muted">—</span>
+        {% endif %}
+      </td>
+      <td>
+        {% if record %}
+        <details>
+          <summary>Show</summary>
+          <div class="accordion mt-2" id="dq-{{ scenario.key }}">
+            <div class="accordion-item">
+              <h2 class="accordion-header" id="dq-input-{{ scenario.key }}-h">
+                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#dq-input-{{ scenario.key }}">Input</button>
+              </h2>
+              <div id="dq-input-{{ scenario.key }}" class="accordion-collapse collapse">
+                <div class="accordion-body">
+                  {% for key in ['orders', 'customers'] %}
+                    {% if record.dq_details.get(key) %}
+                      <h6 class="text-capitalize">{{ key }}</h6>
+                      <pre class="small">{{ record.dq_details.get(key) | tojson(indent=2) }}</pre>
+                    {% endif %}
+                  {% endfor %}
+                </div>
+              </div>
+            </div>
+            <div class="accordion-item">
+              <h2 class="accordion-header" id="dq-output-{{ scenario.key }}-h">
+                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#dq-output-{{ scenario.key }}">Output</button>
+              </h2>
+              <div id="dq-output-{{ scenario.key }}" class="accordion-collapse collapse">
+                <div class="accordion-body">
+                  {% if fails %}
+                    {% for key, info in fails.items() %}
+                      <div class="mb-2"><strong>{{ key }}</strong>: <code>{{ info.expression }}</code> ({{ info.count }})
+                      {% if info.examples %}
+                        <details class="small"><summary>Examples</summary><pre class="small mb-0">{{ info.examples | tojson(indent=2) }}</pre></details>
+                      {% endif %}
+                      </div>
+                    {% endfor %}
+                  {% endif %}
+                  {% if schema_errors %}
+                    <div class="mb-2">
+                      <strong>Schema errors</strong>
+                      <ul class="small mb-0 ps-3">
+                        {% for err in schema_errors %}
+                          <li>{{ err }}</li>
+                        {% endfor %}
+                      </ul>
+                    </div>
+                  {% endif %}
+                  {% set warnings = output_details.get('warnings', []) %}
+                  {% if warnings %}
+                    <div class="mb-2">
+                      <strong>Warnings</strong>
+                      <ul class="small mb-0 ps-3">
+                        {% for warning in warnings %}
+                          <li>{{ warning }}</li>
+                        {% endfor %}
+                      </ul>
+                    </div>
+                  {% endif %}
+                  {% set aux = output_details.get('auxiliary_datasets', []) %}
+                  {% if aux %}
+                    <div class="mb-2">
+                      <strong>Auxiliary datasets</strong>
+                      <ul class="small mb-0 ps-3">
+                        {% for entry in aux %}
+                          <li><span class="text-capitalize">{{ entry.kind }}</span>: <code>{{ entry.dataset }}</code>{% if entry.path %} ({{ entry.path }}){% endif %}</li>
+                        {% endfor %}
+                      </ul>
+                    </div>
+                  {% endif %}
+                  {% if dq_aux %}
+                    <div class="mb-2">
+                      <strong>Auxiliary DQ statuses</strong>
+                      <ul class="small mb-0 ps-3">
+                        {% for entry in dq_aux %}
+                          {% set details = entry.get('details') if entry.get('details') is mapping else {} %}
+                          <li>
+                            <code>{{ entry.get('dataset_id') }}</code> → {{ entry.get('status') }}
+                            {% if details.get('reason') %}
+                              <span class="text-muted">({{ details.get('reason') }})</span>
+                            {% endif %}
+                          </li>
+                        {% endfor %}
+                      </ul>
+                    </div>
+                  {% endif %}
+                </div>
+              </div>
+            </div>
+          </div>
+        </details>
+        {% else %}
+          <span class="text-muted">—</span>
+        {% endif %}
+      </td>
+      <td class="text-center">{{ scenario.run_count }}</td>
+      <td class="text-end">
+        <form class="d-inline" method="post" action="/pipeline/run">
+          <input type="hidden" name="scenario" value="{{ scenario.key }}"/>
+          <button class="btn btn-primary btn-sm" type="submit">Run</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    const buttons = document.querySelectorAll('.scenario-info');
+    buttons.forEach((btn) => {
+      const contentId = btn.getAttribute('data-scenario-popover');
+      if (!contentId) {
+        return;
+      }
+      const source = document.getElementById(contentId);
+      if (!source) {
+        return;
+      }
+      const popover = new bootstrap.Popover(btn, {
+        html: true,
+        sanitize: false,
+        trigger: 'focus',
+        container: 'body',
+        title: btn.getAttribute('data-popover-title') || '',
+        content: source.innerHTML,
+      });
+      btn.addEventListener('shown.bs.popover', () => {
+        if (window.mermaid && typeof window.mermaid.run === 'function') {
+          window.mermaid.run({ nodes: document.querySelectorAll('.popover .mermaid') });
+        } else if (window.mermaid && typeof window.mermaid.init === 'function') {
+          window.mermaid.init(undefined, document.querySelectorAll('.popover .mermaid'));
+        }
+      });
+    });
+
+    const forms = document.querySelectorAll('#scenario-table form');
+    forms.forEach((form) => {
+      form.addEventListener('submit', () => {
+        if (form.dataset.submitting === 'true') {
+          return;
+        }
+        form.dataset.submitting = 'true';
+
+        const button = form.querySelector('button[type="submit"]');
+        if (button) {
+          button.disabled = true;
+          button.innerHTML = '';
+          const spinner = document.createElement('span');
+          spinner.className = 'spinner-border spinner-border-sm me-2';
+          spinner.setAttribute('role', 'status');
+          spinner.setAttribute('aria-hidden', 'true');
+          button.appendChild(spinner);
+          const label = document.createElement('span');
+          label.textContent = 'Running…';
+          button.appendChild(label);
+        }
+
+        const row = form.closest('tr');
+        if (!row) {
+          return;
+        }
+        const statusCell = row.querySelector('[data-status-cell]');
+        if (statusCell) {
+          statusCell.innerHTML = '<span class="text-muted">Running…</span>';
+        }
+        const violationsCell = row.querySelector('[data-violations-cell]');
+        if (violationsCell) {
+          violationsCell.innerHTML = '<span class="text-muted">—</span>';
+        }
+      });
+    });
+  });
+</script>
+{% endblock %}

--- a/tests/test_server_pages.py
+++ b/tests/test_server_pages.py
@@ -42,6 +42,8 @@ def test_contract_versions_page():
     client = TestClient(app)
     resp = client.get(f"/contracts/{rec.contract_id}")
     assert resp.status_code == 200
+    assert "Open editor" in resp.text
+    assert f"/contracts/{rec.contract_id}/{rec.contract_version}/edit" in resp.text
 
 
 def test_customers_contract_versions_page():
@@ -52,7 +54,7 @@ def test_customers_contract_versions_page():
 
 def test_pipeline_runs_page_lists_scenarios():
     client = TestClient(app)
-    resp = client.get("/datasets")
+    resp = client.get("/pipeline-runs")
     assert resp.status_code == 200
     for key, cfg in SCENARIOS.items():
         assert cfg["label"] in resp.text
@@ -73,6 +75,15 @@ def test_dataset_versions_page():
     client = TestClient(app)
     resp = client.get(f"/datasets/{rec.dataset_name}")
     assert resp.status_code == 200
+
+
+def test_datasets_page_catalog_overview():
+    client = TestClient(app)
+    resp = client.get("/datasets")
+    assert resp.status_code == 200
+    assert "orders" in resp.text
+    assert "Status:" in resp.text
+    assert "Open editor" in resp.text
 
 
 def test_dataset_pages_without_contract():
@@ -109,11 +120,11 @@ def test_flash_message_consumed_once():
     token = queue_flash(message="Hello there", error=None)
     client = TestClient(app)
 
-    first = client.get(f"/datasets?flash={token}")
+    first = client.get(f"/pipeline-runs?flash={token}")
     assert first.status_code == 200
     assert "Hello there" in first.text
 
-    second = client.get(f"/datasets?flash={token}")
+    second = client.get(f"/pipeline-runs?flash={token}")
     assert second.status_code == 200
     assert "Hello there" not in second.text
 


### PR DESCRIPTION
## Summary
- add a dataset catalog view that aggregates latest status, contract, and draft information and offers editor entry points for linked contracts
- split the pipeline runs UI to /pipeline-runs and update navigation/index links
- enrich the contract versions page with status badges, server details, latest run metadata, and provide direct editor access from the listing

## Testing
- PYTHONPATH=src pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68db844bad90832eb003c65b36afffd1