### PR TITLE
Prevent distribution builds from using local dependency paths

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,14 @@ _OPTIONAL_INTERNAL_DEPENDENCIES = [
 
 _ALL_INTERNAL_PACKAGES = _INTERNAL_CORE_DEPENDENCIES + _OPTIONAL_INTERNAL_DEPENDENCIES
 
-_LOCAL_FALLBACK_PACKAGES = set(_ALL_INTERNAL_PACKAGES)
+_BUILD_DIST_COMMANDS = {"sdist", "bdist_wheel"}
+
+
+def _building_distribution() -> bool:
+    return any(arg in _BUILD_DIST_COMMANDS for arg in sys.argv[1:])
+
+
+_LOCAL_FALLBACK_PACKAGES = set() if _building_distribution() else set(_ALL_INTERNAL_PACKAGES)
 
 
 def _use_pypi_versions() -> bool:


### PR DESCRIPTION
## Summary
- detect distribution build commands in `setup.py` and disable local path fallbacks
- ensure published metadata pins internal dependencies to version numbers instead of file URIs

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68de404afd08832e8a0298f08ba93387