### PR TITLE
Switch release workflow to commit trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,9 @@ concurrency:
 
 on:
   push:
-    tags:
-      - "dc43-v*"
-      - "dc43-service-clients-v*"
-      - "dc43-service-backends-v*"
-      - "dc43-integrations-v*"
-      - "dc43-contracts-app-v*"
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   determine:
@@ -32,8 +29,46 @@ jobs:
 
       - name: Identify release tags
         id: tags
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message || '' }}
         run: |
           set -euo pipefail
+
+          if [ "$EVENT_NAME" = "push" ]; then
+            if ! printf '%s' "$COMMIT_MESSAGE" | grep -qi '\[release\]'; then
+              prefixes=(
+                "dc43-v"
+                "dc43-service-clients-v"
+                "dc43-service-backends-v"
+                "dc43-integrations-v"
+                "dc43-contracts-app-v"
+              )
+              outputs=(
+                "core_tag"
+                "service_clients_tag"
+                "service_backends_tag"
+                "integrations_tag"
+                "contracts_app_tag"
+              )
+
+              for name in "${outputs[@]}"; do
+                echo "${name}=" >> "$GITHUB_OUTPUT"
+              done
+
+              {
+                echo "primary="
+                echo "should_run=false"
+              } >> "$GITHUB_OUTPUT"
+
+              cat <<'SUMMARY' >> "$GITHUB_STEP_SUMMARY"
+                ### Release run skipped
+                The latest commit on `main` does not contain the required `[release]` marker.
+                Add `[release]` to the commit message that bumps versions and push again to run the pipeline.
+              SUMMARY
+              exit 0
+            fi
+          fi
 
           tags=$(git tag --points-at "$GITHUB_SHA" | sort || true)
           if [ -z "$tags" ]; then

--- a/docs/release-versioning.md
+++ b/docs/release-versioning.md
@@ -66,8 +66,9 @@ Common workflows:
   ```
 
 - **Release everything that changed:** create annotated tags for all packages that need a release,
-  ensure the release commit message includes `[release]`, and push the branch plus tags to `origin`
-  (`git push origin main --tags`).
+  and push the branch plus tags to `origin` (`git push origin main --tags`). The CLI checks that the
+  target commit message already contains `[release]` so GitHub Actions will execute. Use
+  `--allow-missing-release-marker` when intentionally tagging an older commit without the marker.
 
   ```bash
   python scripts/release.py --apply --push
@@ -92,7 +93,7 @@ For a package bump (example: `dc43-service-backends`):
 1. Update the version in `packages/dc43-service-backends/VERSION`.
 2. Update changelog notes (either a shared CHANGELOG or one per package).
 3. Commit the changes with a message such as `chore(backends): release 0.9.0 [release]` so that the
-   automation runs.
+   automation runs (the release helper script will verify the marker is present).
 4. Merge to `main` via PR.
 5. Tag the merge commit: `git tag -a dc43-service-backends-v0.9.0`.
 6. Push the branch and tags together: `git push origin main --tags`.

--- a/docs/release-versioning.md
+++ b/docs/release-versioning.md
@@ -67,8 +67,9 @@ Common workflows:
 
 - **Release everything that changed:** create annotated tags for all packages that need a release,
   and push the branch plus tags to `origin` (`git push origin main --tags`). The CLI checks that the
-  target commit message already contains `[release]` so GitHub Actions will execute. Use
-  `--allow-missing-release-marker` when intentionally tagging an older commit without the marker.
+  target commit message already contains `[release]` so GitHub Actions will execute, and when targeting
+  `HEAD` it can amend the commit for you if the marker is missing. Use `--allow-missing-release-marker`
+  when intentionally tagging an older commit without the marker.
 
   ```bash
   python scripts/release.py --apply --push
@@ -93,7 +94,8 @@ For a package bump (example: `dc43-service-backends`):
 1. Update the version in `packages/dc43-service-backends/VERSION`.
 2. Update changelog notes (either a shared CHANGELOG or one per package).
 3. Commit the changes with a message such as `chore(backends): release 0.9.0 [release]` so that the
-   automation runs (the release helper script will verify the marker is present).
+   automation runs (the release helper script will verify the marker is present and can amend `HEAD`
+   for you if you forget).
 4. Merge to `main` via PR.
 5. Tag the merge commit: `git tag -a dc43-service-backends-v0.9.0`.
 6. Push the branch and tags together: `git push origin main --tags`.


### PR DESCRIPTION
## Summary
- trigger the release workflow on main commits containing a `[release]` marker (or manual dispatch) instead of per-tag pushes
- add a guard that skips automation when the marker is missing while keeping tag detection logic unchanged
- document the new trigger requirements and push sequence in the release guide

## Testing
- not run (workflow/documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68ddfe84fa70832e870693eb7eadad50