### PR TITLE
Add Docker packaging for contracts app

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ On top of the conceptual platform, dc43 ships opinionated integrations that you 
 - Spark & DLT pipelines via `dc43_integrations.spark.io` with schema/metric helpers from `dc43_service_backends.data_quality.backend` for auto-casting and contract-aware IO.
 - Storage backends such as filesystem (DBFS/UC volumes), Delta tables, and Collibra through `CollibraContractStore`.
 - A pluggable data-quality client with a stub implementation that can be replaced by catalog-native tools.
+- Scenario-first getting started guides (operations setup, local Spark flows, remote integrations, and the contracts app helper) live in [`docs/getting-started/`](docs/getting-started/README.md).
 
 See [`docs/implementations/data-quality-governance/collibra.md`](docs/implementations/data-quality-governance/collibra.md) for end-to-end orchestration guidance when Collibra owns stewardship workflows. Component deep dives cover the [contract store](docs/component-contract-store.md), [contract drafter](docs/component-contract-drafter.md), [data-quality governance interface](docs/component-data-quality-governance.md), [data-quality engine](docs/component-data-quality-engine.md), and [integration layer](docs/component-integration-layer.md). Each component links to implementation catalogs under [`docs/implementations/`](docs/implementations/) so you can pick technology-specific guides (Spark, Delta, Collibra, ...).
 

