### PR TITLE
Stop overriding dataset format in integration helper stub

### DIFF
--- a/packages/dc43-contracts-app/src/dc43_contracts_app/server.py
+++ b/packages/dc43-contracts-app/src/dc43_contracts_app/server.py
@@ -1505,8 +1505,6 @@ def _spark_stub_for_selection(
                 "    data_quality_service=dq_client,",
             ]
         )
-        if fmt:
-            lines.append(f"    format={fmt!r},")
         if server.get("dataset"):
             lines.append(f"    table={server['dataset']!r},")
         lines.extend(
@@ -1588,8 +1586,6 @@ def _spark_stub_for_selection(
                 "    governance_service=governance_client,",
             ]
         )
-        if fmt:
-            lines.append(f"    format={fmt!r},")
         if server.get("dataset"):
             lines.append(f"    table={server['dataset']!r},")
         lines.extend(


### PR DESCRIPTION
## Summary
- remove the generated format argument from integration helper read/write stub calls so contracts control the storage format

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68dd7de62d98832e95b2a4627e8e7c58