### PR TITLE
Ensure service client tests install HTTP dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,14 +97,14 @@ jobs:
               pip install -e '.[test]'
               ;;
             dc43-service-clients)
-              pip install -e packages/dc43-service-clients
+              pip install -e packages/dc43-service-clients[http]
               ;;
             dc43-service-backends)
-              pip install -e packages/dc43-service-clients
+              pip install -e packages/dc43-service-clients[http]
               pip install -e packages/dc43-service-backends
               ;;
             dc43-integrations)
-              pip install -e packages/dc43-service-clients
+              pip install -e packages/dc43-service-clients[http]
               pip install -e packages/dc43-integrations
               ;;
             dc43-contracts-app)

--- a/packages/dc43-service-clients/src/dc43_service_clients/_http_sync.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/_http_sync.py
@@ -7,19 +7,11 @@ import inspect
 import threading
 from typing import Any, Awaitable, TypeVar
 
-try:  # pragma: no cover - optional dependency guard
-    import httpx
-except ModuleNotFoundError as exc:  # pragma: no cover
-    raise ModuleNotFoundError(
-        "httpx is required to use the HTTP service clients. Install "
-        "'dc43-service-clients[http]' to enable them."
-    ) from exc
+import httpx
 
 T = TypeVar("T")
 
 _LOOP_LOCAL = threading.local()
-
-
 def _ensure_thread_loop() -> asyncio.AbstractEventLoop:
     """Return an event loop bound to the current thread."""
 
@@ -56,7 +48,7 @@ def _await_sync(awaitable: Awaitable[T]) -> T:
     )
 
 
-def ensure_response(result: Any) -> httpx.Response:
+def ensure_response(result: Any) -> "httpx.Response":
     """Return an ``httpx.Response`` from ``result``.
 
     ``result`` may already be a response (for synchronous clients) or an

--- a/packages/dc43-service-clients/src/dc43_service_clients/data_quality/client/remote.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/data_quality/client/remote.py
@@ -4,13 +4,7 @@ from __future__ import annotations
 
 from typing import Mapping, Sequence
 
-try:  # pragma: no cover - optional dependency guard
-    import httpx
-except ModuleNotFoundError as exc:  # pragma: no cover
-    raise ModuleNotFoundError(
-        "httpx is required to use the HTTP data-quality client. Install "
-        "'dc43-service-clients[http]' to enable it."
-    ) from exc
+import httpx
 from open_data_contract_standard.model import OpenDataContractStandard  # type: ignore
 
 from dc43_service_clients._http_sync import ensure_response, close_client


### PR DESCRIPTION
## Summary
- import httpx directly in the synchronous HTTP utilities and remote data-quality client so missing dependencies surface during module import
- install the dc43-service-clients[http] extra in the release workflow to provide required HTTP dependencies during package tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68dd81d081f0832ebe4d2a62e521b058