### PR TITLE
Ensure service backends depend on dc43 core package

### DIFF
--- a/packages/dc43-service-backends/pyproject.toml
+++ b/packages/dc43-service-backends/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 dependencies = [
+  "dc43>=0.8.0.0",
   "dc43-service-clients>=0.0.3",
   "open-data-contract-standard==3.0.2",
 ]

--- a/scripts/_packages.py
+++ b/scripts/_packages.py
@@ -55,12 +55,12 @@ PACKAGES = {
 }
 
 DEFAULT_RELEASE_ORDER = [
+    "dc43",
     "dc43-service-clients",
     "dc43-service-backends",
     "dc43-integrations",
     "dc43-contracts-app",
     "dc43-demo-app",
-    "dc43",
 ]
 
 INTERNAL_PACKAGE_NAMES = set(PACKAGES)


### PR DESCRIPTION
## Summary
- add the dc43 core distribution as a dependency for the dc43-service-backends package
- update the default release order so the core package is built before downstream packages

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68dd8b3b7670832e8f1e8e559667bbe8