--- a/deploy/contracts-app/Dockerfile
+++ b/deploy/contracts-app/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    DC43_CONTRACTS_APP_BACKEND_MODE=remote
+
+WORKDIR /app
+
+# Install dc43 packages from the repository to keep contracts metadata in sync with the
+# backend services.
+COPY packages/dc43-service-clients /tmp/dc43-service-clients
+COPY packages/dc43-service-backends /tmp/dc43-service-backends
+COPY packages/dc43-contracts-app /tmp/dc43-contracts-app
+
+RUN pip install --no-cache-dir /tmp/dc43-service-clients \
+    && pip install --no-cache-dir "/tmp/dc43-service-backends[http]" \
+    && pip install --no-cache-dir /tmp/dc43-contracts-app \
+    && pip install --no-cache-dir "uvicorn[standard]>=0.24" \
+    && rm -rf /tmp/dc43-service-clients /tmp/dc43-service-backends /tmp/dc43-contracts-app
+
+EXPOSE 8000
+
+CMD ["uvicorn", "dc43_contracts_app.server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/deploy/contracts-app/README.md
+++ b/deploy/contracts-app/README.md
@@ -1,0 +1,52 @@
+# Contracts app container
+
+The contracts helper lives under `packages/dc43-contracts-app`. Ship it as a container so
+Spark developers can generate integration stubs without cloning the repository. The image
+runs the FastAPI UI and talks to the shared governance backend in **remote** mode by
+default.
+
+## Build and publish
+
+The packaging helper accepts `contracts-app` as a target. Build an image locally or push
+directly to your registry:
+
+```bash
+# Build only
+python scripts/package_http_backend.py --target contracts-app --image dc43-contracts-app:local
+
+# Build and push
+python scripts/package_http_backend.py \
+  --target contracts-app \
+  --image myregistry.azurecr.io/dc43/contracts-app:latest \
+  --push
+```
+
+To drive Docker manually run:
+
+```bash
+docker build -t dc43-contracts-app -f deploy/contracts-app/Dockerfile .
+```
+
+## Runtime configuration
+
+The container exposes the UI on port `8000` and expects a reachable governance backend.
+Set the following environment variables when starting the container:
+
+- `DC43_CONTRACTS_APP_BACKEND_URL` – URL for the HTTP backend published by your
+  operations team (for example `https://governance.example.com`).
+- `DC43_BACKEND_TOKEN` – shared secret required by the backend service.
+- `DC43_CONTRACTS_APP_BACKEND_MODE` – override to `embedded` if you want the container to
+  spawn the in-process backend instead of dialing a remote service.
+
+Example:
+
+```bash
+docker run --rm \
+  -p 8000:8000 \
+  -e DC43_CONTRACTS_APP_BACKEND_URL="https://governance.example.com" \
+  -e DC43_BACKEND_TOKEN="super-secret" \
+  myregistry.azurecr.io/dc43/contracts-app:latest
+```
+
+Mount a contracts directory under `/contracts` and set `DC43_CONTRACT_STORE` if you run in
+embedded mode and need persistent drafts.

--- a/deploy/http-backend/README.md
+++ b/deploy/http-backend/README.md
@@ -7,7 +7,20 @@ container without publishing wheels.
 
 ## Building the image
 
-From the repository root, build the Docker image with the provided Dockerfile:
+From the repository root, build the Docker image with the provided Dockerfile.
+You can call `docker` directly or rely on the helper CLI that wraps the build
+and optional push to a registry. The helper accepts multiple targets and
+defaults to `http-backend`:
+
+```bash
+# Build the image locally
+python scripts/package_http_backend.py --target http-backend --image dc43-service-backends-http:local
+
+# Build and push to a remote registry
+python scripts/package_http_backend.py --target http-backend --image myregistry.azurecr.io/dc43/governance:latest --push
+```
+
+When invoking Docker manually the equivalent command is:
 
 ```bash
 docker build -t dc43-service-backends-http -f deploy/http-backend/Dockerfile .

--- a/deploy/terraform/aws-service-backend/README.md
+++ b/deploy/terraform/aws-service-backend/README.md
@@ -1,0 +1,52 @@
+# AWS Fargate deployment
+
+This Terraform stack deploys the dc43 HTTP service backends on Amazon ECS with
+Fargate. It provisions:
+
+- An ECS cluster and task definition running the `dc43-service-backends-http`
+  container
+- An Amazon EFS file system mounted into the task for persistent contracts
+- CloudWatch logging, IAM roles, and execution policies
+- An Application Load Balancer fronting the service with TLS termination
+
+## Usage
+
+1. Build the container image and push it to Amazon ECR.
+2. Populate a `terraform.tfvars` file with the required variables (see below).
+3. Apply the configuration from the repository root:
+
+   ```bash
+   terraform -chdir=deploy/terraform/aws-service-backend init
+   terraform -chdir=deploy/terraform/aws-service-backend apply
+   ```
+
+The deployment expects existing networking primitives (subnets and security
+groups) so it can plug into your VPC topology.
+
+## Required variables
+
+| Name | Description |
+| ---- | ----------- |
+| `aws_region` | AWS region to deploy into (e.g. `eu-west-1`). |
+| `cluster_name` | Name of the ECS cluster. |
+| `ecr_image_uri` | Fully qualified image URI (including tag) in ECR. |
+| `backend_token` | Optional bearer token enforced by the service. |
+| `contract_filesystem` | Name used for the EFS file system. |
+| `private_subnet_ids` | Private subnet IDs where the Fargate tasks run. |
+| `load_balancer_subnet_ids` | Subnets for the public Application Load Balancer. |
+| `service_security_group_id` | Security group applied to the ECS service ENI. |
+| `load_balancer_security_group_id` | Security group attached to the ALB. |
+| `certificate_arn` | ACM certificate ARN for HTTPS. |
+| `vpc_id` | VPC that hosts the deployment. |
+
+Optional variables let you tune CPU/memory, desired task count, and health check
+thresholds—check `variables.tf` for the full list.
+
+## Outputs
+
+- `load_balancer_dns_name` – Public DNS of the Application Load Balancer.
+- `service_name` – Name of the ECS service.
+- `efs_id` – ID of the EFS file system that stores contracts.
+
+Upload approved contracts or seed drafts by writing to the EFS share exposed to
+the tasks.

--- a/deploy/terraform/aws-service-backend/main.tf
+++ b/deploy/terraform/aws-service-backend/main.tf
@@ -1,0 +1,240 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.20.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+resource "aws_ecs_cluster" "main" {
+  name = var.cluster_name
+}
+
+resource "aws_cloudwatch_log_group" "main" {
+  name              = "/dc43/service-backends"
+  retention_in_days = var.log_retention_days
+}
+
+resource "aws_iam_role" "task_execution" {
+  name = "${var.cluster_name}-task-execution"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "task" {
+  name = "${var.cluster_name}-task"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "task_efs" {
+  name = "${var.cluster_name}-efs-access"
+  role = aws_iam_role.task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticfilesystem:ClientMount",
+          "elasticfilesystem:ClientWrite",
+          "elasticfilesystem:ClientRootAccess"
+        ]
+        Resource = aws_efs_file_system.contracts.arn
+      }
+    ]
+  })
+}
+
+resource "aws_security_group" "efs" {
+  name        = "${var.cluster_name}-efs"
+  description = "Allow NFS from ECS tasks"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = 2049
+    to_port         = 2049
+    protocol        = "tcp"
+    security_groups = [var.service_security_group_id]
+    description     = "NFS from ECS tasks"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_efs_file_system" "contracts" {
+  creation_token = var.contract_filesystem
+  encrypted      = true
+}
+
+resource "aws_efs_mount_target" "contracts" {
+  for_each = toset(var.private_subnet_ids)
+
+  file_system_id  = aws_efs_file_system.contracts.id
+  subnet_id       = each.value
+  security_groups = [aws_security_group.efs.id]
+}
+
+resource "aws_lb" "main" {
+  name               = "${var.cluster_name}-alb"
+  load_balancer_type = "application"
+  security_groups    = [var.load_balancer_security_group_id]
+  subnets            = var.load_balancer_subnet_ids
+  idle_timeout       = 60
+}
+
+resource "aws_lb_target_group" "main" {
+  name        = "${var.cluster_name}-tg"
+  port        = var.container_port
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = var.vpc_id
+
+  health_check {
+    path                = var.health_check_path
+    matcher             = "200-399"
+    healthy_threshold   = var.health_check_healthy_threshold
+    unhealthy_threshold = var.health_check_unhealthy_threshold
+    interval            = var.health_check_interval
+    timeout             = var.health_check_timeout
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.main.arn
+  }
+}
+
+resource "aws_ecs_task_definition" "main" {
+  family                   = "${var.cluster_name}-service"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  volume {
+    name = "contracts"
+
+    efs_volume_configuration {
+      file_system_id     = aws_efs_file_system.contracts.id
+      transit_encryption = "ENABLED"
+    }
+  }
+
+  container_definitions = jsonencode([
+    {
+      name         = "dc43-service-backends"
+      image        = var.ecr_image_uri
+      essential    = true
+      portMappings = [{
+        containerPort = var.container_port
+        hostPort      = var.container_port
+        protocol      = "tcp"
+      }]
+      environment = [
+        {
+          name  = "DC43_BACKEND_TOKEN"
+          value = var.backend_token
+        },
+        {
+          name  = "DC43_CONTRACT_STORE"
+          value = var.contract_storage_path
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.main.name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "dc43"
+        }
+      }
+      mountPoints = [{
+        containerPath = var.contract_storage_path
+        sourceVolume  = "contracts"
+        readOnly      = false
+      }]
+    }
+  ])
+}
+
+resource "aws_ecs_service" "main" {
+  name            = "${var.cluster_name}-service"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.main.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent         = 200
+
+  network_configuration {
+    subnets         = var.private_subnet_ids
+    security_groups = [var.service_security_group_id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.main.arn
+    container_name   = "dc43-service-backends"
+    container_port   = var.container_port
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
+  depends_on = [aws_lb_listener.https]
+}
+
+output "load_balancer_dns_name" {
+  value = aws_lb.main.dns_name
+}
+
+output "service_name" {
+  value = aws_ecs_service.main.name
+}
+
+output "efs_id" {
+  value = aws_efs_file_system.contracts.id
+}

--- a/deploy/terraform/aws-service-backend/variables.tf
+++ b/deploy/terraform/aws-service-backend/variables.tf
@@ -1,0 +1,121 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "ECS cluster name"
+  type        = string
+}
+
+variable "ecr_image_uri" {
+  description = "Fully qualified ECR image URI"
+  type        = string
+}
+
+variable "backend_token" {
+  description = "Bearer token enforced by the service"
+  type        = string
+  default     = ""
+}
+
+variable "contract_filesystem" {
+  description = "Identifier for the EFS file system"
+  type        = string
+}
+
+variable "contract_storage_path" {
+  description = "Mount path inside the container for the contract store"
+  type        = string
+  default     = "/contracts"
+}
+
+variable "private_subnet_ids" {
+  description = "Private subnet IDs for the ECS service"
+  type        = list(string)
+}
+
+variable "load_balancer_subnet_ids" {
+  description = "Subnets for the Application Load Balancer"
+  type        = list(string)
+}
+
+variable "service_security_group_id" {
+  description = "Security group applied to ECS tasks"
+  type        = string
+}
+
+variable "load_balancer_security_group_id" {
+  description = "Security group attached to the load balancer"
+  type        = string
+}
+
+variable "certificate_arn" {
+  description = "ACM certificate for HTTPS"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC hosting the deployment"
+  type        = string
+}
+
+variable "task_cpu" {
+  description = "Fargate CPU units"
+  type        = string
+  default     = "512"
+}
+
+variable "task_memory" {
+  description = "Fargate memory in MiB"
+  type        = string
+  default     = "1024"
+}
+
+variable "container_port" {
+  description = "Container listening port"
+  type        = number
+  default     = 8001
+}
+
+variable "desired_count" {
+  description = "Number of task replicas"
+  type        = number
+  default     = 2
+}
+
+variable "health_check_path" {
+  description = "ALB health check path"
+  type        = string
+  default     = "/health"
+}
+
+variable "health_check_interval" {
+  description = "Seconds between health checks"
+  type        = number
+  default     = 30
+}
+
+variable "health_check_timeout" {
+  description = "Health check timeout"
+  type        = number
+  default     = 5
+}
+
+variable "health_check_healthy_threshold" {
+  description = "Healthy threshold"
+  type        = number
+  default     = 2
+}
+
+variable "health_check_unhealthy_threshold" {
+  description = "Unhealthy threshold"
+  type        = number
+  default     = 2
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log retention"
+  type        = number
+  default     = 30
+}

--- a/deploy/terraform/azure-service-backend/README.md
+++ b/deploy/terraform/azure-service-backend/README.md
@@ -1,0 +1,46 @@
+# Azure Container Apps deployment
+
+This Terraform template deploys the dc43 service backends as a container app.
+It provisions:
+
+- A resource group
+- Log Analytics workspace for diagnostics
+- A Container Apps environment
+- A storage account and Azure Files share for the contract store
+- The container app with ingress enabled and registry credentials configured
+
+## Usage
+
+1. Build and push the `dc43-service-backends-http` image to an Azure Container
+   Registry that the deployment can reach.
+2. Create a `terraform.tfvars` file with the variables described below.
+3. Run Terraform from the repository root:
+
+   ```bash
+   terraform -chdir=deploy/terraform/azure-service-backend init
+   terraform -chdir=deploy/terraform/azure-service-backend apply
+   ```
+
+## Required variables
+
+| Name | Description |
+| ---- | ----------- |
+| `subscription_id` | Azure subscription that hosts the deployment. |
+| `resource_group_name` | Name of the resource group that will be created (or reused). |
+| `location` | Azure region (e.g. `westeurope`). |
+| `container_registry` | Login server of the Azure Container Registry (e.g. `myregistry.azurecr.io`). |
+| `container_registry_username` | Username for pulling the image. |
+| `container_registry_password` | Password or token for the registry. |
+| `image_tag` | Repository and tag of the container image (e.g. `dc43-service-backends-http:latest`). |
+| `backend_token` | Optional bearer token enforced by the service backends. |
+| `contract_storage` | Mount path used by the service to persist contracts. |
+
+Optional variables let you customise the container app name, ingress port, and
+scaling settings—see `variables.tf` for the full list.
+
+## Outputs
+
+- `container_app_fqdn` – Public FQDN of the container app.
+- `storage_account_name` – Azure Storage account that holds the contracts share.
+
+Use the storage account to upload existing contracts or to back up drafts.

--- a/deploy/terraform/azure-service-backend/main.tf
+++ b/deploy/terraform/azure-service-backend/main.tf
@@ -1,0 +1,140 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.72.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.1"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id = var.subscription_id
+}
+
+resource "azurerm_resource_group" "main" {
+  name     = var.resource_group_name
+  location = var.location
+}
+
+resource "random_string" "storage_suffix" {
+  length  = 6
+  upper   = false
+  special = false
+}
+
+resource "azurerm_log_analytics_workspace" "main" {
+  name                = "${var.resource_group_name}-law"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
+resource "azurerm_container_app_environment" "main" {
+  name                       = var.container_app_environment_name
+  location                   = azurerm_resource_group.main.location
+  resource_group_name        = azurerm_resource_group.main.name
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+}
+
+resource "azurerm_storage_account" "contracts" {
+  name                     = lower(substr(replace("${var.resource_group_name}${random_string.storage_suffix.result}", "-", ""), 0, 24))
+  location                 = azurerm_resource_group.main.location
+  resource_group_name      = azurerm_resource_group.main.name
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  enable_https_traffic_only = true
+}
+
+resource "azurerm_storage_share" "contracts" {
+  name                 = var.contract_share_name
+  storage_account_name = azurerm_storage_account.contracts.name
+  quota                = var.contract_share_quota_gb
+}
+
+resource "azurerm_container_app" "main" {
+  name                         = var.container_app_name
+  resource_group_name          = azurerm_resource_group.main.name
+  location                     = azurerm_resource_group.main.location
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  revision_mode                = "Single"
+
+  ingress {
+    external_enabled = true
+    target_port      = var.ingress_port
+    transport        = "Auto"
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  registry {
+    server               = var.container_registry
+    username             = var.container_registry_username
+    password_secret_name = "registry-password"
+  }
+
+  secret {
+    name  = "registry-password"
+    value = var.container_registry_password
+  }
+
+  secret {
+    name  = "contracts-storage-key"
+    value = azurerm_storage_account.contracts.primary_access_key
+  }
+
+  template {
+    min_replicas = var.min_replicas
+    max_replicas = var.max_replicas
+
+    container {
+      name   = "dc43-service-backends"
+      image  = "${var.container_registry}/${var.image_tag}"
+      cpu    = var.container_cpu
+      memory = var.container_memory
+
+      env {
+        name  = "DC43_BACKEND_TOKEN"
+        value = var.backend_token
+      }
+
+      env {
+        name  = "DC43_CONTRACT_STORE"
+        value = var.contract_storage
+      }
+
+      volume_mounts {
+        name      = "contracts"
+        mount_path = var.contract_storage
+      }
+    }
+
+    volume {
+      name                                = "contracts"
+      storage_type                         = "AzureFile"
+      storage_name                         = azurerm_storage_account.contracts.name
+      storage_account_name                 = azurerm_storage_account.contracts.name
+      share_name                           = azurerm_storage_share.contracts.name
+      storage_account_access_key_secret_ref = "contracts-storage-key"
+    }
+  }
+
+  tags = var.tags
+}
+
+output "container_app_fqdn" {
+  value = azurerm_container_app.main.latest_revision_fqdn
+}
+
+output "storage_account_name" {
+  value = azurerm_storage_account.contracts.name
+}

--- a/deploy/terraform/azure-service-backend/main.tf
+++ b/deploy/terraform/azure-service-backend/main.tf
@@ -119,12 +119,12 @@ resource "azurerm_container_app" "main" {
     }
 
     volume {
-      name                                = "contracts"
-      storage_type                         = "AzureFile"
-      storage_name                         = azurerm_storage_account.contracts.name
-      storage_account_name                 = azurerm_storage_account.contracts.name
-      share_name                           = azurerm_storage_share.contracts.name
-      storage_account_access_key_secret_ref = "contracts-storage-key"
+      name                                 = "contracts"
+      storage_type                          = "AzureFile"
+      storage_name                          = azurerm_storage_account.contracts.name
+      storage_account_name                  = azurerm_storage_account.contracts.name
+      share_name                            = azurerm_storage_share.contracts.name
+      storage_account_key_secret_name       = "contracts-storage-key"
     }
   }
 

--- a/deploy/terraform/azure-service-backend/variables.tf
+++ b/deploy/terraform/azure-service-backend/variables.tf
@@ -1,0 +1,107 @@
+variable "subscription_id" {
+  description = "Azure subscription ID"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Resource group for the deployment"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+}
+
+variable "container_registry" {
+  description = "Azure Container Registry login server"
+  type        = string
+}
+
+variable "container_registry_username" {
+  description = "Username used to pull the container image"
+  type        = string
+}
+
+variable "container_registry_password" {
+  description = "Password or token for the container registry"
+  type        = string
+  sensitive   = true
+}
+
+variable "image_tag" {
+  description = "Repository and tag of the container image"
+  type        = string
+}
+
+variable "backend_token" {
+  description = "Bearer token enforced by the service backends"
+  type        = string
+  default     = ""
+}
+
+variable "contract_storage" {
+  description = "Path mounted inside the container for contracts"
+  type        = string
+  default     = "/contracts"
+}
+
+variable "contract_share_name" {
+  description = "Azure Files share used for contract storage"
+  type        = string
+  default     = "contracts"
+}
+
+variable "contract_share_quota_gb" {
+  description = "Quota for the Azure Files share"
+  type        = number
+  default     = 100
+}
+
+variable "container_app_environment_name" {
+  description = "Name of the Container Apps environment"
+  type        = string
+  default     = "dc43-env"
+}
+
+variable "container_app_name" {
+  description = "Name of the Container App"
+  type        = string
+  default     = "dc43-service-backends"
+}
+
+variable "ingress_port" {
+  description = "Port exposed by the container"
+  type        = number
+  default     = 8001
+}
+
+variable "min_replicas" {
+  description = "Minimum number of container replicas"
+  type        = number
+  default     = 1
+}
+
+variable "max_replicas" {
+  description = "Maximum number of container replicas"
+  type        = number
+  default     = 3
+}
+
+variable "container_cpu" {
+  description = "CPU allocated to the container"
+  type        = string
+  default     = "0.5"
+}
+
+variable "container_memory" {
+  description = "Memory allocated to the container"
+  type        = string
+  default     = "1.0Gi"
+}
+
+variable "tags" {
+  description = "Tags applied to Azure resources"
+  type        = map(string)
+  default     = {}
+}

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,0 +1,14 @@
+# Getting started with dc43
+
+Pick the guide that matches your role and the environment you have access to. Each walkthrough links back to component reference
+material when you want to dive deeper.
+
+## Scenario index
+
+- [Operations: publish shared service backends](ops-service-backend.md)
+- [Spark developers: run dc43 fully locally](spark-local.md)
+- [Spark developers: consume shared dc43 services](spark-remote.md)
+- [Spark developers: generate pipeline stubs with the contracts app](spark-contract-app-helper.md)
+
+The guides assume you have a working Python 3.11 environment. When you work from a source checkout run `pip install -e .` from the
+repository root so editable installs pick up sibling packages.

--- a/docs/getting-started/ops-service-backend.md
+++ b/docs/getting-started/ops-service-backend.md
@@ -1,0 +1,159 @@
+# Operations: publish shared service backends
+
+Use this guide when you run the dc43 governance services for your teams. It walks through packaging the HTTP backends, validating
+configuration locally, and deploying them to Azure Container Apps or AWS ECS Fargate with the Terraform modules shipped in this
+repository.
+
+## Prerequisites
+
+- Docker CLI for building images.
+- Terraform 1.5+ for infrastructure deployments.
+- Access to a container registry (Azure Container Registry or Amazon ECR).
+- Python 3.11 to edit configuration and run local smoke tests.
+
+The governance services read their configuration from TOML files. Start from the templates under [`docs/templates/`](../templates/)
+and adapt [`service-backends-configuration.md`](../service-backends-configuration.md) to your storage toolchain (filesystem, Delta,
+Collibra, ...).
+
+## 1. Build and test the HTTP container
+
+The FastAPI surface lives under `deploy/http-backend`. Build the container with the HTTP extra so runtime dependencies are baked
+in. You can either invoke Docker directly or use the helper script that wraps the build and optional push:
+
+```bash
+# Build only
+python scripts/package_http_backend.py --image dc43-service-backends-http:local
+
+# Build and push to a registry in one step
+python scripts/package_http_backend.py \
+  --image myregistry.azurecr.io/dc43/governance:latest \
+  --push
+```
+
+When using the raw Docker CLI the equivalent command is:
+
+```bash
+docker build -t dc43-service-backends-http -f deploy/http-backend/Dockerfile .
+```
+
+Smoke test the image before publishing it. Mount a contract directory and inject the shared token the clients will use:
+
+```bash
+docker run --rm \
+  -p 8001:8001 \
+  -e DC43_BACKEND_TOKEN="super-secret" \
+  -v $(pwd)/contracts:/contracts \
+  dc43-service-backends-http
+```
+
+Visit `http://localhost:8001/docs` to confirm the FastAPI app boots. Stop the container once probes return `200 OK`.
+
+Push the image to your registry once the smoke test passes (replace the example tags with your own registry URI). The helper
+script automatically pushes when `--push` is provided. When pushing manually run:
+
+```bash
+docker tag dc43-service-backends-http myregistry.azurecr.io/dc43/governance:latest
+docker push myregistry.azurecr.io/dc43/governance:latest
+```
+
+## 2. (Optional) Publish the contracts helper UI
+
+Teams who prefer a ready-to-use portal for browsing datasets and generating
+integration stubs can run the contracts app as a companion service. Build the
+image with the same helper script, selecting the `contracts-app` target:
+
+```bash
+# Build the contracts app locally
+python scripts/package_http_backend.py --target contracts-app --image dc43-contracts-app:local
+
+# Build and push to a registry
+python scripts/package_http_backend.py \
+  --target contracts-app \
+  --image myregistry.azurecr.io/dc43/contracts-app:latest \
+  --push
+```
+
+Run the container next to the HTTP backend and point it at the shared service:
+
+```bash
+docker run --rm \
+  -p 8000:8000 \
+  -e DC43_CONTRACTS_APP_BACKEND_URL="https://governance.example.com" \
+  -e DC43_BACKEND_TOKEN="super-secret" \
+  myregistry.azurecr.io/dc43/contracts-app:latest
+```
+
+The [contracts app README](../../deploy/contracts-app/README.md) covers
+additional environment variables for embedded mode and local storage mounts.
+
+## 3. Provision shared infrastructure
+
+dc43 ships Terraform recipes you can adapt to your naming standards. Provide real values through `terraform.tfvars` instead of
+hard-coding secrets in `main.tf`.
+
+### 2.1 Azure Container Apps
+
+The module in [`deploy/terraform/azure-service-backend/`](../../deploy/terraform/azure-service-backend/) provisions the resource
+group dependencies, Log Analytics workspace, Container Apps environment, and the container app itself.
+
+Sample `terraform.tfvars`:
+
+```hcl
+subscription_id     = "00000000-0000-0000-0000-000000000000"
+resource_group_name = "rg-dc43-governance"
+location            = "westeurope"
+container_registry  = "myregistry.azurecr.io"
+image_tag           = "dc43/governance:latest"
+backend_token       = "super-secret"
+contract_storage    = "/contracts"
+```
+
+Apply the plan:
+
+```bash
+terraform -chdir=deploy/terraform/azure-service-backend init
+terraform -chdir=deploy/terraform/azure-service-backend apply
+```
+
+Bind Azure Files, Blob Storage, or another persistent volume to `contract_storage` if authors need durable drafts. The module
+outputs the HTTPS endpoint your Spark developers will target.
+
+### 2.2 AWS ECS Fargate
+
+The AWS stack under [`deploy/terraform/aws-service-backend/`](../../deploy/terraform/aws-service-backend/) creates an ECS cluster,
+Application Load Balancer, Fargate service, and EFS volume for contract drafts.
+
+Sample `terraform.tfvars`:
+
+```hcl
+aws_region                       = "eu-west-1"
+cluster_name                     = "dc43-governance"
+ecr_image_uri                    = "123456789012.dkr.ecr.eu-west-1.amazonaws.com/dc43/governance:latest"
+backend_token                    = "super-secret"
+contract_filesystem              = "dc43-contracts"
+private_subnet_ids               = ["subnet-aaaa", "subnet-bbbb"]
+load_balancer_subnet_ids         = ["subnet-cccc", "subnet-dddd"]
+service_security_group_id        = "sg-0123456789abcdef0"
+load_balancer_security_group_id  = "sg-abcdef0123456789"
+certificate_arn                  = "arn:aws:acm:eu-west-1:123456789012:certificate/uuid"
+```
+
+Apply the plan:
+
+```bash
+terraform -chdir=deploy/terraform/aws-service-backend init
+terraform -chdir=deploy/terraform/aws-service-backend apply
+```
+
+The module exposes the HTTPS listener URL after provisioning. Mount the generated EFS volume inside your pipelines if they need to
+share draft artifacts with the backends.
+
+## 4. Handoff to developers
+
+Once the service is reachable:
+
+1. Share the base URL (for example `https://governance.example.com`) and the `DC43_BACKEND_TOKEN` secret with developers.
+2. Clarify which storage backend powers the contract store so developers can replicate it locally for tests.
+3. Point teams to the [Spark developer guides](spark-local.md) and [remote service walkthrough](spark-remote.md).
+
+Keep your Terraform state in version control or a remote backend (Azure Storage, S3) so future updates stay reproducible.

--- a/docs/getting-started/spark-contract-app-helper.md
+++ b/docs/getting-started/spark-contract-app-helper.md
@@ -1,0 +1,83 @@
+# Spark developers: generate stubs with the contracts app helper
+
+The contracts app ships a visual "integration helper" that turns approved contracts into starter code for your pipelines. Follow
+these steps to run the helper locally or against the shared governance service.
+
+## 1. Install the contracts app
+
+The helper lives in the `dc43-contracts-app` package. Install it alongside the Spark extras so generated snippets match the APIs
+you use in notebooks:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install "dc43-contracts-app[spark]"
+```
+
+If you work from this repository run `pip install -e .[demo]` to install the demo dependencies and reuse editable sources.
+
+## 2. Point the app at a backend
+
+Choose one of the following configurations:
+
+- **Use the shared service** – set the backend URL and token you received from the operations team:
+
+  ```bash
+  export DC43_CONTRACTS_APP_BACKEND_MODE="remote"
+  export DC43_CONTRACTS_APP_BACKEND_URL="https://governance.example.com"
+  export DC43_BACKEND_TOKEN="super-secret"
+  ```
+
+- **Run everything locally** – leave the defaults in place and the helper will spawn the embedded backend with an in-memory
+  contract store. Populate it with sample contracts under `~/.config/dc43/contracts_app/contracts/` or point
+  `DC43_CONTRACT_STORE` to an existing repository of ODCS documents.
+
+## 3. Start the UI
+
+You can run the helper directly from your virtual environment or rely on a
+container published by the operations team.
+
+### Option A – run from source
+
+Launch the FastAPI app with Uvicorn:
+
+```bash
+uvicorn dc43_contracts_app.server:app --host 0.0.0.0 --port 8000
+```
+
+Visit `http://localhost:8000/integration-helper` in your browser. The landing
+page shows your available datasets on the left and the integration helper on the
+right.
+
+### Option B – run from a container
+
+If your platform team published the contracts app image, pull it and point the
+container at the governance backend:
+
+```bash
+docker run --rm \
+  -p 8000:8000 \
+  -e DC43_CONTRACTS_APP_BACKEND_URL="https://governance.example.com" \
+  -e DC43_BACKEND_TOKEN="super-secret" \
+  myregistry.azurecr.io/dc43/contracts-app:latest
+```
+
+Override `DC43_CONTRACTS_APP_BACKEND_MODE=embedded` and mount `/contracts` if
+you need the container to spawn the backend locally.
+
+## 4. Generate a Spark stub
+
+1. Select one or more contracts from the catalog tree.
+2. For each transformation, choose the integration strategy (Spark batch, Delta Live Tables, streaming, ...).
+3. Click **Generate stub**. The helper calls `/api/integration-helper/stub` to assemble a tailored Spark snippet.
+4. Copy the highlighted code block and paste it into your notebook or repo. The snippet already imports
+   `write_with_contract`, sets up the expected contract version, and includes TODO markers for business-specific logic.
+
+You can switch the target language from the dropdown above the stub (for example to Python or SQL) and regenerate as often as
+needed.
+
+## 5. Keep everything in sync
+
+- Refresh the page after the governance team publishes a new contract version so the helper pulls the latest schema.
+- Re-run the helper whenever you change integration strategies—the generator adapts to streaming vs. batch choices.
+- Pair this walkthrough with the [remote Spark guide](spark-remote.md) so the generated stub points at the correct backend.

--- a/docs/getting-started/spark-local.md
+++ b/docs/getting-started/spark-local.md
@@ -1,0 +1,79 @@
+# Spark developers: run dc43 fully locally
+
+Use this flow when you want to experiment with dc43 on a laptop, Databricks Repo, or CI runner without calling remote services.
+Everything runs in-process so you can validate contracts before your platform team provisions shared governance backends.
+
+## 1. Install the local extras
+
+Create (or reuse) a Python environment for your Spark notebooks and install the local extras:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install "dc43-service-backends[local]"
+pip install "dc43-integrations[spark]"
+```
+
+Working from a source checkout? Run `pip install -e .` from the repository root so notebooks pick up changes immediately.
+
+## 2. Configure the embedded backends
+
+The dc43 backends read their configuration from TOML. Copy the templates under [`docs/templates/`](../templates/) and adapt them
+to your environment. A minimal filesystem-backed configuration looks like this:
+
+```toml
+# dc43-service-backends.toml
+[contract_store]
+type = "filesystem"
+root = "~/contracts"
+
+[data_quality]
+type = "stub"
+
+[auth]
+token = ""  # leave empty when you embed everything in the same process
+```
+
+Point the loader at this file before you start orchestrations:
+
+```python
+from pathlib import Path
+from dc43_service_backends.config import load_config
+from dc43_service_backends.contracts import load_contract_store
+from dc43_integrations.spark.contracts import SparkContractLoader
+
+config = load_config(Path.home() / ".config/dc43/dc43-service-backends.toml")
+contract_store = load_contract_store(config.contract_store)
+loader = SparkContractLoader(spark, contract_store)
+contract = loader.load_latest_version("sales.orders")
+```
+
+## 3. Run pipelines with the local store
+
+You can now use helpers such as `write_with_contract` to validate schema alignment without an HTTP hop:
+
+```python
+from dc43_service_clients.contracts import LocalContractServiceClient
+from dc43_integrations.spark.io import write_with_contract, ContractVersionLocator
+
+service_client = LocalContractServiceClient(contract_store)
+
+write_with_contract(
+    df=orders_df,
+    contract_id="sales.orders",
+    contract_service=service_client,
+    expected_contract_version=">=0.1.0",
+    dataset_locator=ContractVersionLocator(dataset_version="latest"),
+    mode="append",
+    enforce=True,
+    auto_cast=True,
+)
+```
+
+Switch the `[contract_store]` section to `type = "collibra_stub"` when you want to emulate Collibra responses during unit tests.
+The stub ships with the same contract resolution flow as the HTTP service, making it easy to swap the real backend later.
+
+## 4. Next steps
+
+- Move to the [remote service guide](spark-remote.md) when your platform team provides a shared backend.
+- Explore the [component documentation](../component-contract-store.md) for deeper implementation details.

--- a/docs/getting-started/spark-remote.md
+++ b/docs/getting-started/spark-remote.md
@@ -1,0 +1,89 @@
+# Spark developers: consume shared dc43 services
+
+Follow this guide once your platform team exposes the dc43 governance services over HTTP. You will re-use the Spark helpers but
+point them at the shared backend instead of embedding the store locally.
+
+## 1. Gather connection details
+
+Ask your operations team for:
+
+- The base URL of the governance service (for example `https://governance.example.com`).
+- The shared `DC43_BACKEND_TOKEN` secret, if authentication is enabled.
+- Context about the backing contract store (filesystem, Collibra, Delta) so you can mirror behaviour locally when needed.
+
+## 2. Install the runtime helpers
+
+You only need the service clients (with the HTTP extra) and Spark integrations when the backend runs remotely:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install "dc43-service-clients[http]"
+pip install "dc43-integrations[spark]"
+```
+
+If you already installed the full stack using `pip install -e .` you can reuse that environment.
+
+## 3. Configure the remote backend
+
+Choose one of the following methods:
+
+### Environment variables
+
+```bash
+export DC43_CONTRACTS_APP_BACKEND_MODE="remote"
+export DC43_CONTRACTS_APP_BACKEND_URL="https://governance.example.com"
+export DC43_BACKEND_TOKEN="super-secret"
+```
+
+### Explicit configuration file
+
+Update your TOML configuration:
+
+```toml
+# dc43-service-backends.toml
+[contract_store]
+type = "remote"
+base_url = "https://governance.example.com"
+token = "super-secret"
+```
+
+Load it at runtime:
+
+```python
+from dc43_service_backends.config import load_config
+from dc43_service_clients.contracts import RemoteContractServiceClient
+
+config = load_config("/path/to/dc43-service-backends.toml")
+service_client = RemoteContractServiceClient(
+    base_url=config.contract_store.base_url or "",
+    token=config.contract_store.token,
+)
+```
+
+## 4. Enforce contracts from Spark
+
+Once the service client is initialised, the IO helpers behave the same way as in the local guide:
+
+```python
+from dc43_integrations.spark.io import write_with_contract, ContractVersionLocator
+
+write_with_contract(
+    df=orders_df,
+    contract_id="sales.orders",
+    contract_service=service_client,
+    expected_contract_version=">=0.1.0",
+    dataset_locator=ContractVersionLocator(dataset_version="latest"),
+    mode="append",
+    enforce=True,
+    auto_cast=True,
+)
+```
+
+Remote calls automatically forward the token you configured. You can continue using the Collibra stub for integration tests while
+pointing staging and production pipelines at the shared backend.
+
+## 5. Next steps
+
+- Ask your ops partners for the health endpoint to integrate with monitoring (`/health` on the FastAPI service).
+- Use the [contracts app helper](spark-contract-app-helper.md) to generate stubs for new pipelines.

--- a/scripts/package_http_backend.py
+++ b/scripts/package_http_backend.py
@@ -1,0 +1,109 @@
+"""Helper CLI for building and publishing dc43 service images.
+
+The script wraps a couple of `docker` invocations so operators can rely on a
+single command regardless of the target registry. It assumes the Docker CLI is
+installed and authenticated against the registry when `--push` is requested.
+
+Usage examples:
+
+```bash
+# HTTP backend image
+python scripts/package_http_backend.py --image myregistry.azurecr.io/dc43/governance:1.0.0
+
+# Contracts app image
+python scripts/package_http_backend.py --target contracts-app --image myregistry.azurecr.io/dc43/contracts-app:latest --push
+```
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+TARGETS: dict[str, Path] = {
+    "http-backend": ROOT / "deploy" / "http-backend" / "Dockerfile",
+    "contracts-app": ROOT / "deploy" / "contracts-app" / "Dockerfile",
+}
+
+
+def run(cmd: Sequence[str]) -> None:
+    """Run *cmd* and echo it before execution."""
+
+    print("$", " ".join(shlex.quote(part) for part in cmd))
+    subprocess.run(cmd, check=True)
+
+
+def build(image: str, dockerfile: Path, context: Path, platform: str | None) -> None:
+    """Build the requested image using *dockerfile*."""
+
+    command = [
+        "docker",
+        "build",
+        "-t",
+        image,
+        "-f",
+        str(dockerfile),
+    ]
+    if platform:
+        command.extend(["--platform", platform])
+    command.append(str(context))
+    run(command)
+
+
+def push(image: str) -> None:
+    """Push the previously built image to its registry."""
+
+    run(["docker", "push", image])
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--target",
+        choices=sorted(TARGETS),
+        default="http-backend",
+        help="Which service image to build.",
+    )
+    parser.add_argument(
+        "--image",
+        required=True,
+        help="Fully qualified image reference including registry and tag.",
+    )
+    parser.add_argument(
+        "--context",
+        type=Path,
+        default=ROOT,
+        help="Build context passed to docker build (defaults to repository root).",
+    )
+    parser.add_argument(
+        "--platform",
+        help="Optional target platform passed to docker build (for example linux/amd64).",
+    )
+    parser.add_argument(
+        "--push",
+        action="store_true",
+        help="Push the image to the remote registry after a successful build.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    build(
+        args.image,
+        dockerfile=TARGETS[args.target],
+        context=args.context,
+        platform=args.platform,
+    )
+    if args.push:
+        push(args.image)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Dockerfile and runtime guide for shipping the contracts app as a container
- extend the packaging helper CLI so it can build both the HTTP backend and contracts app images
- document the new container workflow in the operations and contracts helper getting-started guides

## Testing
- python -m compileall scripts/package_http_backend.py

------
https://chatgpt.com/codex/tasks/task_b_68de683dd7f0832e9a8b036dbb1d440e