### PR TITLE
Improve release tagging diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ __pycache__
 test_temp_files
 pytest.log
 build
+release-artifacts/
 .DS_Store

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -95,7 +95,12 @@ def run_git(*args: str, check: bool = True) -> str:
 def ensure_clean_worktree() -> None:
     status = run_git("status", "--porcelain")
     if status:
-        raise ReleaseError("Your working tree has uncommitted changes. Commit or stash them before releasing.")
+        formatted = "\n".join(f"    {line}" for line in status.splitlines())
+        raise ReleaseError(
+            "Your working tree has uncommitted changes:\n"
+            f"{formatted}\n"
+            "Commit or stash them before releasing."
+        )
 
 
 def prompt_yes_no(question: str) -> bool:


### PR DESCRIPTION
## Summary
- ignore the release-artifacts build output directory so release tagging runs with a clean tree
- show the list of uncommitted files when the release helper detects a dirty worktree

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_b_68de4acdaa98832ebe335b5d19ed69cc