### PR TITLE
Document and enforce contract status guardrails in demo and integrations

### DIFF
--- a/docs/component-write-violation-strategies.md
+++ b/docs/component-write-violation-strategies.md
@@ -82,7 +82,8 @@ override the final validation result after the adapter has revalidated the persi
   naming (`valid_suffix`, `reject_suffix`, separator).
 - `StrictWriteViolationStrategy` – wraps another strategy (e.g. split) and flips the final validation result to `ok=False` when
   violations or warnings persist. Pipelines see the failure via the returned `ValidationResult` while the underlying strategy can
-  still materialise auxiliary datasets for remediation.
+  still materialise auxiliary datasets for remediation. When the wrapped strategy exposes contract status guardrails (allowed
+  statuses, missing-status handling, etc.) the strict decorator now inherits those policies so enforcement stays consistent.
 
 The demo application bundles a "Split invalid rows" scenario that exercises the strategy end-to-end—see
 [`docs/demo-pipeline-scenarios.md`](demo-pipeline-scenarios.md) for a walkthrough and mermaid diagram covering the join, validation,

--- a/packages/dc43-contracts-app/CHANGELOG.md
+++ b/packages/dc43-contracts-app/CHANGELOG.md
@@ -1,0 +1,6 @@
+# dc43-contracts-app changelog
+
+## [Unreleased]
+### Added
+- Documented contract status guardrails in the integration helper stub and notes so generated Spark
+  snippets explain how to opt into draft or deprecated contracts safely.

--- a/packages/dc43-demo-app/CHANGELOG.md
+++ b/packages/dc43-demo-app/CHANGELOG.md
@@ -1,0 +1,12 @@
+# dc43-demo-app changelog
+
+## [Unreleased]
+### Added
+- Draft `orders_enriched:3.0.0` contract and curated demo scenario that boosts low amounts,
+  stamps placeholder customer segments, and logs contract-status overrides when drafts are allowed.
+- Contract status enforcement hooks in the demo pipeline with metadata describing the active policy
+  on reads and writes.
+
+### Changed
+- Updated pipeline scenarios, docs, and tests to reflect the default rejection of non-active
+  contracts and the new override workflow for development runs.

--- a/packages/dc43-demo-app/src/dc43_demo_app/demo_data/contracts/orders_enriched/3.0.0.json
+++ b/packages/dc43-demo-app/src/dc43_demo_app/demo_data/contracts/orders_enriched/3.0.0.json
@@ -1,0 +1,46 @@
+{
+  "version": "3.0.0",
+  "kind": "DataContract",
+  "apiVersion": "3.0.2",
+  "id": "orders_enriched",
+  "name": "Orders Enriched",
+  "description": {"usage": "Orders joined with customers plus draft loyalty metrics"},
+  "status": "draft",
+  "servers": [
+    {
+      "server": "local",
+      "type": "filesystem",
+      "path": "data/orders_enriched.parquet",
+      "format": "parquet",
+      "customProperties": [
+        {
+          "property": "dc43.core.versioning",
+          "value": {
+            "mode": "delta",
+            "timeTravel": "versionAsOf",
+            "notes": "Use dataset_version as Delta time travel hint"
+          }
+        },
+        {
+          "property": "dc43.pathPattern",
+          "value": "delta.`data/orders_enriched.parquet` versionAsOf={version}"
+        }
+      ]
+    }
+  ],
+  "schema": [
+    {
+      "name": "orders_enriched",
+      "properties": [
+        {"name": "order_id", "physicalType": "integer", "required": true},
+        {"name": "customer_id", "physicalType": "integer", "required": true},
+        {"name": "order_ts", "physicalType": "string", "required": true},
+        {"name": "amount", "physicalType": "double", "required": true,
+         "quality": [{"mustBeGreaterThan": 100}]},
+        {"name": "currency", "physicalType": "string", "required": true},
+        {"name": "customer_name", "physicalType": "string", "required": true},
+        {"name": "customer_segment", "physicalType": "string", "required": true}
+      ]
+    }
+  ]
+}

--- a/packages/dc43-demo-app/src/dc43_demo_app/demo_data/records/contract_meta.json
+++ b/packages/dc43-demo-app/src/dc43_demo_app/demo_data/records/contract_meta.json
@@ -4,5 +4,6 @@
   {"id": "customers", "version": "1.0.0", "status": "active"},
   {"id": "orders_enriched", "version": "1.0.0", "status": "active"},
   {"id": "orders_enriched", "version": "1.1.0", "status": "active"},
-  {"id": "orders_enriched", "version": "2.0.0", "status": "active"}
+  {"id": "orders_enriched", "version": "2.0.0", "status": "active"},
+  {"id": "orders_enriched", "version": "3.0.0", "status": "draft"}
 ]

--- a/packages/dc43-integrations/CHANGELOG.md
+++ b/packages/dc43-integrations/CHANGELOG.md
@@ -1,0 +1,10 @@
+# dc43-integrations changelog
+
+## [Unreleased]
+### Added
+- Enforced Open Data Contract status guardrails in the Spark read/write helpers with
+  configurable policies that default to rejecting non-active contracts and expose
+  overrides through the existing read and write strategies.
+- Documented the new contract status options across the demo pipeline, integration
+  helper, and docs to help teams opt into draft or deprecated contracts for
+  development scenarios while keeping production defaults strict.

--- a/packages/dc43-integrations/CHANGELOG.md
+++ b/packages/dc43-integrations/CHANGELOG.md
@@ -8,3 +8,7 @@
 - Documented the new contract status options across the demo pipeline, integration
   helper, and docs to help teams opt into draft or deprecated contracts for
   development scenarios while keeping production defaults strict.
+
+### Fixed
+- `StrictWriteViolationStrategy` now reuses the wrapped strategy's contract status
+  allowances so strict enforcement respects custom governance policies.

--- a/packages/dc43-integrations/src/dc43_integrations/spark/violation_strategy.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/violation_strategy.py
@@ -327,6 +327,57 @@ class StrictWriteViolationStrategy:
     base: WriteViolationStrategy = field(default_factory=NoOpWriteViolationStrategy)
     failure_message: str = "Validation recorded contract violations"
     fail_on_warnings: bool = False
+    allowed_contract_statuses: tuple[str, ...] | None = None
+    allow_missing_contract_status: bool | None = None
+    contract_status_case_insensitive: bool | None = None
+    contract_status_failure_message: str | None = None
+
+    def _contract_status_option(self, name: str, default: Any) -> Any:
+        value = getattr(self, name, None)
+        if value is not None:
+            return value
+
+        base = getattr(self, "base", None)
+        if base is None:
+            return default
+
+        inherited = getattr(base, name, None)
+        if inherited is not None:
+            return inherited
+
+        return default
+
+    def validate_contract_status(
+        self,
+        *,
+        contract: OpenDataContractStandard,
+        enforce: bool,
+        operation: str,
+    ) -> None:
+        validator = getattr(self.base, "validate_contract_status", None)
+        if validator is not None:
+            validator(contract=contract, enforce=enforce, operation=operation)
+            return
+
+        from .io import _validate_contract_status  # local import to avoid cycles
+
+        _validate_contract_status(
+            contract=contract,
+            enforce=enforce,
+            operation=operation,
+            allowed_statuses=self._contract_status_option(
+                "allowed_contract_statuses", ("active",)
+            ),
+            allow_missing=self._contract_status_option(
+                "allow_missing_contract_status", True
+            ),
+            case_insensitive=self._contract_status_option(
+                "contract_status_case_insensitive", True
+            ),
+            failure_message=self._contract_status_option(
+                "contract_status_failure_message", None
+            ),
+        )
 
     def plan(self, context: WriteStrategyContext) -> WritePlan:  # noqa: D401 - short docstring
         base_plan = self.base.plan(context)

--- a/packages/dc43-integrations/src/dc43_integrations/spark/violation_strategy.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/violation_strategy.py
@@ -118,6 +118,30 @@ class WriteViolationStrategy(Protocol):
 class NoOpWriteViolationStrategy:
     """Default strategy that keeps the original behaviour intact."""
 
+    allowed_contract_statuses: tuple[str, ...] = ("active",)
+    allow_missing_contract_status: bool = True
+    contract_status_case_insensitive: bool = True
+    contract_status_failure_message: str | None = None
+
+    def validate_contract_status(
+        self,
+        *,
+        contract: OpenDataContractStandard,
+        enforce: bool,
+        operation: str,
+    ) -> None:
+        from .io import _validate_contract_status  # local import to avoid cycles
+
+        _validate_contract_status(
+            contract=contract,
+            enforce=enforce,
+            operation=operation,
+            allowed_statuses=self.allowed_contract_statuses,
+            allow_missing=self.allow_missing_contract_status,
+            case_insensitive=self.contract_status_case_insensitive,
+            failure_message=self.contract_status_failure_message,
+        )
+
     def plan(self, context: WriteStrategyContext) -> WritePlan:  # noqa: D401 - short docstring
         return WritePlan(primary=context.base_request())
 
@@ -132,6 +156,29 @@ class SplitWriteViolationStrategy:
     include_reject: bool = True
     write_primary_on_violation: bool = False
     dataset_suffix_separator: str = "::"
+    allowed_contract_statuses: tuple[str, ...] = ("active",)
+    allow_missing_contract_status: bool = True
+    contract_status_case_insensitive: bool = True
+    contract_status_failure_message: str | None = None
+
+    def validate_contract_status(
+        self,
+        *,
+        contract: OpenDataContractStandard,
+        enforce: bool,
+        operation: str,
+    ) -> None:
+        from .io import _validate_contract_status  # local import to avoid cycles
+
+        _validate_contract_status(
+            contract=contract,
+            enforce=enforce,
+            operation=operation,
+            allowed_statuses=self.allowed_contract_statuses,
+            allow_missing=self.allow_missing_contract_status,
+            case_insensitive=self.contract_status_case_insensitive,
+            failure_message=self.contract_status_failure_message,
+        )
 
     def plan(self, context: WriteStrategyContext) -> WritePlan:  # noqa: D401 - short docstring
         result = context.validation


### PR DESCRIPTION
## Summary
- add Unreleased changelog entries for dc43-integrations, dc43-demo-app, and dc43-contracts-app
- enforce contract status policies in the demo pipeline, add the draft 3.0.0 contract, and refresh pipeline docs/tests
- document contract status guardrails in the contracts app integration helper

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68de89c225b8832ebb6be47c35d072a4