### PR TITLE
Add contract-specific Spark helpers and Collibra ODPS backend

### DIFF
--- a/docs/component-integration-layer.md
+++ b/docs/component-integration-layer.md
@@ -38,6 +38,45 @@ Adapters should stay thin: they orchestrate the component interfaces
 rather than re-implementing them. Implementations can target Spark, SQL
 warehouses, streaming frameworks, REST services, or ELT tools.
 
+## Data product bindings and draft enforcement
+
+Spark pipelines can now declare Open Data Product Standard (ODPS) bindings when
+calling the integration helpers. Dedicated wrappers surface the most common
+flows:
+
+- `read_from_contract` / `write_with_contract_id` accept contract identifiers
+  directly, keeping the signature laser-focused on contract lookups and
+  validation knobs.
+- `read_from_data_product` / `write_to_data_product` resolve contracts directly
+  from the data product service when a binding points at an existing port.
+
+All helpers forward to `read_with_contract` / `write_with_contract` under the
+hood so callers can mix and match parameters as needed. Passing both a binding
+and a contract id continues to pin the run to the requested contract while
+recording the port metadata.
+
+Whenever a read or write registers a new input/output port the integration
+layer aborts the pipeline: the service returns a draft ODPS document and dc43
+raises to guarantee the draft is reviewed before the pipeline is rerun. The
+registration payload includes the draft version so orchestration logs can point
+data stewards at the exact ODPS revision that needs attention. Pipelines that
+should continue must pre-register their ports or run a preparatory job that
+creates the draft out-of-band.
+
+The data product backend ships with the in-memory implementation used by tests,
+a filesystem-backed variant (`FilesystemDataProductServiceBackend`) that
+serialises ODPS documents as JSON compliant with the official schema, and a
+Collibra-aware backend (`CollibraDataProductServiceBackend`). The latter pairs
+with either `StubCollibraDataProductAdapter`—a filesystem stub suitable for
+local development—or `HttpCollibraDataProductAdapter` when pointing at a live
+Collibra deployment. This makes it easy to capture the resulting draft
+documents alongside contract files in source control or wire the same pipeline
+to Collibra without code changes.
+
+> Run `pytest packages/dc43-integrations/tests/test_integration.py -k
+> data_product_pipeline_roundtrip -q` to exercise the full
+> “data product → intermediate contract → data product” hand-off.
+
 ## Implementation catalog
 
 Technology-specific guides live under

--- a/docs/demo-pipeline-scenarios.md
+++ b/docs/demo-pipeline-scenarios.md
@@ -11,6 +11,30 @@ stores the verdicts returned by read and write validation, captures the
 metrics produced by the quality rules, and records draft contract versions so
 the UI mirrors what a catalog-integrated deployment would display.
 
+## Data product roundtrip pipeline
+
+The integration test suite now documents how a pipeline can stitch data product
+bindings and raw contracts together without manual port registration. The flow
+is simple:
+
+1. Read from an existing data product output using `read_from_data_product` so
+   the contract is resolved automatically.
+2. Persist an intermediate dataset that is only governed by a contract with
+   `write_with_contract_id` (the contract-only helper).
+3. Load the intermediate dataset with `read_from_contract` and publish the
+   final slice through `write_to_data_product`, which registers the output port
+   if it already exists and aborts the pipeline if a draft must be created.
+
+Recreate the run locally with:
+
+```bash
+pytest packages/dc43-integrations/tests/test_integration.py \
+    -k data_product_pipeline_roundtrip -q
+```
+
+The log output highlights when the pipeline would have halted because of an ODPS
+draft, making it clear how draft enforcement integrates with orchestration.
+
 ```mermaid
 graph TD
     Orders["orders latest → 2024-01-01\ncontract orders:1.1.0"] --> Join

--- a/docs/service-backends-configuration.md
+++ b/docs/service-backends-configuration.md
@@ -148,3 +148,23 @@ Copy the relevant file to a writable location, adjust the values to match your
 environment, and point the applications at the resulting TOML using the
 environment variables listed above or by passing the path directly to the
 respective `load_config()` helper.
+
+## Data product backends
+
+The service stack now exposes ODPS data product endpoints alongside the
+contract and governance APIs. Three implementations ship with the repository:
+
+- `LocalDataProductServiceBackend` keeps definitions in memory and is ideal for
+  unit tests.
+- `FilesystemDataProductServiceBackend` persists each ODPS document as a JSON
+  file that matches the official schema, making it a good fit for local
+  sandboxes and CI environments.
+- `CollibraDataProductServiceBackend` delegates persistence to Collibra through
+  pluggable adapters. Pair it with
+  `StubCollibraDataProductAdapter` (filesystem-backed and perfect for tests) or
+  `HttpCollibraDataProductAdapter` when pointing at a live Collibra deployment.
+
+Deployments that back onto Collibra can therefore reuse the same
+`DataProductServiceClient` APIs as local runs. Swap between in-memory,
+filesystem, and Collibra-backed options without touching pipeline code while
+retaining draft-registration behaviour across environments.

--- a/packages/dc43-integrations/CHANGELOG.md
+++ b/packages/dc43-integrations/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Documented the new contract status options across the demo pipeline, integration
   helper, and docs to help teams opt into draft or deprecated contracts for
   development scenarios while keeping production defaults strict.
+- Added contract- and data-product-specific helpers
+  (`read_from_contract`, `write_with_contract_id`, `read_from_data_product`,
+  `write_to_data_product`) that resolve ODPS contracts automatically and abort
+  pipelines when port registration produces a draft version.
 
 ### Fixed
 - `StrictWriteViolationStrategy` now reuses the wrapped strategy's contract status

--- a/packages/dc43-integrations/CHANGELOG.md
+++ b/packages/dc43-integrations/CHANGELOG.md
@@ -16,3 +16,7 @@
 ### Fixed
 - `StrictWriteViolationStrategy` now reuses the wrapped strategy's contract status
   allowances so strict enforcement respects custom governance policies.
+- Spark writes that overwrite their source path now checkpoint the aligned dataframe
+  before executing so contract-enforced data product registrations succeed without
+  triggering spurious "file not found" failures, and `write_to_data_product`
+  accepts explicit contract identifiers for the final stage of DP pipelines.

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io.py
@@ -31,6 +31,13 @@ from pyspark.sql import DataFrame, SparkSession
 from dc43_service_clients.contracts.client.interface import ContractServiceClient
 from dc43_service_clients.data_quality.client.interface import DataQualityServiceClient
 from dc43_service_clients.data_quality import ObservationPayload, ValidationResult
+from dc43_service_clients.data_products import (
+    DataProductInputBinding,
+    DataProductOutputBinding,
+    DataProductServiceClient,
+    normalise_input_binding,
+    normalise_output_binding,
+)
 from dc43_service_clients.governance.client.interface import GovernanceServiceClient
 from dc43_service_clients.governance import PipelineContext, normalise_pipeline_context
 from .data_quality import (
@@ -979,6 +986,8 @@ def read_with_contract(
     auto_cast: bool = True,
     data_quality_service: Optional[DataQualityServiceClient] = None,
     governance_service: Optional[GovernanceServiceClient] = None,
+    data_product_service: Optional[DataProductServiceClient] = None,
+    data_product_input: Optional[DataProductInputBinding | Mapping[str, object]] = None,
     dataset_locator: Optional[DatasetLocatorStrategy] = None,
     status_strategy: Optional[ReadStatusStrategy] = None,
     pipeline_context: Optional[PipelineContextLike] = None,
@@ -1002,6 +1011,8 @@ def read_with_contract(
     auto_cast: bool = True,
     data_quality_service: Optional[DataQualityServiceClient] = None,
     governance_service: Optional[GovernanceServiceClient] = None,
+    data_product_service: Optional[DataProductServiceClient] = None,
+    data_product_input: Optional[DataProductInputBinding | Mapping[str, object]] = None,
     dataset_locator: Optional[DatasetLocatorStrategy] = None,
     status_strategy: Optional[ReadStatusStrategy] = None,
     pipeline_context: Optional[PipelineContextLike] = None,
@@ -1025,6 +1036,8 @@ def read_with_contract(
     auto_cast: bool = True,
     data_quality_service: Optional[DataQualityServiceClient] = None,
     governance_service: Optional[GovernanceServiceClient] = None,
+    data_product_service: Optional[DataProductServiceClient] = None,
+    data_product_input: Optional[DataProductInputBinding | Mapping[str, object]] = None,
     dataset_locator: Optional[DatasetLocatorStrategy] = None,
     status_strategy: Optional[ReadStatusStrategy] = None,
     pipeline_context: Optional[PipelineContextLike] = None,
@@ -1048,6 +1061,8 @@ def read_with_contract(
     # Governance / DQ orchestration
     data_quality_service: Optional[DataQualityServiceClient] = None,
     governance_service: Optional[GovernanceServiceClient] = None,
+    data_product_service: Optional[DataProductServiceClient] = None,
+    data_product_input: Optional[DataProductInputBinding | Mapping[str, object]] = None,
     dataset_locator: Optional[DatasetLocatorStrategy] = None,
     status_strategy: Optional[ReadStatusStrategy] = None,
     pipeline_context: Optional[PipelineContextLike] = None,
@@ -1063,6 +1078,50 @@ def read_with_contract(
     """
     locator = dataset_locator or ContractFirstDatasetLocator()
     dq_status_handler = status_strategy or DefaultReadStatusStrategy()
+
+    dp_binding = normalise_input_binding(data_product_input)
+    dp_service = data_product_service
+    resolved_contract_id = contract_id
+    resolved_expected_version = expected_contract_version
+    if (
+        resolved_contract_id is None
+        and dp_service is not None
+        and dp_binding is not None
+        and dp_binding.source_data_product
+        and dp_binding.source_output_port
+    ):
+        try:
+            contract_ref = dp_service.resolve_output_contract(
+                data_product_id=dp_binding.source_data_product,
+                port_name=dp_binding.source_output_port,
+            )
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception(
+                "Failed to resolve output contract for data product %s port %s",
+                dp_binding.source_data_product,
+                dp_binding.source_output_port,
+            )
+        else:
+            if contract_ref is None:
+                logger.warning(
+                    "Data product %s output port %s did not provide a contract reference",
+                    dp_binding.source_data_product,
+                    dp_binding.source_output_port,
+                )
+            else:
+                resolved_contract_id, resolved_expected_version = contract_ref
+                logger.info(
+                    "Resolved contract %s:%s from data product %s output %s",
+                    resolved_contract_id,
+                    resolved_expected_version,
+                    dp_binding.source_data_product,
+                    dp_binding.source_output_port,
+                )
+
+    if resolved_contract_id is not None:
+        contract_id = resolved_contract_id
+    if expected_contract_version is None and resolved_expected_version is not None:
+        expected_contract_version = resolved_expected_version
 
     contract: Optional[OpenDataContractStandard] = None
     if contract_id:
@@ -1229,7 +1288,130 @@ def read_with_contract(
             ),
         )
 
+    if dp_service and dp_binding and contract is not None:
+        if not dp_binding.data_product:
+            logger.warning(
+                "data_product_input requires a data_product identifier to register input ports",
+            )
+        else:
+            port_name = (
+                dp_binding.port_name
+                or dp_binding.source_output_port
+                or contract.id
+            )
+            try:
+                registration = dp_service.register_input_port(
+                    data_product_id=dp_binding.data_product,
+                    port_name=port_name,
+                    contract_id=contract.id,
+                    contract_version=contract.version,
+                    bump=dp_binding.bump,
+                    custom_properties=dp_binding.custom_properties,
+                    source_data_product=dp_binding.source_data_product,
+                    source_output_port=dp_binding.source_output_port,
+                )
+            except Exception:  # pragma: no cover - defensive logging
+                logger.exception(
+                    "Failed to register data product input port %s on %s",
+                    port_name,
+                    dp_binding.data_product,
+                )
+            else:
+                if registration.changed:
+                    product = registration.product
+                    version = product.version or "<unknown>"
+                    if (product.status or "").lower() != "draft":
+                        raise RuntimeError(
+                            "Data product input registration did not produce a draft version"
+                        )
+                    raise RuntimeError(
+                        "Data product %s input port %s requires review at version %s"
+                        % (dp_binding.data_product, port_name, version)
+                    )
+
     return (df, status) if return_status else df
+
+
+def read_from_contract(
+    spark: SparkSession,
+    *,
+    contract_id: str,
+    contract_service: ContractServiceClient,
+    expected_contract_version: Optional[str] = None,
+    format: Optional[str] = None,
+    path: Optional[str] = None,
+    table: Optional[str] = None,
+    options: Optional[Dict[str, str]] = None,
+    enforce: bool = True,
+    auto_cast: bool = True,
+    data_quality_service: Optional[DataQualityServiceClient] = None,
+    governance_service: Optional[GovernanceServiceClient] = None,
+    dataset_locator: Optional[DatasetLocatorStrategy] = None,
+    status_strategy: Optional[ReadStatusStrategy] = None,
+    pipeline_context: Optional[PipelineContextLike] = None,
+    return_status: bool = True,
+) -> DataFrame | Tuple[DataFrame, Optional[ValidationResult]]:
+    """Read and validate a dataset by referencing a contract identifier directly."""
+
+    return read_with_contract(
+        spark,
+        contract_id=contract_id,
+        contract_service=contract_service,
+        expected_contract_version=expected_contract_version,
+        format=format,
+        path=path,
+        table=table,
+        options=options,
+        enforce=enforce,
+        auto_cast=auto_cast,
+        data_quality_service=data_quality_service,
+        governance_service=governance_service,
+        dataset_locator=dataset_locator,
+        status_strategy=status_strategy,
+        pipeline_context=pipeline_context,
+        return_status=return_status,
+    )
+
+
+def read_from_data_product(
+    spark: SparkSession,
+    *,
+    data_product_service: DataProductServiceClient,
+    data_product_input: DataProductInputBinding | Mapping[str, object],
+    contract_service: Optional[ContractServiceClient] = None,
+    format: Optional[str] = None,
+    path: Optional[str] = None,
+    table: Optional[str] = None,
+    options: Optional[Dict[str, str]] = None,
+    enforce: bool = True,
+    auto_cast: bool = True,
+    data_quality_service: Optional[DataQualityServiceClient] = None,
+    governance_service: Optional[GovernanceServiceClient] = None,
+    dataset_locator: Optional[DatasetLocatorStrategy] = None,
+    status_strategy: Optional[ReadStatusStrategy] = None,
+    pipeline_context: Optional[PipelineContextLike] = None,
+    return_status: bool = True,
+) -> DataFrame | Tuple[DataFrame, Optional[ValidationResult]]:
+    """Read a dataset by resolving the contract from a data product input binding."""
+
+    return read_with_contract(
+        spark,
+        contract_service=contract_service,
+        data_product_service=data_product_service,
+        data_product_input=data_product_input,
+        format=format,
+        path=path,
+        table=table,
+        options=options,
+        enforce=enforce,
+        auto_cast=auto_cast,
+        data_quality_service=data_quality_service,
+        governance_service=governance_service,
+        dataset_locator=dataset_locator,
+        status_strategy=status_strategy,
+        pipeline_context=pipeline_context,
+        return_status=return_status,
+    )
 
 
 # Overloads allow static checkers to track the tuple return when ``return_status``
@@ -1250,10 +1432,12 @@ def write_with_contract(
     auto_cast: bool = True,
     data_quality_service: Optional[DataQualityServiceClient] = None,
     governance_service: Optional[GovernanceServiceClient] = None,
+    data_product_service: Optional[DataProductServiceClient] = None,
+    data_product_output: Optional[DataProductOutputBinding | Mapping[str, object]] = None,
     dataset_locator: Optional[DatasetLocatorStrategy] = None,
     pipeline_context: Optional[PipelineContextLike] = None,
     return_status: Literal[True],
-    violation_strategy: Optional[WriteViolationStrategy] = ...,
+    violation_strategy: Optional[WriteViolationStrategy] = ..., 
 ) -> tuple[ValidationResult, Optional[ValidationResult]]:
     ...
 
@@ -1274,10 +1458,12 @@ def write_with_contract(
     auto_cast: bool = True,
     data_quality_service: Optional[DataQualityServiceClient] = None,
     governance_service: Optional[GovernanceServiceClient] = None,
+    data_product_service: Optional[DataProductServiceClient] = None,
+    data_product_output: Optional[DataProductOutputBinding | Mapping[str, object]] = None,
     dataset_locator: Optional[DatasetLocatorStrategy] = None,
     pipeline_context: Optional[PipelineContextLike] = None,
     return_status: Literal[False] = False,
-    violation_strategy: Optional[WriteViolationStrategy] = ...,
+    violation_strategy: Optional[WriteViolationStrategy] = ..., 
 ) -> ValidationResult:
     ...
 
@@ -1297,6 +1483,8 @@ def write_with_contract(
     auto_cast: bool = True,
     data_quality_service: Optional[DataQualityServiceClient] = None,
     governance_service: Optional[GovernanceServiceClient] = None,
+    data_product_service: Optional[DataProductServiceClient] = None,
+    data_product_output: Optional[DataProductOutputBinding | Mapping[str, object]] = None,
     dataset_locator: Optional[DatasetLocatorStrategy] = None,
     pipeline_context: Optional[PipelineContextLike] = None,
     return_status: bool = False,
@@ -1311,6 +1499,60 @@ def write_with_contract(
     locator = dataset_locator or ContractFirstDatasetLocator()
 
     strategy = violation_strategy or NoOpWriteViolationStrategy()
+    dp_output_binding = normalise_output_binding(data_product_output)
+    dp_service = data_product_service
+
+    resolved_contract_id = contract_id
+    resolved_expected_version = expected_contract_version
+    if (
+        resolved_contract_id is None
+        and dp_service is not None
+        and dp_output_binding is not None
+        and dp_output_binding.data_product
+        and dp_output_binding.port_name
+    ):
+        try:
+            contract_ref = dp_service.resolve_output_contract(
+                data_product_id=dp_output_binding.data_product,
+                port_name=dp_output_binding.port_name,
+            )
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception(
+                "Failed to resolve output contract for data product %s port %s",
+                dp_output_binding.data_product,
+                dp_output_binding.port_name,
+            )
+        else:
+            if contract_ref is None:
+                logger.warning(
+                    "Data product %s output port %s did not provide a contract reference",
+                    dp_output_binding.data_product,
+                    dp_output_binding.port_name,
+                )
+            else:
+                resolved_contract_id, resolved_expected_version = contract_ref
+                logger.info(
+                    "Resolved contract %s:%s from data product %s output %s",
+                    resolved_contract_id,
+                    resolved_expected_version,
+                    dp_output_binding.data_product,
+                    dp_output_binding.port_name,
+                )
+    elif (
+        resolved_contract_id is None
+        and dp_output_binding is not None
+        and dp_output_binding.data_product
+        and not dp_output_binding.port_name
+    ):
+        logger.warning(
+            "data_product_output for %s cannot resolve a contract without port_name",
+            dp_output_binding.data_product,
+        )
+
+    if resolved_contract_id is not None:
+        contract_id = resolved_contract_id
+    if expected_contract_version is None and resolved_expected_version is not None:
+        expected_contract_version = resolved_expected_version
 
     contract: Optional[OpenDataContractStandard] = None
     if contract_id:
@@ -1415,6 +1657,43 @@ def write_with_contract(
             if enforce:
                 raise ValueError(f"Contract validation failed: {result.errors}")
 
+    def _register_output_port_if_needed() -> None:
+        if dp_service is None or dp_output_binding is None or contract is None:
+            return
+        if not dp_output_binding.data_product:
+            logger.warning(
+                "data_product_output requires a data_product identifier to register output ports",
+            )
+            return
+        port_name = dp_output_binding.port_name or contract.id
+        try:
+            registration = dp_service.register_output_port(
+                data_product_id=dp_output_binding.data_product,
+                port_name=port_name,
+                contract_id=contract.id,
+                contract_version=contract.version,
+                bump=dp_output_binding.bump,
+                custom_properties=dp_output_binding.custom_properties,
+            )
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception(
+                "Failed to register data product output port %s on %s",
+                port_name,
+                dp_output_binding.data_product,
+            )
+        else:
+            if registration.changed:
+                product = registration.product
+                version = product.version or "<unknown>"
+                if (product.status or "").lower() != "draft":
+                    raise RuntimeError(
+                        "Data product output registration did not produce a draft version"
+                    )
+                raise RuntimeError(
+                    "Data product %s output port %s requires review at version %s"
+                    % (dp_output_binding.data_product, port_name, version)
+                )
+
     options_dict: Dict[str, str] = {}
     if resolution.write_options:
         options_dict.update(resolution.write_options)
@@ -1487,6 +1766,7 @@ def write_with_contract(
 
     if not requests:
         final_result = plan.result_factory() if plan.result_factory else result
+        _register_output_port_if_needed()
         if return_status:
             return final_result, None
         return final_result
@@ -1648,9 +1928,99 @@ def write_with_contract(
 
                 primary_status.details = primary_details
 
+    _register_output_port_if_needed()
+
     if return_status:
         return final_result, primary_status
     return final_result
+
+
+def write_with_contract_id(
+    *,
+    df: DataFrame,
+    contract_id: str,
+    contract_service: ContractServiceClient,
+    expected_contract_version: Optional[str] = None,
+    path: Optional[str] = None,
+    table: Optional[str] = None,
+    format: Optional[str] = None,
+    options: Optional[Dict[str, str]] = None,
+    mode: str = "append",
+    enforce: bool = True,
+    auto_cast: bool = True,
+    data_quality_service: Optional[DataQualityServiceClient] = None,
+    governance_service: Optional[GovernanceServiceClient] = None,
+    dataset_locator: Optional[DatasetLocatorStrategy] = None,
+    pipeline_context: Optional[PipelineContextLike] = None,
+    return_status: bool = False,
+    violation_strategy: Optional[WriteViolationStrategy] = None,
+) -> Any:
+    """Write a dataset while enforcing a specific contract identifier."""
+
+    return write_with_contract(
+        df=df,
+        contract_id=contract_id,
+        contract_service=contract_service,
+        expected_contract_version=expected_contract_version,
+        path=path,
+        table=table,
+        format=format,
+        options=options,
+        mode=mode,
+        enforce=enforce,
+        auto_cast=auto_cast,
+        data_quality_service=data_quality_service,
+        governance_service=governance_service,
+        dataset_locator=dataset_locator,
+        pipeline_context=pipeline_context,
+        return_status=return_status,
+        violation_strategy=violation_strategy,
+    )
+
+
+def write_to_data_product(
+    *,
+    df: DataFrame,
+    data_product_service: DataProductServiceClient,
+    data_product_output: DataProductOutputBinding | Mapping[str, object],
+    contract_service: Optional[ContractServiceClient] = None,
+    expected_contract_version: Optional[str] = None,
+    path: Optional[str] = None,
+    table: Optional[str] = None,
+    format: Optional[str] = None,
+    options: Optional[Dict[str, str]] = None,
+    mode: str = "append",
+    enforce: bool = True,
+    auto_cast: bool = True,
+    data_quality_service: Optional[DataQualityServiceClient] = None,
+    governance_service: Optional[GovernanceServiceClient] = None,
+    dataset_locator: Optional[DatasetLocatorStrategy] = None,
+    pipeline_context: Optional[PipelineContextLike] = None,
+    return_status: bool = False,
+    violation_strategy: Optional[WriteViolationStrategy] = None,
+) -> Any:
+    """Write a dataset and register it against a data product output binding."""
+
+    return write_with_contract(
+        df=df,
+        contract_service=contract_service,
+        data_product_service=data_product_service,
+        data_product_output=data_product_output,
+        expected_contract_version=expected_contract_version,
+        path=path,
+        table=table,
+        format=format,
+        options=options,
+        mode=mode,
+        enforce=enforce,
+        auto_cast=auto_cast,
+        data_quality_service=data_quality_service,
+        governance_service=governance_service,
+        dataset_locator=dataset_locator,
+        pipeline_context=pipeline_context,
+        return_status=return_status,
+        violation_strategy=violation_strategy,
+    )
 
 
 def _execute_write_request(

--- a/packages/dc43-service-backends/CHANGELOG.md
+++ b/packages/dc43-service-backends/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 ### Added
+- Data product backends now consume the shared ODPS helpers from
+  `dc43-service-clients` so they can operate without the core package during
+  isolated builds.
 - Added `DataProductRegistrationResult` metadata so callers can detect when ODPS
   registrations create new drafts.
 - Introduced `FilesystemDataProductServiceBackend` which persists ODPS documents

--- a/packages/dc43-service-backends/CHANGELOG.md
+++ b/packages/dc43-service-backends/CHANGELOG.md
@@ -1,0 +1,10 @@
+# dc43-service-backends changelog
+
+## [Unreleased]
+### Added
+- Added `DataProductRegistrationResult` metadata so callers can detect when ODPS
+  registrations create new drafts.
+- Introduced `FilesystemDataProductServiceBackend` which persists ODPS documents
+  as JSON compatible with the standard schema for local and CI environments.
+- Added `CollibraDataProductServiceBackend` alongside stub and HTTP adapters so
+  deployments backed by Collibra can expose ODPS APIs without custom glue code.

--- a/packages/dc43-service-backends/src/dc43_service_backends/__init__.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     "auth",
     "config",
     "contracts",
+    "data_products",
     "data_quality",
     "governance",
     "server",

--- a/packages/dc43-service-backends/src/dc43_service_backends/data_products/__init__.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/data_products/__init__.py
@@ -1,0 +1,24 @@
+"""Data product service backends."""
+
+from .backend import (
+    CollibraDataProductAdapter,
+    CollibraDataProductServiceBackend,
+    DataProductRegistrationResult,
+    DataProductServiceBackend,
+    FilesystemDataProductServiceBackend,
+    HttpCollibraDataProductAdapter,
+    LocalDataProductServiceBackend,
+    StubCollibraDataProductAdapter,
+)
+
+__all__ = [
+    "CollibraDataProductAdapter",
+    "CollibraDataProductServiceBackend",
+    "DataProductRegistrationResult",
+    "DataProductServiceBackend",
+    "FilesystemDataProductServiceBackend",
+    "HttpCollibraDataProductAdapter",
+    "LocalDataProductServiceBackend",
+    "StubCollibraDataProductAdapter",
+]
+

--- a/packages/dc43-service-backends/src/dc43_service_backends/data_products/backend/__init__.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/data_products/backend/__init__.py
@@ -1,0 +1,21 @@
+"""Data product backend implementations."""
+
+from .collibra import (
+    CollibraDataProductAdapter,
+    CollibraDataProductServiceBackend,
+    HttpCollibraDataProductAdapter,
+    StubCollibraDataProductAdapter,
+)
+from .interface import DataProductRegistrationResult, DataProductServiceBackend
+from .local import FilesystemDataProductServiceBackend, LocalDataProductServiceBackend
+
+__all__ = [
+    "DataProductRegistrationResult",
+    "DataProductServiceBackend",
+    "FilesystemDataProductServiceBackend",
+    "LocalDataProductServiceBackend",
+    "CollibraDataProductAdapter",
+    "CollibraDataProductServiceBackend",
+    "HttpCollibraDataProductAdapter",
+    "StubCollibraDataProductAdapter",
+]

--- a/packages/dc43-service-backends/src/dc43_service_backends/data_products/backend/collibra.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/data_products/backend/collibra.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import tempfile
 from typing import Dict, Mapping, Optional, Protocol, Sequence
 
-from dc43.core.odps import (
+from dc43_service_clients.odps import (
     DataProductInputPort,
     DataProductOutputPort,
     OpenDataProductStandard,

--- a/packages/dc43-service-backends/src/dc43_service_backends/data_products/backend/collibra.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/data_products/backend/collibra.py
@@ -1,0 +1,366 @@
+"""Collibra-backed data product backend implementations."""
+
+from __future__ import annotations
+
+import tempfile
+from typing import Dict, Mapping, Optional, Protocol, Sequence
+
+from dc43.core.odps import (
+    DataProductInputPort,
+    DataProductOutputPort,
+    OpenDataProductStandard,
+    as_odps_dict,
+    evolve_to_draft,
+    to_model,
+)
+
+from .interface import DataProductRegistrationResult, DataProductServiceBackend
+from .local import FilesystemDataProductServiceBackend
+
+
+def _as_custom_properties(data: Optional[Mapping[str, object]]) -> list[dict[str, object]]:
+    if not data:
+        return []
+    props: list[dict[str, object]] = []
+    for key, value in data.items():
+        props.append({"property": str(key), "value": value})
+    return props
+
+
+class CollibraDataProductAdapter(Protocol):
+    """Minimal abstraction for Collibra data product operations."""
+
+    def list_versions(self, data_product_id: str) -> Sequence[str]:
+        """Return the known versions for ``data_product_id``."""
+
+    def get_data_product(self, data_product_id: str, version: str) -> Mapping[str, object]:
+        """Return the ODPS payload for ``data_product_id`` at ``version``."""
+
+    def latest_data_product(self, data_product_id: str) -> Optional[Mapping[str, object]]:
+        """Return the latest ODPS payload for ``data_product_id`` when available."""
+
+    def upsert_data_product(
+        self,
+        product: Mapping[str, object],
+        *,
+        status: Optional[str] = None,
+    ) -> None:
+        """Persist ``product`` in Collibra with the desired lifecycle ``status``."""
+
+
+class CollibraDataProductServiceBackend(DataProductServiceBackend):
+    """Expose Collibra-managed data products through the backend interface."""
+
+    def __init__(
+        self,
+        adapter: CollibraDataProductAdapter,
+        *,
+        default_status: str = "Draft",
+    ) -> None:
+        self._adapter = adapter
+        self._default_status = default_status
+
+    # ------------------------------------------------------------------
+    # Base persistence helpers
+    # ------------------------------------------------------------------
+    def put(self, product: OpenDataProductStandard) -> None:  # noqa: D401 - short docstring
+        if not product.version:
+            raise ValueError("Data product version is required")
+        payload = as_odps_dict(product)
+        status = payload.get("status") or product.status or self._default_status
+        if status:
+            payload["status"] = status
+        self._adapter.upsert_data_product(payload, status=status)
+
+    def get(self, data_product_id: str, version: str) -> OpenDataProductStandard:  # noqa: D401
+        payload = self._adapter.get_data_product(data_product_id, version)
+        return to_model(payload)
+
+    def latest(self, data_product_id: str) -> Optional[OpenDataProductStandard]:  # noqa: D401
+        payload = self._adapter.latest_data_product(data_product_id)
+        if payload is None:
+            return None
+        return to_model(payload)
+
+    def list_versions(self, data_product_id: str) -> Sequence[str]:  # noqa: D401
+        versions = self._adapter.list_versions(data_product_id)
+        return sorted(str(value) for value in versions)
+
+    # ------------------------------------------------------------------
+    # Port registration helpers
+    # ------------------------------------------------------------------
+    def _existing_versions(self, data_product_id: str) -> Sequence[str]:
+        return self.list_versions(data_product_id)
+
+    def _ensure_product(self, data_product_id: str) -> OpenDataProductStandard:
+        product = self.latest(data_product_id)
+        if product is not None:
+            return product.clone()
+        status = self._default_status.lower() if self._default_status else "draft"
+        return OpenDataProductStandard(id=data_product_id, status=status)
+
+    def _store_updated(
+        self,
+        product: OpenDataProductStandard,
+        *,
+        bump: str,
+        data_product_id: str,
+    ) -> OpenDataProductStandard:
+        evolve_to_draft(
+            product,
+            existing_versions=self._existing_versions(data_product_id),
+            bump=bump,
+        )
+        self.put(product)
+        return product
+
+    def register_input_port(
+        self,
+        *,
+        data_product_id: str,
+        port: DataProductInputPort,
+        bump: str = "minor",
+        custom_properties: Optional[Mapping[str, object]] = None,
+        source_data_product: Optional[str] = None,
+        source_output_port: Optional[str] = None,
+    ) -> DataProductRegistrationResult:
+        product = self._ensure_product(data_product_id)
+        did_change = product.ensure_input_port(port)
+        if not did_change:
+            return DataProductRegistrationResult(product=product, changed=False)
+
+        props = _as_custom_properties(custom_properties)
+        if source_data_product:
+            props.append(
+                {
+                    "property": "dc43.input.source_data_product",
+                    "value": source_data_product,
+                }
+            )
+        if source_output_port:
+            props.append(
+                {
+                    "property": "dc43.input.source_output_port",
+                    "value": source_output_port,
+                }
+            )
+        if props:
+            existing = list(port.custom_properties)
+            for item in props:
+                if item not in existing:
+                    existing.append(item)
+            port.custom_properties = existing
+
+        updated = self._store_updated(product, bump=bump, data_product_id=data_product_id)
+        return DataProductRegistrationResult(product=updated, changed=True)
+
+    def register_output_port(
+        self,
+        *,
+        data_product_id: str,
+        port: DataProductOutputPort,
+        bump: str = "minor",
+        custom_properties: Optional[Mapping[str, object]] = None,
+    ) -> DataProductRegistrationResult:
+        product = self._ensure_product(data_product_id)
+        did_change = product.ensure_output_port(port)
+        if not did_change:
+            return DataProductRegistrationResult(product=product, changed=False)
+
+        props = _as_custom_properties(custom_properties)
+        if props:
+            existing = list(port.custom_properties)
+            for item in props:
+                if item not in existing:
+                    existing.append(item)
+            port.custom_properties = existing
+
+        updated = self._store_updated(product, bump=bump, data_product_id=data_product_id)
+        return DataProductRegistrationResult(product=updated, changed=True)
+
+    def resolve_output_contract(
+        self,
+        *,
+        data_product_id: str,
+        port_name: str,
+    ) -> Optional[tuple[str, str]]:
+        product = self.latest(data_product_id)
+        if product is None:
+            return None
+        port = product.find_output_port(port_name)
+        if port is None or not port.contract_id:
+            return None
+        return port.contract_id, port.version
+
+
+class StubCollibraDataProductAdapter(CollibraDataProductAdapter):
+    """Filesystem-backed stub adapter used for tests and demos."""
+
+    def __init__(self, base_path: Optional[str] = None) -> None:
+        if base_path is None:
+            self._temp_dir = tempfile.TemporaryDirectory(prefix="dc43-collibra-dp-")
+            base_path = self._temp_dir.name
+        else:
+            self._temp_dir = None
+        self._backend = FilesystemDataProductServiceBackend(base_path)
+
+    def close(self) -> None:
+        if getattr(self, "_temp_dir", None) is not None:
+            self._temp_dir.cleanup()
+            self._temp_dir = None
+
+    def __del__(self) -> None:  # pragma: no cover - best effort cleanup
+        try:
+            self.close()
+        except Exception:
+            pass
+
+    def list_versions(self, data_product_id: str) -> Sequence[str]:  # noqa: D401
+        return self._backend.list_versions(data_product_id)
+
+    def get_data_product(self, data_product_id: str, version: str) -> Mapping[str, object]:  # noqa: D401
+        model = self._backend.get(data_product_id, version)
+        return as_odps_dict(model)
+
+    def latest_data_product(self, data_product_id: str) -> Optional[Mapping[str, object]]:  # noqa: D401
+        model = self._backend.latest(data_product_id)
+        if model is None:
+            return None
+        return as_odps_dict(model)
+
+    def upsert_data_product(
+        self,
+        product: Mapping[str, object],
+        *,
+        status: Optional[str] = None,
+    ) -> None:
+        model = to_model(product)
+        if status:
+            model.status = status
+        self._backend.put(model)
+
+
+class HttpCollibraDataProductAdapter(CollibraDataProductAdapter):
+    """HTTP adapter aligned with Collibra Data Product endpoints."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        token: Optional[str] = None,
+        timeout: float = 10.0,
+        client=None,
+        products_endpoint_template: str = "/rest/2.0/dataproducts/{data_product}",
+    ) -> None:
+        try:
+            import httpx  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency guard
+            raise RuntimeError("httpx is required to use HttpCollibraDataProductAdapter") from exc
+
+        self._httpx = httpx
+        self._base_url = base_url.rstrip("/")
+        self._token = token
+        self._products_endpoint_template = products_endpoint_template.rstrip("/")
+        if client is None:
+            self._client = httpx.Client(base_url=self._base_url, timeout=timeout)
+            self._owns_client = True
+        else:
+            self._client = client
+            self._owns_client = False
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+    def __enter__(self) -> "HttpCollibraDataProductAdapter":  # pragma: no cover - trivial
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - trivial
+        self.close()
+
+    # ------------------------------------------------------------------
+    # Request helpers
+    # ------------------------------------------------------------------
+    def _headers(self) -> Dict[str, str]:
+        headers = {"accept": "application/json"}
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
+        return headers
+
+    def _product_url(self, data_product: str, suffix: str = "") -> str:
+        base = self._products_endpoint_template.format(data_product=data_product)
+        return f"{base}{suffix}"
+
+    def list_versions(self, data_product_id: str) -> Sequence[str]:  # noqa: D401
+        resp = self._client.get(
+            self._product_url(data_product_id, "/versions"),
+            headers=self._headers(),
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        if isinstance(payload, Mapping):
+            values = payload.get("data") or payload.get("results") or payload.get("versions")
+            if isinstance(values, Sequence) and not isinstance(values, (str, bytes)):
+                return [str(item) for item in values]
+        if isinstance(payload, Sequence) and not isinstance(payload, (str, bytes)):
+            return [str(item) for item in payload]
+        return []
+
+    def get_data_product(self, data_product_id: str, version: str) -> Mapping[str, object]:  # noqa: D401
+        resp = self._client.get(
+            self._product_url(data_product_id, f"/versions/{version}"),
+            headers=self._headers(),
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        if isinstance(payload, Mapping):
+            if "dataProduct" in payload and isinstance(payload["dataProduct"], Mapping):
+                return payload["dataProduct"]
+            if "data" in payload and isinstance(payload["data"], Mapping):
+                return payload["data"]
+        return payload
+
+    def latest_data_product(self, data_product_id: str) -> Optional[Mapping[str, object]]:  # noqa: D401
+        resp = self._client.get(
+            self._product_url(data_product_id, "/latest"),
+            headers=self._headers(),
+        )
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        payload = resp.json()
+        if isinstance(payload, Mapping):
+            if "dataProduct" in payload and isinstance(payload["dataProduct"], Mapping):
+                return payload["dataProduct"]
+            if "data" in payload and isinstance(payload["data"], Mapping):
+                return payload["data"]
+        return payload
+
+    def upsert_data_product(
+        self,
+        product: Mapping[str, object],
+        *,
+        status: Optional[str] = None,
+    ) -> None:
+        data_product_id = str(product.get("id") or "").strip()
+        version = str(product.get("version") or "").strip()
+        if not data_product_id or not version:
+            raise ValueError("Collibra data product payload requires id and version")
+        payload: Dict[str, object] = dict(product)
+        if status and not payload.get("status"):
+            payload["status"] = status
+        resp = self._client.put(
+            self._product_url(data_product_id, f"/versions/{version}"),
+            headers=self._headers(),
+            json={"dataProduct": payload},
+        )
+        resp.raise_for_status()
+
+
+__all__ = [
+    "CollibraDataProductAdapter",
+    "CollibraDataProductServiceBackend",
+    "HttpCollibraDataProductAdapter",
+    "StubCollibraDataProductAdapter",
+]
+

--- a/packages/dc43-service-backends/src/dc43_service_backends/data_products/backend/interface.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/data_products/backend/interface.py
@@ -1,0 +1,73 @@
+"""Protocol describing data product service operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Optional, Protocol, Sequence
+
+from dc43.core.odps import (
+    DataProductInputPort,
+    DataProductOutputPort,
+    OpenDataProductStandard,
+)
+
+
+@dataclass
+class DataProductRegistrationResult:
+    """Result returned by port registration operations."""
+
+    product: OpenDataProductStandard
+    changed: bool
+
+
+class DataProductServiceBackend(Protocol):
+    """Interface implemented by data product management backends."""
+
+    def put(self, product: OpenDataProductStandard) -> None:
+        """Persist ``product`` making it available for subsequent lookups."""
+
+    def get(self, data_product_id: str, version: str) -> OpenDataProductStandard:
+        """Return a specific version of ``data_product_id``."""
+
+    def latest(self, data_product_id: str) -> Optional[OpenDataProductStandard]:
+        """Return the latest version of ``data_product_id`` when available."""
+
+    def list_versions(self, data_product_id: str) -> Sequence[str]:
+        """Return the known versions for ``data_product_id``."""
+
+    def register_input_port(
+        self,
+        *,
+        data_product_id: str,
+        port: DataProductInputPort,
+        bump: str = "minor",
+        custom_properties: Optional[Mapping[str, object]] = None,
+        source_data_product: Optional[str] = None,
+        source_output_port: Optional[str] = None,
+    ) -> DataProductRegistrationResult:
+        """Ensure ``port`` is attached to ``data_product_id`` input ports."""
+
+    def register_output_port(
+        self,
+        *,
+        data_product_id: str,
+        port: DataProductOutputPort,
+        bump: str = "minor",
+        custom_properties: Optional[Mapping[str, object]] = None,
+    ) -> DataProductRegistrationResult:
+        """Ensure ``port`` is attached to ``data_product_id`` output ports."""
+
+    def resolve_output_contract(
+        self,
+        *,
+        data_product_id: str,
+        port_name: str,
+    ) -> Optional[tuple[str, str]]:
+        """Return ``(contract_id, contract_version)`` for ``port_name`` when known."""
+
+
+__all__ = [
+    "DataProductRegistrationResult",
+    "DataProductServiceBackend",
+]
+

--- a/packages/dc43-service-backends/src/dc43_service_backends/data_products/backend/interface.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/data_products/backend/interface.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Mapping, Optional, Protocol, Sequence
 
-from dc43.core.odps import (
+from dc43_service_clients.odps import (
     DataProductInputPort,
     DataProductOutputPort,
     OpenDataProductStandard,

--- a/packages/dc43-service-backends/src/dc43_service_backends/data_products/backend/local.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/data_products/backend/local.py
@@ -1,0 +1,181 @@
+"""In-memory data product backend used by the service stack."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, Optional
+import json
+import logging
+
+from dc43.core.odps import (
+    DataProductInputPort,
+    DataProductOutputPort,
+    OpenDataProductStandard,
+    as_odps_dict,
+    evolve_to_draft,
+    to_model,
+)
+
+from .interface import DataProductRegistrationResult, DataProductServiceBackend
+
+
+logger = logging.getLogger(__name__)
+
+
+def _as_custom_properties(data: Optional[Mapping[str, object]]) -> list[dict[str, object]]:
+    if not data:
+        return []
+    props: list[dict[str, object]] = []
+    for key, value in data.items():
+        props.append({"property": str(key), "value": value})
+    return props
+
+
+class LocalDataProductServiceBackend(DataProductServiceBackend):
+    """Store ODPS documents in memory while providing port registration helpers."""
+
+    def __init__(self) -> None:
+        self._products: Dict[str, Dict[str, OpenDataProductStandard]] = defaultdict(dict)
+        self._latest: Dict[str, str] = {}
+
+    def _existing_versions(self, data_product_id: str) -> Iterable[str]:
+        return self._products.get(data_product_id, {}).keys()
+
+    def put(self, product: OpenDataProductStandard) -> None:  # noqa: D401 - short docstring
+        if not product.version:
+            raise ValueError("Data product version is required")
+        store = self._products.setdefault(product.id, {})
+        store[product.version] = product.clone()
+        self._latest[product.id] = product.version
+
+    def get(self, data_product_id: str, version: str) -> OpenDataProductStandard:  # noqa: D401
+        versions = self._products.get(data_product_id)
+        if not versions or version not in versions:
+            raise FileNotFoundError(f"data product {data_product_id}:{version} not found")
+        return versions[version].clone()
+
+    def latest(self, data_product_id: str) -> Optional[OpenDataProductStandard]:  # noqa: D401
+        version = self._latest.get(data_product_id)
+        if version is None:
+            return None
+        return self.get(data_product_id, version)
+
+    def list_versions(self, data_product_id: str) -> list[str]:  # noqa: D401
+        versions = self._products.get(data_product_id, {})
+        return sorted(versions.keys())
+
+    def _ensure_product(self, data_product_id: str) -> OpenDataProductStandard:
+        latest = self.latest(data_product_id)
+        if latest is not None:
+            return latest.clone()
+        # Seed a minimal draft when the product does not yet exist
+        product = OpenDataProductStandard(id=data_product_id, status="draft")
+        product.version = None
+        return product
+
+    def _store_updated(
+        self,
+        product: OpenDataProductStandard,
+        *,
+        bump: str,
+        existing_versions: Iterable[str],
+    ) -> OpenDataProductStandard:
+        evolve_to_draft(product, existing_versions=existing_versions, bump=bump)
+        self.put(product)
+        return product
+
+    def register_input_port(
+        self,
+        *,
+        data_product_id: str,
+        port: DataProductInputPort,
+        bump: str = "minor",
+        custom_properties: Optional[Mapping[str, object]] = None,
+        source_data_product: Optional[str] = None,
+        source_output_port: Optional[str] = None,
+    ) -> DataProductRegistrationResult:  # noqa: D401
+        product = self._ensure_product(data_product_id)
+        did_change = product.ensure_input_port(port)
+        if not did_change:
+            return DataProductRegistrationResult(product=product, changed=False)
+        props = _as_custom_properties(custom_properties)
+        if source_data_product:
+            props.append(
+                {
+                    "property": "dc43.input.source_data_product",
+                    "value": source_data_product,
+                }
+            )
+        if source_output_port:
+            props.append(
+                {
+                    "property": "dc43.input.source_output_port",
+                    "value": source_output_port,
+                }
+            )
+        if props:
+            port.custom_properties.extend(
+                [item for item in props if item not in port.custom_properties]
+            )
+        updated = self._store_updated(
+            product,
+            bump=bump,
+            existing_versions=self._existing_versions(data_product_id),
+        )
+        return DataProductRegistrationResult(product=updated, changed=True)
+
+    def resolve_output_contract(
+        self,
+        *,
+        data_product_id: str,
+        port_name: str,
+    ) -> Optional[tuple[str, str]]:  # noqa: D401
+        product = self.latest(data_product_id)
+        if product is None:
+            return None
+        port = product.find_output_port(port_name)
+        if port is None or not port.contract_id:
+            return None
+        return port.contract_id, port.version
+
+
+class FilesystemDataProductServiceBackend(LocalDataProductServiceBackend):
+    """Persist ODPS documents as JSON files following the ODPS schema."""
+
+    def __init__(self, root: str | Path) -> None:
+        self._root_path = Path(root)
+        self._root_path.mkdir(parents=True, exist_ok=True)
+        super().__init__()
+        self._load_existing()
+
+    def _product_dir(self, data_product_id: str) -> Path:
+        safe_id = data_product_id.replace("/", "__")
+        return self._root_path / safe_id
+
+    def _product_path(self, data_product_id: str, version: str) -> Path:
+        return self._product_dir(data_product_id) / f"{version}.json"
+
+    def _load_existing(self) -> None:
+        for json_path in self._root_path.rglob("*.json"):
+            try:
+                with json_path.open("r", encoding="utf-8") as handle:
+                    payload = json.load(handle)
+                product = to_model(payload)
+            except Exception:  # pragma: no cover - defensive, best-effort loader
+                logger.exception("Failed to load data product definition from %s", json_path)
+                continue
+            LocalDataProductServiceBackend.put(self, product)
+    
+    def put(self, product: OpenDataProductStandard) -> None:  # noqa: D401
+        super().put(product)
+        if not product.version:
+            return
+        path = self._product_path(product.id, product.version)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as handle:
+            json.dump(as_odps_dict(product), handle, indent=2, sort_keys=True)
+
+
+__all__ = ["LocalDataProductServiceBackend", "FilesystemDataProductServiceBackend"]
+

--- a/packages/dc43-service-backends/src/dc43_service_backends/data_products/backend/local.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/data_products/backend/local.py
@@ -125,6 +125,32 @@ class LocalDataProductServiceBackend(DataProductServiceBackend):
         )
         return DataProductRegistrationResult(product=updated, changed=True)
 
+    def register_output_port(
+        self,
+        *,
+        data_product_id: str,
+        port: DataProductOutputPort,
+        bump: str = "minor",
+        custom_properties: Optional[Mapping[str, object]] = None,
+    ) -> DataProductRegistrationResult:  # noqa: D401
+        product = self._ensure_product(data_product_id)
+        did_change = product.ensure_output_port(port)
+        if not did_change:
+            return DataProductRegistrationResult(product=product, changed=False)
+
+        props = _as_custom_properties(custom_properties)
+        if props:
+            port.custom_properties.extend(
+                [item for item in props if item not in port.custom_properties]
+            )
+
+        updated = self._store_updated(
+            product,
+            bump=bump,
+            existing_versions=self._existing_versions(data_product_id),
+        )
+        return DataProductRegistrationResult(product=updated, changed=True)
+
     def resolve_output_contract(
         self,
         *,

--- a/packages/dc43-service-backends/src/dc43_service_backends/data_products/backend/local.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/data_products/backend/local.py
@@ -8,7 +8,7 @@ from typing import Dict, Iterable, Mapping, Optional
 import json
 import logging
 
-from dc43.core.odps import (
+from dc43_service_clients.odps import (
     DataProductInputPort,
     DataProductOutputPort,
     OpenDataProductStandard,

--- a/packages/dc43-service-backends/src/dc43_service_backends/server.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/server.py
@@ -16,7 +16,7 @@ except ModuleNotFoundError as exc:  # pragma: no cover - raised when optional de
 from pydantic import BaseModel
 from open_data_contract_standard.model import OpenDataContractStandard  # type: ignore
 
-from dc43.core.odps import (
+from dc43_service_clients.odps import (
     DataProductInputPort,
     DataProductOutputPort,
     as_odps_dict as as_odps_product_dict,

--- a/packages/dc43-service-backends/src/dc43_service_backends/server.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/server.py
@@ -16,6 +16,11 @@ except ModuleNotFoundError as exc:  # pragma: no cover - raised when optional de
 from pydantic import BaseModel
 from open_data_contract_standard.model import OpenDataContractStandard  # type: ignore
 
+from dc43.core.odps import (
+    DataProductInputPort,
+    DataProductOutputPort,
+    as_odps_dict as as_odps_product_dict,
+)
 from dc43_service_clients.data_quality.transport import (
     decode_observation_payload,
     decode_validation_result,
@@ -31,6 +36,7 @@ from dc43_service_clients.governance.transport import (
 from dc43_service_clients.governance.models import QualityAssessment
 
 from .contracts import ContractServiceBackend
+from .data_products import DataProductServiceBackend
 from .data_quality import DataQualityServiceBackend
 from .governance.backend import GovernanceServiceBackend
 
@@ -40,6 +46,24 @@ class _LinkDatasetPayload(BaseModel):
     dataset_version: str
     contract_id: str
     contract_version: str
+
+
+class _DataProductInputPayload(BaseModel):
+    port_name: str
+    contract_id: str
+    contract_version: str
+    bump: str = "minor"
+    custom_properties: Optional[Mapping[str, Any]] = None
+    source_data_product: Optional[str] = None
+    source_output_port: Optional[str] = None
+
+
+class _DataProductOutputPayload(BaseModel):
+    port_name: str
+    contract_id: str
+    contract_version: str
+    bump: str = "minor"
+    custom_properties: Optional[Mapping[str, Any]] = None
 
 
 class _EvaluateDQPayload(BaseModel):
@@ -101,6 +125,7 @@ def build_app(
     contract_backend: ContractServiceBackend,
     dq_backend: DataQualityServiceBackend,
     governance_backend: GovernanceServiceBackend,
+    data_product_backend: DataProductServiceBackend,
     dependencies: Sequence[object] | None = None,
 ) -> FastAPI:
     """Create a FastAPI app exposing the provided backend implementations."""
@@ -160,6 +185,85 @@ def build_app(
         if version is None:
             raise HTTPException(status_code=404, detail="no contract linked")
         return {"contract_version": version}
+
+    # ------------------------------------------------------------------
+    # Data product endpoints
+    # ------------------------------------------------------------------
+    @router.get("/data-products/{data_product_id}/versions/{version}")
+    def get_data_product(data_product_id: str, version: str) -> Mapping[str, Any]:
+        try:
+            product = data_product_backend.get(data_product_id, version)
+        except FileNotFoundError as exc:  # pragma: no cover - backend signals missing product
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return as_odps_product_dict(product)
+
+    @router.get("/data-products/{data_product_id}/latest")
+    def latest_data_product(data_product_id: str) -> Mapping[str, Any]:
+        product = data_product_backend.latest(data_product_id)
+        if product is None:
+            raise HTTPException(status_code=404, detail="data product not found")
+        return as_odps_product_dict(product)
+
+    @router.get("/data-products/{data_product_id}/versions")
+    def list_data_product_versions(data_product_id: str) -> list[str]:
+        versions = data_product_backend.list_versions(data_product_id)
+        return [str(value) for value in versions]
+
+    @router.post("/data-products/{data_product_id}/input-ports")
+    def register_data_product_input(
+        data_product_id: str, payload: _DataProductInputPayload
+    ) -> Mapping[str, Any]:
+        result = data_product_backend.register_input_port(
+            data_product_id=data_product_id,
+            port=DataProductInputPort(
+                name=payload.port_name,
+                version=payload.contract_version,
+                contract_id=payload.contract_id,
+            ),
+            bump=payload.bump,
+            custom_properties=payload.custom_properties,
+            source_data_product=payload.source_data_product,
+            source_output_port=payload.source_output_port,
+        )
+        return {
+            "product": as_odps_product_dict(result.product),
+            "changed": result.changed,
+        }
+
+    @router.post("/data-products/{data_product_id}/output-ports")
+    def register_data_product_output(
+        data_product_id: str, payload: _DataProductOutputPayload
+    ) -> Mapping[str, Any]:
+        result = data_product_backend.register_output_port(
+            data_product_id=data_product_id,
+            port=DataProductOutputPort(
+                name=payload.port_name,
+                version=payload.contract_version,
+                contract_id=payload.contract_id,
+            ),
+            bump=payload.bump,
+            custom_properties=payload.custom_properties,
+        )
+        return {
+            "product": as_odps_product_dict(result.product),
+            "changed": result.changed,
+        }
+
+    @router.get("/data-products/{data_product_id}/output-ports/{port_name}/contract")
+    def resolve_data_product_output_contract(
+        data_product_id: str, port_name: str
+    ) -> Mapping[str, Any]:
+        contract = data_product_backend.resolve_output_contract(
+            data_product_id=data_product_id,
+            port_name=port_name,
+        )
+        if contract is None:
+            raise HTTPException(status_code=404, detail="output port not found")
+        contract_id, contract_version = contract
+        return {
+            "contract_id": contract_id,
+            "contract_version": contract_version,
+        }
 
     # ------------------------------------------------------------------
     # Data-quality endpoints

--- a/packages/dc43-service-backends/src/dc43_service_backends/web.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/web.py
@@ -15,6 +15,10 @@ from typing import Sequence
 from dc43_service_backends.contracts.backend import ContractServiceBackend, LocalContractServiceBackend
 from dc43_service_backends.contracts.backend.stores import FSContractStore
 from dc43_service_backends.contracts.backend.stores.interface import ContractStore
+from dc43_service_backends.data_products import (
+    DataProductServiceBackend,
+    LocalDataProductServiceBackend,
+)
 from dc43_service_backends.data_quality.backend import (
     DataQualityServiceBackend,
     LocalDataQualityServiceBackend,
@@ -28,6 +32,7 @@ def build_local_app(
     store: ContractStore | str,
     *,
     contract_backend: ContractServiceBackend | None = None,
+    data_product_backend: DataProductServiceBackend | None = None,
     dq_backend: DataQualityServiceBackend | None = None,
     governance_backend: GovernanceServiceBackend | None = None,
     dependencies: Sequence[object] | None = None,
@@ -39,6 +44,8 @@ def build_local_app(
 
     if contract_backend is None:
         contract_backend = LocalContractServiceBackend(store)
+    if data_product_backend is None:
+        data_product_backend = LocalDataProductServiceBackend()
     if dq_backend is None:
         dq_backend = LocalDataQualityServiceBackend()
     if governance_backend is None:
@@ -50,6 +57,7 @@ def build_local_app(
 
     return build_app(
         contract_backend=contract_backend,
+        data_product_backend=data_product_backend,
         dq_backend=dq_backend,
         governance_backend=governance_backend,
         dependencies=dependencies,

--- a/packages/dc43-service-backends/tests/test_data_products_backend.py
+++ b/packages/dc43-service-backends/tests/test_data_products_backend.py
@@ -1,0 +1,107 @@
+from pathlib import Path
+
+from dc43.core.odps import DataProductInputPort, DataProductOutputPort
+from dc43_service_backends.data_products import (
+    CollibraDataProductServiceBackend,
+    FilesystemDataProductServiceBackend,
+    LocalDataProductServiceBackend,
+    StubCollibraDataProductAdapter,
+)
+
+
+def test_register_input_port_creates_draft_version() -> None:
+    backend = LocalDataProductServiceBackend()
+
+    registration = backend.register_input_port(
+        data_product_id="dp.analytics",
+        port=DataProductInputPort(name="orders", version="1.0.0", contract_id="orders"),
+        source_data_product="dp.source",
+        source_output_port="gold",
+    )
+
+    assert registration.changed is True
+    product = registration.product
+    assert product.version is not None
+    assert product.status == "draft"
+    assert product.input_ports[0].contract_id == "orders"
+    latest = backend.latest("dp.analytics")
+    assert latest is not None
+    assert latest.version == product.version
+
+
+def test_register_input_port_idempotent() -> None:
+    backend = LocalDataProductServiceBackend()
+    backend.register_input_port(
+        data_product_id="dp.analytics",
+        port=DataProductInputPort(name="orders", version="1.0.0", contract_id="orders"),
+    )
+
+    registration = backend.register_input_port(
+        data_product_id="dp.analytics",
+        port=DataProductInputPort(name="orders", version="1.0.0", contract_id="orders"),
+    )
+
+    assert registration.changed is False
+
+
+def test_register_output_port_updates_version_once() -> None:
+    backend = LocalDataProductServiceBackend()
+    backend.register_output_port(
+        data_product_id="dp.analytics",
+        port=DataProductOutputPort(name="snapshot", version="1.0.0", contract_id="snapshot"),
+    )
+    first_version = backend.latest("dp.analytics").version
+    update = backend.register_output_port(
+        data_product_id="dp.analytics",
+        port=DataProductOutputPort(name="snapshot", version="1.1.0", contract_id="snapshot"),
+    )
+    assert update.changed is True
+    second_version = backend.latest("dp.analytics").version
+    assert second_version != first_version
+
+
+def test_resolve_output_contract_returns_contract_reference() -> None:
+    backend = LocalDataProductServiceBackend()
+    backend.register_output_port(
+        data_product_id="dp.analytics",
+        port=DataProductOutputPort(name="report", version="2.0.0", contract_id="report"),
+    )
+    resolved = backend.resolve_output_contract(
+        data_product_id="dp.analytics",
+        port_name="report",
+    )
+    assert resolved == ("report", "2.0.0")
+
+
+def test_filesystem_backend_persists_products(tmp_path: Path) -> None:
+    backend = FilesystemDataProductServiceBackend(tmp_path)
+
+    backend.register_output_port(
+        data_product_id="dp.analytics",
+        port=DataProductOutputPort(name="snapshot", version="1.0.0", contract_id="snapshot"),
+    )
+
+    on_disk = list(tmp_path.rglob("*.json"))
+    assert on_disk
+
+    reloaded = FilesystemDataProductServiceBackend(tmp_path)
+    product = reloaded.latest("dp.analytics")
+    assert product is not None
+    assert product.output_ports[0].contract_id == "snapshot"
+
+
+def test_collibra_backend_uses_stub_adapter(tmp_path: Path) -> None:
+    adapter = StubCollibraDataProductAdapter(str(tmp_path))
+    backend = CollibraDataProductServiceBackend(adapter)
+
+    registration = backend.register_output_port(
+        data_product_id="dp.analytics",
+        port=DataProductOutputPort(name="snapshot", version="1.0.0", contract_id="snapshot"),
+    )
+
+    assert registration.changed is True
+    latest = backend.latest("dp.analytics")
+    assert latest is not None
+    assert latest.output_ports[0].contract_id == "snapshot"
+
+    adapter.close()

--- a/packages/dc43-service-backends/tests/test_data_products_backend.py
+++ b/packages/dc43-service-backends/tests/test_data_products_backend.py
@@ -1,12 +1,12 @@
 from pathlib import Path
 
-from dc43.core.odps import DataProductInputPort, DataProductOutputPort
 from dc43_service_backends.data_products import (
     CollibraDataProductServiceBackend,
     FilesystemDataProductServiceBackend,
     LocalDataProductServiceBackend,
     StubCollibraDataProductAdapter,
 )
+from dc43_service_clients.odps import DataProductInputPort, DataProductOutputPort
 
 
 def test_register_input_port_creates_draft_version() -> None:

--- a/packages/dc43-service-clients/CHANGELOG.md
+++ b/packages/dc43-service-clients/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Bundled ODPS helpers so the package can run its tests without the core
   distribution installed and to provide a single import path for downstream
   service components.
+- Hardened the ODPS helper import guard so standalone installs no longer raise
+  ``ModuleNotFoundError`` when the root ``dc43`` package is absent.
 - Client APIs now surface `DataProductRegistrationResult` so orchestrators can
   fail pipelines when ODPS input/output registrations create drafts.
 - Updated the remote adapter to consume the new backend response shape including

--- a/packages/dc43-service-clients/CHANGELOG.md
+++ b/packages/dc43-service-clients/CHANGELOG.md
@@ -1,0 +1,8 @@
+# dc43-service-clients changelog
+
+## [Unreleased]
+### Added
+- Client APIs now surface `DataProductRegistrationResult` so orchestrators can
+  fail pipelines when ODPS input/output registrations create drafts.
+- Updated the remote adapter to consume the new backend response shape including
+  the registration metadata.

--- a/packages/dc43-service-clients/CHANGELOG.md
+++ b/packages/dc43-service-clients/CHANGELOG.md
@@ -9,3 +9,5 @@
   fail pipelines when ODPS input/output registrations create drafts.
 - Updated the remote adapter to consume the new backend response shape including
   the registration metadata.
+- Added a lightweight `LocalDataProductServiceBackend` testing stub so the
+  package test suite no longer depends on the service backend distribution.

--- a/packages/dc43-service-clients/CHANGELOG.md
+++ b/packages/dc43-service-clients/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 ### Added
+- Bundled ODPS helpers so the package can run its tests without the core
+  distribution installed and to provide a single import path for downstream
+  service components.
 - Client APIs now surface `DataProductRegistrationResult` so orchestrators can
   fail pipelines when ODPS input/output registrations create drafts.
 - Updated the remote adapter to consume the new backend response shape including

--- a/packages/dc43-service-clients/CHANGELOG.md
+++ b/packages/dc43-service-clients/CHANGELOG.md
@@ -13,3 +13,8 @@
   the registration metadata.
 - Added a lightweight `LocalDataProductServiceBackend` testing stub so the
   package test suite no longer depends on the service backend distribution.
+
+### Fixed
+- Decoupled the data product clients from the backend package so importing the
+  protocol and client helpers no longer requires installing the service
+  backends distribution.

--- a/packages/dc43-service-clients/src/dc43_service_clients/__init__.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from importlib import import_module
 from typing import Any
 
-__all__ = ["contracts", "data_products", "data_quality", "governance"]
+__all__ = ["contracts", "data_products", "data_quality", "governance", "odps"]
 
 
 def __getattr__(name: str) -> Any:

--- a/packages/dc43-service-clients/src/dc43_service_clients/__init__.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from importlib import import_module
 from typing import Any
 
-__all__ = ["contracts", "data_quality", "governance"]
+__all__ = ["contracts", "data_products", "data_quality", "governance"]
 
 
 def __getattr__(name: str) -> Any:

--- a/packages/dc43-service-clients/src/dc43_service_clients/data_products/__init__.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/data_products/__init__.py
@@ -1,0 +1,24 @@
+"""Client-facing data product service helpers."""
+
+from .client.interface import DataProductServiceClient
+from .client.local import LocalDataProductServiceClient
+from .client.remote import RemoteDataProductServiceClient
+from .models import (
+    DataProductInputBinding,
+    DataProductOutputBinding,
+    normalise_input_binding,
+    normalise_output_binding,
+)
+from dc43_service_backends.data_products import DataProductRegistrationResult
+
+__all__ = [
+    "DataProductInputBinding",
+    "DataProductOutputBinding",
+    "DataProductRegistrationResult",
+    "DataProductServiceClient",
+    "LocalDataProductServiceClient",
+    "RemoteDataProductServiceClient",
+    "normalise_input_binding",
+    "normalise_output_binding",
+]
+

--- a/packages/dc43-service-clients/src/dc43_service_clients/data_products/__init__.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/data_products/__init__.py
@@ -1,5 +1,6 @@
 """Client-facing data product service helpers."""
 
+from ._compat import DataProductRegistrationResult
 from .client.interface import DataProductServiceClient
 from .client.local import LocalDataProductServiceClient
 from .client.remote import RemoteDataProductServiceClient
@@ -9,7 +10,6 @@ from .models import (
     normalise_input_binding,
     normalise_output_binding,
 )
-from dc43_service_backends.data_products import DataProductRegistrationResult
 
 __all__ = [
     "DataProductInputBinding",

--- a/packages/dc43-service-clients/src/dc43_service_clients/data_products/_compat.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/data_products/_compat.py
@@ -1,0 +1,10 @@
+"""Compatibility helpers for optional data product backend dependency."""
+
+from __future__ import annotations
+
+try:  # pragma: no cover - exercised in environments with optional deps missing
+    from dc43_service_backends.data_products import DataProductRegistrationResult
+except ModuleNotFoundError:  # pragma: no cover - fallback when backends absent
+    from ._types import DataProductRegistrationResult
+
+__all__ = ["DataProductRegistrationResult"]

--- a/packages/dc43-service-clients/src/dc43_service_clients/data_products/_types.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/data_products/_types.py
@@ -1,0 +1,18 @@
+"""Internal fallbacks for data product service types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from dc43_service_clients.odps import OpenDataProductStandard
+
+
+@dataclass
+class DataProductRegistrationResult:
+    """Result returned by port registration operations."""
+
+    product: OpenDataProductStandard
+    changed: bool
+
+
+__all__ = ["DataProductRegistrationResult"]

--- a/packages/dc43-service-clients/src/dc43_service_clients/data_products/client/__init__.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/data_products/client/__init__.py
@@ -1,0 +1,12 @@
+"""Client implementations for data product services."""
+
+from .interface import DataProductServiceClient
+from .local import LocalDataProductServiceClient
+from .remote import RemoteDataProductServiceClient
+
+__all__ = [
+    "DataProductServiceClient",
+    "LocalDataProductServiceClient",
+    "RemoteDataProductServiceClient",
+]
+

--- a/packages/dc43-service-clients/src/dc43_service_clients/data_products/client/interface.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/data_products/client/interface.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from typing import Mapping, Optional, Protocol
 
-from dc43_service_backends.data_products import DataProductRegistrationResult
 from dc43_service_clients.odps import OpenDataProductStandard
+
+from .._compat import DataProductRegistrationResult
 
 
 class DataProductServiceClient(Protocol):

--- a/packages/dc43-service-clients/src/dc43_service_clients/data_products/client/interface.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/data_products/client/interface.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Mapping, Optional, Protocol
 
-from dc43.core.odps import OpenDataProductStandard
 from dc43_service_backends.data_products import DataProductRegistrationResult
+from dc43_service_clients.odps import OpenDataProductStandard
 
 
 class DataProductServiceClient(Protocol):

--- a/packages/dc43-service-clients/src/dc43_service_clients/data_products/client/interface.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/data_products/client/interface.py
@@ -1,0 +1,59 @@
+"""Protocols for interacting with data product services."""
+
+from __future__ import annotations
+
+from typing import Mapping, Optional, Protocol
+
+from dc43.core.odps import OpenDataProductStandard
+from dc43_service_backends.data_products import DataProductRegistrationResult
+
+
+class DataProductServiceClient(Protocol):
+    """Expose operations provided by the data product management service."""
+
+    def get(self, data_product_id: str, version: str) -> OpenDataProductStandard:
+        ...
+
+    def latest(self, data_product_id: str) -> Optional[OpenDataProductStandard]:
+        ...
+
+    def list_versions(self, data_product_id: str) -> list[str]:
+        ...
+
+    def register_input_port(
+        self,
+        *,
+        data_product_id: str,
+        port_name: str,
+        contract_id: str,
+        contract_version: str,
+        bump: str = "minor",
+        custom_properties: Optional[Mapping[str, object]] = None,
+        source_data_product: Optional[str] = None,
+        source_output_port: Optional[str] = None,
+    ) -> DataProductRegistrationResult:
+        ...
+
+    def register_output_port(
+        self,
+        *,
+        data_product_id: str,
+        port_name: str,
+        contract_id: str,
+        contract_version: str,
+        bump: str = "minor",
+        custom_properties: Optional[Mapping[str, object]] = None,
+    ) -> DataProductRegistrationResult:
+        ...
+
+    def resolve_output_contract(
+        self,
+        *,
+        data_product_id: str,
+        port_name: str,
+    ) -> Optional[tuple[str, str]]:
+        ...
+
+
+__all__ = ["DataProductServiceClient"]
+

--- a/packages/dc43-service-clients/src/dc43_service_clients/data_products/client/local.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/data_products/client/local.py
@@ -1,0 +1,107 @@
+"""Local adapter delegating data product requests to backend implementations."""
+
+from __future__ import annotations
+
+from typing import Mapping, Optional, TYPE_CHECKING
+
+from dc43.core.odps import OpenDataProductStandard
+from dc43_service_backends.data_products import DataProductRegistrationResult
+
+from .interface import DataProductServiceClient
+
+if TYPE_CHECKING:  # pragma: no cover - imported for typing only
+    from dc43_service_backends.data_products import (
+        DataProductServiceBackend,
+        LocalDataProductServiceBackend,
+    )
+else:  # pragma: no cover - help type checkers when optional deps missing
+    DataProductServiceBackend = LocalDataProductServiceBackend = object  # type: ignore
+
+
+class LocalDataProductServiceClient(DataProductServiceClient):
+    """Adapter that fulfils the client protocol against a backend instance."""
+
+    def __init__(self, backend: "DataProductServiceBackend | None" = None) -> None:
+        if backend is None:
+            from dc43_service_backends.data_products import (  # pylint: disable=import-outside-toplevel
+                LocalDataProductServiceBackend as _LocalDataProductServiceBackend,
+            )
+
+            backend = _LocalDataProductServiceBackend()
+        self._backend = backend
+
+    def get(self, data_product_id: str, version: str) -> OpenDataProductStandard:
+        return self._backend.get(data_product_id, version)
+
+    def latest(self, data_product_id: str) -> Optional[OpenDataProductStandard]:
+        return self._backend.latest(data_product_id)
+
+    def list_versions(self, data_product_id: str) -> list[str]:
+        return list(self._backend.list_versions(data_product_id))
+
+    def register_input_port(
+        self,
+        *,
+        data_product_id: str,
+        port_name: str,
+        contract_id: str,
+        contract_version: str,
+        bump: str = "minor",
+        custom_properties: Optional[Mapping[str, object]] = None,
+        source_data_product: Optional[str] = None,
+        source_output_port: Optional[str] = None,
+    ) -> DataProductRegistrationResult:
+        from dc43.core.odps import DataProductInputPort
+
+        port = DataProductInputPort(
+            name=port_name,
+            version=contract_version,
+            contract_id=contract_id,
+        )
+        return self._backend.register_input_port(
+            data_product_id=data_product_id,
+            port=port,
+            bump=bump,
+            custom_properties=custom_properties,
+            source_data_product=source_data_product,
+            source_output_port=source_output_port,
+        )
+
+    def register_output_port(
+        self,
+        *,
+        data_product_id: str,
+        port_name: str,
+        contract_id: str,
+        contract_version: str,
+        bump: str = "minor",
+        custom_properties: Optional[Mapping[str, object]] = None,
+    ) -> DataProductRegistrationResult:
+        from dc43.core.odps import DataProductOutputPort
+
+        port = DataProductOutputPort(
+            name=port_name,
+            version=contract_version,
+            contract_id=contract_id,
+        )
+        return self._backend.register_output_port(
+            data_product_id=data_product_id,
+            port=port,
+            bump=bump,
+            custom_properties=custom_properties,
+        )
+
+    def resolve_output_contract(
+        self,
+        *,
+        data_product_id: str,
+        port_name: str,
+    ) -> Optional[tuple[str, str]]:
+        return self._backend.resolve_output_contract(
+            data_product_id=data_product_id,
+            port_name=port_name,
+        )
+
+
+__all__ = ["LocalDataProductServiceClient"]
+

--- a/packages/dc43-service-clients/src/dc43_service_clients/data_products/client/local.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/data_products/client/local.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import Mapping, Optional, TYPE_CHECKING
 
-from dc43.core.odps import OpenDataProductStandard
 from dc43_service_backends.data_products import DataProductRegistrationResult
+from dc43_service_clients.odps import OpenDataProductStandard
 
 from .interface import DataProductServiceClient
 
@@ -51,7 +51,7 @@ class LocalDataProductServiceClient(DataProductServiceClient):
         source_data_product: Optional[str] = None,
         source_output_port: Optional[str] = None,
     ) -> DataProductRegistrationResult:
-        from dc43.core.odps import DataProductInputPort
+        from dc43_service_clients.odps import DataProductInputPort
 
         port = DataProductInputPort(
             name=port_name,
@@ -77,7 +77,7 @@ class LocalDataProductServiceClient(DataProductServiceClient):
         bump: str = "minor",
         custom_properties: Optional[Mapping[str, object]] = None,
     ) -> DataProductRegistrationResult:
-        from dc43.core.odps import DataProductOutputPort
+        from dc43_service_clients.odps import DataProductOutputPort
 
         port = DataProductOutputPort(
             name=port_name,

--- a/packages/dc43-service-clients/src/dc43_service_clients/data_products/client/local.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/data_products/client/local.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from typing import Mapping, Optional, TYPE_CHECKING
 
-from dc43_service_backends.data_products import DataProductRegistrationResult
 from dc43_service_clients.odps import OpenDataProductStandard
 
 from .interface import DataProductServiceClient
+from .._compat import DataProductRegistrationResult
 
 if TYPE_CHECKING:  # pragma: no cover - imported for typing only
     from dc43_service_backends.data_products import (
@@ -23,9 +23,14 @@ class LocalDataProductServiceClient(DataProductServiceClient):
 
     def __init__(self, backend: "DataProductServiceBackend | None" = None) -> None:
         if backend is None:
-            from dc43_service_backends.data_products import (  # pylint: disable=import-outside-toplevel
-                LocalDataProductServiceBackend as _LocalDataProductServiceBackend,
-            )
+            try:
+                from dc43_service_backends.data_products import (  # pylint: disable=import-outside-toplevel
+                    LocalDataProductServiceBackend as _LocalDataProductServiceBackend,
+                )
+            except ModuleNotFoundError:  # pragma: no cover - exercised when backends absent
+                from dc43_service_clients.testing import (  # pylint: disable=import-outside-toplevel
+                    LocalDataProductServiceBackend as _LocalDataProductServiceBackend,
+                )
 
             backend = _LocalDataProductServiceBackend()
         self._backend = backend

--- a/packages/dc43-service-clients/src/dc43_service_clients/data_products/client/remote.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/data_products/client/remote.py
@@ -12,8 +12,8 @@ except ModuleNotFoundError as exc:  # pragma: no cover
         "'dc43-service-clients[http]' to enable it."
     ) from exc
 
-from dc43.core.odps import OpenDataProductStandard, to_model
 from dc43_service_backends.data_products import DataProductRegistrationResult
+from dc43_service_clients.odps import OpenDataProductStandard, to_model
 from dc43_service_clients._http_sync import close_client, ensure_response
 
 from .interface import DataProductServiceClient

--- a/packages/dc43-service-clients/src/dc43_service_clients/data_products/client/remote.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/data_products/client/remote.py
@@ -1,0 +1,193 @@
+"""HTTP client for interacting with the data product service."""
+
+from __future__ import annotations
+
+from typing import Mapping, Optional
+
+try:  # pragma: no cover - optional dependency guard
+    import httpx
+except ModuleNotFoundError as exc:  # pragma: no cover
+    raise ModuleNotFoundError(
+        "httpx is required to use the HTTP data product client. Install "
+        "'dc43-service-clients[http]' to enable it."
+    ) from exc
+
+from dc43.core.odps import OpenDataProductStandard, to_model
+from dc43_service_backends.data_products import DataProductRegistrationResult
+from dc43_service_clients._http_sync import close_client, ensure_response
+
+from .interface import DataProductServiceClient
+
+
+class RemoteDataProductServiceClient(DataProductServiceClient):
+    """Invoke the data product service over HTTP."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str = "http://localhost:8000",
+        client: httpx.Client | httpx.AsyncClient | None = None,
+        transport: httpx.BaseTransport | None = None,
+        headers: Mapping[str, str] | None = None,
+        auth: httpx.Auth | tuple[str, str] | None = None,
+        token: str | None = None,
+        token_header: str = "Authorization",
+        token_scheme: str = "Bearer",
+    ) -> None:
+        self._base_url = base_url.rstrip("/") if base_url else ""
+        if client is None:
+            header_map = dict(headers or {})
+            if token is not None:
+                scheme = f"{token_scheme} " if token_scheme else ""
+                header_map.setdefault(token_header, f"{scheme}{token}".strip())
+            self._client = httpx.Client(
+                base_url=self._base_url or None,
+                transport=transport,
+                headers=header_map or None,
+                auth=auth,
+            )
+            self._owns_client = True
+        else:
+            self._client = client
+            self._owns_client = False
+            if headers or auth is not None or token is not None:
+                raise ValueError(
+                    "Provide custom headers, auth, or tokens when the client is owned "
+                    "by the RemoteDataProductServiceClient."
+                )
+
+    def close(self) -> None:
+        if self._owns_client:
+            close_client(self._client)
+
+    def _request_path(self, path: str) -> str:
+        if self._base_url and not path.startswith("http"):
+            return f"{self._base_url}{path}"
+        return path
+
+    def _decode_product(self, payload: Mapping[str, object]) -> OpenDataProductStandard:
+        return to_model(payload)
+
+    def _decode_registration(
+        self, payload: Mapping[str, object]
+    ) -> DataProductRegistrationResult:
+        product_payload = payload.get("product") if isinstance(payload, Mapping) else None
+        if not isinstance(product_payload, Mapping):
+            raise ValueError("Malformed registration payload: missing product")
+        product = self._decode_product(product_payload)
+        changed = bool(payload.get("changed")) if isinstance(payload, Mapping) else False
+        return DataProductRegistrationResult(product=product, changed=changed)
+
+    def get(self, data_product_id: str, version: str) -> OpenDataProductStandard:
+        response = ensure_response(
+            self._client.get(
+                self._request_path(f"/data-products/{data_product_id}/versions/{version}"),
+            )
+        )
+        response.raise_for_status()
+        return self._decode_product(response.json())
+
+    def latest(self, data_product_id: str) -> Optional[OpenDataProductStandard]:
+        response = ensure_response(
+            self._client.get(
+                self._request_path(f"/data-products/{data_product_id}/latest"),
+            )
+        )
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        return self._decode_product(response.json())
+
+    def list_versions(self, data_product_id: str) -> list[str]:
+        response = ensure_response(
+            self._client.get(
+                self._request_path(f"/data-products/{data_product_id}/versions"),
+            )
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if isinstance(payload, list):
+            return [str(item) for item in payload]
+        return []
+
+    def register_input_port(
+        self,
+        *,
+        data_product_id: str,
+        port_name: str,
+        contract_id: str,
+        contract_version: str,
+        bump: str = "minor",
+        custom_properties: Optional[Mapping[str, object]] = None,
+        source_data_product: Optional[str] = None,
+        source_output_port: Optional[str] = None,
+    ) -> DataProductRegistrationResult:
+        response = ensure_response(
+            self._client.post(
+                self._request_path(f"/data-products/{data_product_id}/input-ports"),
+                json={
+                    "port_name": port_name,
+                    "contract_id": contract_id,
+                    "contract_version": contract_version,
+                    "bump": bump,
+                    "custom_properties": custom_properties,
+                    "source_data_product": source_data_product,
+                    "source_output_port": source_output_port,
+                },
+            )
+        )
+        response.raise_for_status()
+        return self._decode_registration(response.json())
+
+    def register_output_port(
+        self,
+        *,
+        data_product_id: str,
+        port_name: str,
+        contract_id: str,
+        contract_version: str,
+        bump: str = "minor",
+        custom_properties: Optional[Mapping[str, object]] = None,
+    ) -> DataProductRegistrationResult:
+        response = ensure_response(
+            self._client.post(
+                self._request_path(f"/data-products/{data_product_id}/output-ports"),
+                json={
+                    "port_name": port_name,
+                    "contract_id": contract_id,
+                    "contract_version": contract_version,
+                    "bump": bump,
+                    "custom_properties": custom_properties,
+                },
+            )
+        )
+        response.raise_for_status()
+        return self._decode_registration(response.json())
+
+    def resolve_output_contract(
+        self,
+        *,
+        data_product_id: str,
+        port_name: str,
+    ) -> Optional[tuple[str, str]]:
+        response = ensure_response(
+            self._client.get(
+                self._request_path(
+                    f"/data-products/{data_product_id}/output-ports/{port_name}/contract"
+                )
+            )
+        )
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        payload = response.json()
+        if isinstance(payload, Mapping):
+            cid = payload.get("contract_id")
+            cver = payload.get("contract_version")
+            if cid is not None and cver is not None:
+                return str(cid), str(cver)
+        return None
+
+
+__all__ = ["RemoteDataProductServiceClient"]
+

--- a/packages/dc43-service-clients/src/dc43_service_clients/data_products/client/remote.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/data_products/client/remote.py
@@ -12,11 +12,11 @@ except ModuleNotFoundError as exc:  # pragma: no cover
         "'dc43-service-clients[http]' to enable it."
     ) from exc
 
-from dc43_service_backends.data_products import DataProductRegistrationResult
 from dc43_service_clients.odps import OpenDataProductStandard, to_model
 from dc43_service_clients._http_sync import close_client, ensure_response
 
 from .interface import DataProductServiceClient
+from .._compat import DataProductRegistrationResult
 
 
 class RemoteDataProductServiceClient(DataProductServiceClient):

--- a/packages/dc43-service-clients/src/dc43_service_clients/data_products/models.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/data_products/models.py
@@ -1,0 +1,101 @@
+"""Light-weight helpers for data product integrations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, MutableMapping, Optional
+
+
+@dataclass
+class DataProductInputBinding:
+    """Describe how a dataset should be registered as an input port."""
+
+    data_product: str
+    port_name: Optional[str] = None
+    source_data_product: Optional[str] = None
+    source_output_port: Optional[str] = None
+    bump: str = "minor"
+    custom_properties: Optional[Mapping[str, object]] = None
+
+
+@dataclass
+class DataProductOutputBinding:
+    """Describe how a dataset should be registered as an output port."""
+
+    data_product: str
+    port_name: Optional[str] = None
+    bump: str = "minor"
+    custom_properties: Optional[Mapping[str, object]] = None
+
+
+def _normalise_mapping(value: Optional[Mapping[str, object]]) -> Optional[Mapping[str, object]]:
+    if value is None:
+        return None
+    if isinstance(value, MutableMapping):
+        return value
+    return dict(value)
+
+
+def normalise_input_binding(
+    spec: DataProductInputBinding | Mapping[str, object] | None,
+) -> Optional[DataProductInputBinding]:
+    """Convert ``spec`` to :class:`DataProductInputBinding` when possible."""
+
+    if spec is None:
+        return None
+    if isinstance(spec, DataProductInputBinding):
+        spec.custom_properties = _normalise_mapping(spec.custom_properties)
+        return spec
+    if isinstance(spec, Mapping):
+        data_product = spec.get("data_product") or spec.get("dataProduct")
+        if not data_product:
+            return None
+        return DataProductInputBinding(
+            data_product=str(data_product),
+            port_name=str(spec.get("port_name") or spec.get("portName") or "").strip() or None,
+            source_data_product=str(spec.get("source_data_product") or spec.get("sourceDataProduct") or "").strip() or None,
+            source_output_port=str(spec.get("source_output_port") or spec.get("sourceOutputPort") or "").strip() or None,
+            bump=str(spec.get("bump") or "minor"),
+            custom_properties=_normalise_mapping(
+                spec.get("custom_properties")
+                or spec.get("customProperties")
+                or None
+            ),
+        )
+    return None
+
+
+def normalise_output_binding(
+    spec: DataProductOutputBinding | Mapping[str, object] | None,
+) -> Optional[DataProductOutputBinding]:
+    """Convert ``spec`` to :class:`DataProductOutputBinding` when possible."""
+
+    if spec is None:
+        return None
+    if isinstance(spec, DataProductOutputBinding):
+        spec.custom_properties = _normalise_mapping(spec.custom_properties)
+        return spec
+    if isinstance(spec, Mapping):
+        data_product = spec.get("data_product") or spec.get("dataProduct")
+        if not data_product:
+            return None
+        return DataProductOutputBinding(
+            data_product=str(data_product),
+            port_name=str(spec.get("port_name") or spec.get("portName") or "").strip() or None,
+            bump=str(spec.get("bump") or "minor"),
+            custom_properties=_normalise_mapping(
+                spec.get("custom_properties")
+                or spec.get("customProperties")
+                or None
+            ),
+        )
+    return None
+
+
+__all__ = [
+    "DataProductInputBinding",
+    "DataProductOutputBinding",
+    "normalise_input_binding",
+    "normalise_output_binding",
+]
+

--- a/packages/dc43-service-clients/src/dc43_service_clients/odps.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/odps.py
@@ -13,7 +13,10 @@ from __future__ import annotations
 from importlib import import_module, util as importlib_util
 
 
-_CORE_SPEC = importlib_util.find_spec("dc43.core.odps")
+try:  # pragma: no cover - exercised when dc43 is absent
+    _CORE_SPEC = importlib_util.find_spec("dc43.core.odps")
+except ModuleNotFoundError:  # pragma: no cover - guard for namespace packages
+    _CORE_SPEC = None
 
 if _CORE_SPEC is not None:  # pragma: no cover - exercised when dc43 is present
     _core = import_module("dc43.core.odps")

--- a/packages/dc43-service-clients/src/dc43_service_clients/odps.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/odps.py
@@ -1,0 +1,453 @@
+"""Open Data Product Standard helpers shared across dc43 packages.
+
+This module prefers the canonical implementation that lives in ``dc43.core``
+when it is available so applications embedding the full dc43 distribution only
+have a single source of truth for the ODPS model helpers.  When the core
+package is not installed – for example when running the standalone service
+client test suite – the module falls back to a self-contained implementation so
+the clients can continue to operate.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module, util as importlib_util
+
+
+_CORE_SPEC = importlib_util.find_spec("dc43.core.odps")
+
+if _CORE_SPEC is not None:  # pragma: no cover - exercised when dc43 is present
+    _core = import_module("dc43.core.odps")
+
+    DataProductInputPort = _core.DataProductInputPort
+    DataProductOutputPort = _core.DataProductOutputPort
+    OpenDataProductStandard = _core.OpenDataProductStandard
+    as_odps_dict = _core.as_odps_dict
+    evolve_to_draft = _core.evolve_to_draft
+    next_draft_version = _core.next_draft_version
+    to_model = _core.to_model
+    ODPS_REQUIRED = _core.ODPS_REQUIRED
+
+    __all__ = [
+        "DataProductInputPort",
+        "DataProductOutputPort",
+        "OpenDataProductStandard",
+        "as_odps_dict",
+        "evolve_to_draft",
+        "next_draft_version",
+        "to_model",
+        "ODPS_REQUIRED",
+    ]
+else:
+    from dataclasses import dataclass, field
+    from typing import Any, Dict, Iterable, List, Mapping, Optional
+    import copy
+    import os
+    import re
+
+    SEMVER_RE = re.compile(
+        r"^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$"
+    )
+
+    @dataclass(frozen=True)
+    class SemVer:
+        """Tiny SemVer parser/utility used for version checks."""
+
+        major: int
+        minor: int
+        patch: int
+        prerelease: Optional[str] = None
+        build: Optional[str] = None
+
+        def __str__(self) -> str:  # pragma: no cover - exercised via to_dict
+            base = f"{self.major}.{self.minor}.{self.patch}"
+            if self.prerelease:
+                base += f"-{self.prerelease}"
+            if self.build:
+                base += f"+{self.build}"
+            return base
+
+        @staticmethod
+        def parse(s: str) -> "SemVer":
+            """Parse a ``MAJOR.MINOR.PATCH[-prerelease][+build]`` string."""
+
+            match = SEMVER_RE.match(s)
+            if not match:
+                raise ValueError(f"Invalid semver: {s}")
+            major, minor, patch, prerelease, build = match.groups()
+            return SemVer(int(major), int(minor), int(patch), prerelease, build)
+
+        def bump(self, level: str) -> "SemVer":
+            """Return a new instance bumped at ``major``/``minor``/``patch`` level."""
+
+            if level == "major":
+                return SemVer(self.major + 1, 0, 0)
+            if level == "minor":
+                return SemVer(self.major, self.minor + 1, 0)
+            if level == "patch":
+                return SemVer(self.major, self.minor, self.patch + 1)
+            raise ValueError("level must be one of: major, minor, patch")
+
+
+    ODPS_REQUIRED = os.getenv("DC43_ODPS_REQUIRED", "1.0.0")
+
+
+    def _normalise_custom_properties(raw: Any) -> List[Dict[str, Any]]:
+        if not raw:
+            return []
+        if isinstance(raw, list):
+            return [dict(item) for item in raw if isinstance(item, Mapping)]
+        if isinstance(raw, Mapping):
+            return [dict(raw)]
+        try:
+            return [dict(item) for item in raw if isinstance(item, Mapping)]
+        except TypeError:
+            return []
+
+
+    def _copy_unknown_fields(
+        data: Mapping[str, Any],
+        known: Iterable[str],
+    ) -> Dict[str, Any]:
+        unknown: Dict[str, Any] = {}
+        known_keys = {str(key) for key in known}
+        for key, value in data.items():
+            if key in known_keys:
+                continue
+            unknown[key] = copy.deepcopy(value)
+        return unknown
+
+
+    @dataclass
+    class DataProductInputPort:
+        """Representation of an ODPS input port."""
+
+        name: str
+        version: str
+        contract_id: str
+        custom_properties: List[Dict[str, Any]] = field(default_factory=list)
+        authoritative_definitions: List[Dict[str, Any]] = field(default_factory=list)
+        extra: Dict[str, Any] = field(default_factory=dict)
+
+        @classmethod
+        def from_dict(cls, data: Mapping[str, Any]) -> "DataProductInputPort":
+            name = str(data.get("name", "")).strip()
+            version = str(data.get("version", "")).strip()
+            contract_id = str(data.get("contractId", "")).strip()
+            if not name or not version or not contract_id:
+                raise ValueError("Input port requires name, version, and contractId")
+            extra = _copy_unknown_fields(
+                data,
+                ["name", "version", "contractId", "customProperties", "authoritativeDefinitions"],
+            )
+            return cls(
+                name=name,
+                version=version,
+                contract_id=contract_id,
+                custom_properties=_normalise_custom_properties(data.get("customProperties")),
+                authoritative_definitions=_normalise_custom_properties(
+                    data.get("authoritativeDefinitions")
+                ),
+                extra=extra,
+            )
+
+        def to_dict(self) -> Dict[str, Any]:
+            payload: Dict[str, Any] = {
+                "name": self.name,
+                "version": self.version,
+                "contractId": self.contract_id,
+            }
+            if self.custom_properties:
+                payload["customProperties"] = [
+                    copy.deepcopy(item) for item in self.custom_properties
+                ]
+            if self.authoritative_definitions:
+                payload["authoritativeDefinitions"] = [
+                    copy.deepcopy(item) for item in self.authoritative_definitions
+                ]
+            if self.extra:
+                payload.update(copy.deepcopy(self.extra))
+            return payload
+
+
+    @dataclass
+    class DataProductOutputPort:
+        """Representation of an ODPS output port."""
+
+        name: str
+        version: str
+        contract_id: str
+        description: Optional[str] = None
+        type: Optional[str] = None
+        sbom: List[Dict[str, Any]] = field(default_factory=list)
+        input_contracts: List[Dict[str, Any]] = field(default_factory=list)
+        custom_properties: List[Dict[str, Any]] = field(default_factory=list)
+        authoritative_definitions: List[Dict[str, Any]] = field(default_factory=list)
+        extra: Dict[str, Any] = field(default_factory=dict)
+
+        @classmethod
+        def from_dict(cls, data: Mapping[str, Any]) -> "DataProductOutputPort":
+            name = str(data.get("name", "")).strip()
+            version = str(data.get("version", "")).strip()
+            if not name or not version:
+                raise ValueError("Output port requires name and version")
+            contract_value = data.get("contractId")
+            contract_id = str(contract_value).strip() if contract_value is not None else ""
+            if not contract_id:
+                raise ValueError("Output port requires contractId")
+            known_fields = {
+                "name",
+                "version",
+                "contractId",
+                "description",
+                "type",
+                "sbom",
+                "inputContracts",
+                "customProperties",
+                "authoritativeDefinitions",
+            }
+            extra = _copy_unknown_fields(data, known_fields)
+            return cls(
+                name=name,
+                version=version,
+                contract_id=contract_id,
+                description=str(data["description"]).strip() if data.get("description") else None,
+                type=str(data["type"]).strip() if data.get("type") else None,
+                sbom=_normalise_custom_properties(data.get("sbom")),
+                input_contracts=_normalise_custom_properties(data.get("inputContracts")),
+                custom_properties=_normalise_custom_properties(data.get("customProperties")),
+                authoritative_definitions=_normalise_custom_properties(
+                    data.get("authoritativeDefinitions")
+                ),
+                extra=extra,
+            )
+
+        def to_dict(self) -> Dict[str, Any]:
+            payload: Dict[str, Any] = {
+                "name": self.name,
+                "version": self.version,
+                "contractId": self.contract_id,
+            }
+            if self.description:
+                payload["description"] = self.description
+            if self.type:
+                payload["type"] = self.type
+            if self.sbom:
+                payload["sbom"] = [copy.deepcopy(item) for item in self.sbom]
+            if self.input_contracts:
+                payload["inputContracts"] = [
+                    copy.deepcopy(item) for item in self.input_contracts
+                ]
+            if self.custom_properties:
+                payload["customProperties"] = [
+                    copy.deepcopy(item) for item in self.custom_properties
+                ]
+            if self.authoritative_definitions:
+                payload["authoritativeDefinitions"] = [
+                    copy.deepcopy(item) for item in self.authoritative_definitions
+                ]
+            if self.extra:
+                payload.update(copy.deepcopy(self.extra))
+            return payload
+
+
+    @dataclass
+    class OpenDataProductStandard:
+        """Minimal representation of an ODPS document."""
+
+        id: str
+        status: str
+        api_version: str = ODPS_REQUIRED
+        kind: str = "DataProduct"
+        version: Optional[str] = None
+        name: Optional[str] = None
+        description: Optional[Mapping[str, Any]] = None
+        input_ports: List[DataProductInputPort] = field(default_factory=list)
+        output_ports: List[DataProductOutputPort] = field(default_factory=list)
+        custom_properties: List[Dict[str, Any]] = field(default_factory=list)
+        tags: List[str] = field(default_factory=list)
+        extra: Dict[str, Any] = field(default_factory=dict)
+
+        @classmethod
+        def from_dict(cls, data: Mapping[str, Any]) -> "OpenDataProductStandard":
+            api_version = str(data.get("apiVersion", "")).strip() or ODPS_REQUIRED
+            if api_version != ODPS_REQUIRED:
+                raise ValueError(
+                    f"ODPS apiVersion mismatch. Required {ODPS_REQUIRED}, got {api_version}"
+                )
+            product_id = str(data.get("id", "")).strip()
+            status = str(data.get("status", "")).strip() or "draft"
+            if not product_id:
+                raise ValueError("Data product requires an id")
+            output_ports_raw = data.get("outputPorts", [])
+            input_ports_raw = data.get("inputPorts", [])
+            custom_properties = _normalise_custom_properties(data.get("customProperties"))
+            tags = [str(tag).strip() for tag in data.get("tags", []) if str(tag).strip()]
+            known_fields = {
+                "apiVersion",
+                "id",
+                "kind",
+                "name",
+                "description",
+                "status",
+                "version",
+                "inputPorts",
+                "outputPorts",
+                "customProperties",
+                "tags",
+            }
+            extra = _copy_unknown_fields(data, known_fields)
+            instance = cls(
+                id=product_id,
+                status=status,
+                api_version=api_version,
+                kind=str(data.get("kind", "DataProduct")),
+                version=str(data.get("version")) if data.get("version") else None,
+                name=str(data.get("name")) if data.get("name") else None,
+                description=data.get("description") if isinstance(data.get("description"), Mapping) else None,
+                custom_properties=custom_properties,
+                tags=tags,
+                extra=extra,
+            )
+            instance.input_ports = [
+                DataProductInputPort.from_dict(port)
+                for port in input_ports_raw
+                if isinstance(port, Mapping)
+            ]
+            instance.output_ports = [
+                DataProductOutputPort.from_dict(port)
+                for port in output_ports_raw
+                if isinstance(port, Mapping)
+            ]
+            return instance
+
+        def to_dict(self) -> Dict[str, Any]:
+            payload: Dict[str, Any] = {
+                "apiVersion": self.api_version,
+                "id": self.id,
+                "kind": self.kind,
+                "status": self.status,
+            }
+            if self.version:
+                payload["version"] = self.version
+            if self.name:
+                payload["name"] = self.name
+            if self.description:
+                payload["description"] = copy.deepcopy(self.description)
+            if self.input_ports:
+                payload["inputPorts"] = [port.to_dict() for port in self.input_ports]
+            if self.output_ports:
+                payload["outputPorts"] = [port.to_dict() for port in self.output_ports]
+            if self.custom_properties:
+                payload["customProperties"] = [
+                    copy.deepcopy(item) for item in self.custom_properties
+                ]
+            if self.tags:
+                payload["tags"] = [str(tag) for tag in self.tags]
+            if self.extra:
+                payload.update(copy.deepcopy(self.extra))
+            return payload
+
+        def clone(self) -> "OpenDataProductStandard":
+            return OpenDataProductStandard.from_dict(self.to_dict())
+
+        def find_input_port(self, name: str) -> Optional[DataProductInputPort]:
+            return next((port for port in self.input_ports if port.name == name), None)
+
+        def find_output_port(self, name: str) -> Optional[DataProductOutputPort]:
+            return next((port for port in self.output_ports if port.name == name), None)
+
+        def ensure_input_port(self, port: DataProductInputPort) -> bool:
+            existing = self.find_input_port(port.name)
+            if existing and existing.to_dict() == port.to_dict():
+                return False
+            if existing:
+                self.input_ports = [
+                    port if candidate.name == port.name else candidate
+                    for candidate in self.input_ports
+                ]
+            else:
+                self.input_ports.append(port)
+            return True
+
+        def ensure_output_port(self, port: DataProductOutputPort) -> bool:
+            existing = self.find_output_port(port.name)
+            if existing and existing.to_dict() == port.to_dict():
+                return False
+            if existing:
+                self.output_ports = [
+                    port if candidate.name == port.name else candidate
+                    for candidate in self.output_ports
+                ]
+            else:
+                self.output_ports.append(port)
+            return True
+
+
+    def _ensure_semver(candidate: str) -> str:
+        try:
+            SemVer.parse(candidate)
+        except ValueError as exc:  # pragma: no cover - validation guard
+            raise ValueError(f"Invalid version '{candidate}': {exc}") from exc
+        return candidate
+
+
+    def next_draft_version(existing_versions: Iterable[str]) -> str:
+        versions = [SemVer.parse(version) for version in existing_versions]
+        if not versions:
+            return "0.1.0"
+        latest = max(versions, key=lambda version: (version.major, version.minor, version.patch))
+        if latest.major == 0 and latest.minor == 0:
+            return str(latest.bump("patch"))
+        return str(latest.bump("minor"))
+
+
+    def evolve_to_draft(
+        product: OpenDataProductStandard,
+        *,
+        existing_versions: Iterable[str],
+        bump: str = "minor",
+    ) -> OpenDataProductStandard:
+        current_version = product.version
+        if current_version:
+            base = SemVer.parse(current_version)
+            base = SemVer(base.major, base.minor, base.patch)
+        else:
+            base = SemVer.parse("0.1.0")
+            if bump == "major":
+                base = SemVer.parse("1.0.0")
+            elif bump == "patch":
+                base = SemVer.parse("0.0.1")
+        versions = [SemVer.parse(version) for version in existing_versions]
+        while True:
+            candidate = base.bump(bump) if current_version else base
+            if candidate not in versions:
+                product.version = str(candidate)
+                break
+            base = candidate
+        product.status = "draft"
+        return product
+
+
+    def as_odps_dict(product: OpenDataProductStandard) -> Dict[str, Any]:
+        payload = product.to_dict()
+        payload["inputPorts"] = [port.to_dict() for port in product.input_ports]
+        payload["outputPorts"] = [port.to_dict() for port in product.output_ports]
+        return payload
+
+
+    def to_model(payload: Mapping[str, Any]) -> OpenDataProductStandard:
+        if not isinstance(payload, Mapping):
+            raise TypeError("Payload must be a mapping")
+        return OpenDataProductStandard.from_dict(payload)
+
+
+    __all__ = [
+        "DataProductInputPort",
+        "DataProductOutputPort",
+        "OpenDataProductStandard",
+        "as_odps_dict",
+        "evolve_to_draft",
+        "next_draft_version",
+        "to_model",
+        "ODPS_REQUIRED",
+    ]

--- a/packages/dc43-service-clients/src/dc43_service_clients/testing/__init__.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/testing/__init__.py
@@ -1,0 +1,8 @@
+"""Testing helpers for dc43 service clients."""
+
+from .backends import DataProductRegistrationResult, LocalDataProductServiceBackend
+
+__all__ = [
+    "DataProductRegistrationResult",
+    "LocalDataProductServiceBackend",
+]

--- a/packages/dc43-service-clients/src/dc43_service_clients/testing/backends.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/testing/backends.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
 from typing import Dict, Iterable, Mapping, Optional
 
 from dc43_service_clients.odps import (
@@ -13,13 +12,7 @@ from dc43_service_clients.odps import (
     evolve_to_draft,
 )
 
-
-@dataclass
-class DataProductRegistrationResult:
-    """Result returned by port registration operations."""
-
-    product: OpenDataProductStandard
-    changed: bool
+from ..data_products._compat import DataProductRegistrationResult
 
 
 class LocalDataProductServiceBackend:

--- a/packages/dc43-service-clients/src/dc43_service_clients/testing/backends.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/testing/backends.py
@@ -1,0 +1,174 @@
+"""Test-oriented data product backend implementations."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping, Optional
+
+from dc43_service_clients.odps import (
+    DataProductInputPort,
+    DataProductOutputPort,
+    OpenDataProductStandard,
+    evolve_to_draft,
+)
+
+
+@dataclass
+class DataProductRegistrationResult:
+    """Result returned by port registration operations."""
+
+    product: OpenDataProductStandard
+    changed: bool
+
+
+class LocalDataProductServiceBackend:
+    """Minimal in-memory backend suitable for client test suites."""
+
+    def __init__(self) -> None:
+        self._products: Dict[str, Dict[str, OpenDataProductStandard]] = defaultdict(dict)
+        self._latest: Dict[str, str] = {}
+
+    def _existing_versions(self, data_product_id: str) -> Iterable[str]:
+        return self._products.get(data_product_id, {}).keys()
+
+    def put(self, product: OpenDataProductStandard) -> None:
+        if not product.version:
+            raise ValueError("Data product version is required")
+        store = self._products.setdefault(product.id, {})
+        store[product.version] = product.clone()
+        self._latest[product.id] = product.version
+
+    def get(self, data_product_id: str, version: str) -> OpenDataProductStandard:
+        versions = self._products.get(data_product_id)
+        if not versions or version not in versions:
+            raise FileNotFoundError(f"data product {data_product_id}:{version} not found")
+        return versions[version].clone()
+
+    def latest(self, data_product_id: str) -> Optional[OpenDataProductStandard]:
+        version = self._latest.get(data_product_id)
+        if version is None:
+            return None
+        return self.get(data_product_id, version)
+
+    def list_versions(self, data_product_id: str) -> list[str]:
+        versions = self._products.get(data_product_id, {})
+        return sorted(versions.keys())
+
+    def _ensure_product(self, data_product_id: str) -> OpenDataProductStandard:
+        latest = self.latest(data_product_id)
+        if latest is not None:
+            return latest.clone()
+        product = OpenDataProductStandard(id=data_product_id, status="draft")
+        product.version = None
+        return product
+
+    def _store_updated(
+        self,
+        product: OpenDataProductStandard,
+        *,
+        bump: str,
+        existing_versions: Iterable[str],
+    ) -> OpenDataProductStandard:
+        evolve_to_draft(product, existing_versions=existing_versions, bump=bump)
+        self.put(product)
+        return product
+
+    def register_input_port(
+        self,
+        *,
+        data_product_id: str,
+        port: DataProductInputPort,
+        bump: str = "minor",
+        custom_properties: Optional[Mapping[str, object]] = None,
+        source_data_product: Optional[str] = None,
+        source_output_port: Optional[str] = None,
+    ) -> DataProductRegistrationResult:
+        product = self._ensure_product(data_product_id)
+        did_change = product.ensure_input_port(port)
+        if not did_change:
+            return DataProductRegistrationResult(product=product, changed=False)
+
+        props = self._as_custom_properties(custom_properties)
+        if source_data_product:
+            props.append(
+                {
+                    "property": "dc43.input.source_data_product",
+                    "value": source_data_product,
+                }
+            )
+        if source_output_port:
+            props.append(
+                {
+                    "property": "dc43.input.source_output_port",
+                    "value": source_output_port,
+                }
+            )
+        if props:
+            port.custom_properties.extend(
+                [item for item in props if item not in port.custom_properties]
+            )
+
+        updated = self._store_updated(
+            product,
+            bump=bump,
+            existing_versions=self._existing_versions(data_product_id),
+        )
+        return DataProductRegistrationResult(product=updated, changed=True)
+
+    def register_output_port(
+        self,
+        *,
+        data_product_id: str,
+        port: DataProductOutputPort,
+        bump: str = "minor",
+        custom_properties: Optional[Mapping[str, object]] = None,
+    ) -> DataProductRegistrationResult:
+        product = self._ensure_product(data_product_id)
+        did_change = product.ensure_output_port(port)
+        if not did_change:
+            return DataProductRegistrationResult(product=product, changed=False)
+
+        props = self._as_custom_properties(custom_properties)
+        if props:
+            port.custom_properties.extend(
+                [item for item in props if item not in port.custom_properties]
+            )
+
+        updated = self._store_updated(
+            product,
+            bump=bump,
+            existing_versions=self._existing_versions(data_product_id),
+        )
+        return DataProductRegistrationResult(product=updated, changed=True)
+
+    def resolve_output_contract(
+        self,
+        *,
+        data_product_id: str,
+        port_name: str,
+    ) -> Optional[tuple[str, str]]:
+        product = self.latest(data_product_id)
+        if product is None:
+            return None
+        port = product.find_output_port(port_name)
+        if port is None or not port.contract_id:
+            return None
+        return port.contract_id, port.version
+
+    @staticmethod
+    def _as_custom_properties(
+        data: Optional[Mapping[str, object]]
+    ) -> list[dict[str, object]]:
+        if not data:
+            return []
+        props: list[dict[str, object]] = []
+        for key, value in data.items():
+            props.append({"property": str(key), "value": value})
+        return props
+
+
+__all__ = [
+    "DataProductRegistrationResult",
+    "LocalDataProductServiceBackend",
+]

--- a/packages/dc43-service-clients/tests/test_remote_clients.py
+++ b/packages/dc43-service-clients/tests/test_remote_clients.py
@@ -526,12 +526,13 @@ def test_remote_data_product_client_registers_ports(http_clients):
 
 def test_remote_data_product_resolve_output_contract(http_clients):
     dp_client: RemoteDataProductServiceClient = http_clients["data_product"]
+    contract: OpenDataContractStandard = http_clients["contract_model"]
 
     contract_ref = dp_client.resolve_output_contract(
         data_product_id="dp.analytics",
         port_name="primary",
     )
-    assert contract_ref == ("test.orders", "0.1.0")
+    assert contract_ref == (contract.id, contract.version)
 
 
 def test_http_clients_require_authentication(service_backend):

--- a/packages/dc43-service-clients/tests/test_remote_clients.py
+++ b/packages/dc43-service-clients/tests/test_remote_clients.py
@@ -16,8 +16,8 @@ from open_data_contract_standard.model import (  # type: ignore
     Server,
 )
 
-from dc43.core.odps import DataProductInputPort, DataProductOutputPort
 from dc43_service_backends.data_products import LocalDataProductServiceBackend
+from dc43_service_clients.odps import DataProductInputPort, DataProductOutputPort
 from dc43_service_clients.contracts.client.remote import RemoteContractServiceClient
 from dc43_service_clients.data_quality import ObservationPayload
 from dc43_service_clients.data_products.client.remote import RemoteDataProductServiceClient

--- a/packages/dc43-service-clients/tests/test_remote_clients.py
+++ b/packages/dc43-service-clients/tests/test_remote_clients.py
@@ -16,8 +16,11 @@ from open_data_contract_standard.model import (  # type: ignore
     Server,
 )
 
+from dc43.core.odps import DataProductInputPort, DataProductOutputPort
+from dc43_service_backends.data_products import LocalDataProductServiceBackend
 from dc43_service_clients.contracts.client.remote import RemoteContractServiceClient
 from dc43_service_clients.data_quality import ObservationPayload
+from dc43_service_clients.data_products.client.remote import RemoteDataProductServiceClient
 from dc43_service_clients.data_quality.client.remote import RemoteDataQualityServiceClient
 from dc43_service_clients.data_quality.models import ValidationResult
 from dc43_service_clients.data_quality.transport import encode_validation_result
@@ -80,6 +83,15 @@ class _ServiceBackendMock:
         self._dataset_links: dict[tuple[str, str], str] = {}
         self._governance_status: dict[tuple[str, str], ValidationResult] = {}
         self._pipeline_activity: list[dict[str, object]] = []
+        self._data_products = LocalDataProductServiceBackend()
+        self._data_products.register_output_port(
+            data_product_id="dp.analytics",
+            port=DataProductOutputPort(
+                name="primary",
+                version=contract.version,
+                contract_id=contract.id,
+            ),
+        )
 
     def __call__(self, request: "httpx.Request") -> "httpx.Response":  # pragma: no cover - exercised in tests
         auth_error = self._require_token(request)
@@ -94,6 +106,8 @@ class _ServiceBackendMock:
             return self._handle_data_quality(request, method, path)
         if path.startswith("/governance/"):
             return self._handle_governance(request, method, path)
+        if path.startswith("/data-products/"):
+            return self._handle_data_products(request, method, path)
         return httpx.Response(status_code=404, json={"detail": "Not Found"})
 
     def _require_token(self, request: "httpx.Request") -> "httpx.Response | None":
@@ -159,6 +173,91 @@ class _ServiceBackendMock:
             ]
             return httpx.Response(status_code=200, json=expectations)
         return httpx.Response(status_code=404, json={"detail": "Unknown data-quality endpoint"})
+
+    def _handle_data_products(self, request: "httpx.Request", method: str, path: str) -> "httpx.Response":
+        segments = path.strip("/").split("/")
+        if len(segments) < 2:
+            return httpx.Response(status_code=404, json={"detail": "Unknown data-product endpoint"})
+        product_id = segments[1]
+        backend = self._data_products
+
+        if len(segments) >= 4 and segments[2] == "versions" and method == "GET":
+            version = segments[3]
+            try:
+                product = backend.get(product_id, version)
+            except FileNotFoundError:
+                return httpx.Response(status_code=404, json={"detail": "Unknown data product"})
+            return httpx.Response(status_code=200, json=product.to_dict())
+
+        if len(segments) == 3 and segments[2] == "latest" and method == "GET":
+            product = backend.latest(product_id)
+            if product is None:
+                return httpx.Response(status_code=404, json={"detail": "Unknown data product"})
+            return httpx.Response(status_code=200, json=product.to_dict())
+
+        if len(segments) == 3 and segments[2] == "versions" and method == "GET":
+            versions = backend.list_versions(product_id)
+            return httpx.Response(status_code=200, json=list(versions))
+
+        if len(segments) == 3 and segments[2] == "input-ports" and method == "POST":
+            payload = self._read_json(request)
+            port = DataProductInputPort(
+                name=str(payload.get("port_name")),
+                version=str(payload.get("contract_version")),
+                contract_id=str(payload.get("contract_id")),
+            )
+            result = backend.register_input_port(
+                data_product_id=product_id,
+                port=port,
+                bump=str(payload.get("bump", "minor")),
+                custom_properties=payload.get("custom_properties"),
+                source_data_product=payload.get("source_data_product"),
+                source_output_port=payload.get("source_output_port"),
+            )
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "product": result.product.to_dict(),
+                    "changed": result.changed,
+                },
+            )
+
+        if len(segments) == 3 and segments[2] == "output-ports" and method == "POST":
+            payload = self._read_json(request)
+            port = DataProductOutputPort(
+                name=str(payload.get("port_name")),
+                version=str(payload.get("contract_version")),
+                contract_id=str(payload.get("contract_id")),
+            )
+            result = backend.register_output_port(
+                data_product_id=product_id,
+                port=port,
+                bump=str(payload.get("bump", "minor")),
+                custom_properties=payload.get("custom_properties"),
+            )
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "product": result.product.to_dict(),
+                    "changed": result.changed,
+                },
+            )
+
+        if len(segments) == 5 and segments[2] == "output-ports" and segments[4] == "contract" and method == "GET":
+            port_name = segments[3]
+            resolved = backend.resolve_output_contract(
+                data_product_id=product_id,
+                port_name=port_name,
+            )
+            if resolved is None:
+                return httpx.Response(status_code=404, json={"detail": "Unknown output port"})
+            contract_id, contract_version = resolved
+            return httpx.Response(
+                status_code=200,
+                json={"contract_id": contract_id, "contract_version": contract_version},
+            )
+
+        return httpx.Response(status_code=404, json={"detail": "Unknown data-product endpoint"})
 
     def _handle_governance(self, request: "httpx.Request", method: str, path: str) -> "httpx.Response":
         if path == "/governance/evaluate" and method == "POST":
@@ -282,11 +381,17 @@ def http_clients(service_backend):
         transport=httpx.MockTransport(backend),
         token=token,
     )
+    data_product_client = RemoteDataProductServiceClient(
+        base_url="http://dc43-services",
+        transport=httpx.MockTransport(backend),
+        token=token,
+    )
 
     clients = {
         "contract": contract_client,
         "dq": dq_client,
         "governance": governance_client,
+        "data_product": data_product_client,
         "contract_model": contract,
         "backend": backend,
         "token": token,
@@ -297,6 +402,7 @@ def http_clients(service_backend):
         contract_client.close()
         dq_client.close()
         governance_client.close()
+        data_product_client.close()
 
 
 def test_remote_contract_client_roundtrip(http_clients):
@@ -389,6 +495,40 @@ def test_remote_governance_client(http_clients):
     activity = governance_client.get_pipeline_activity(dataset_id="orders")
     assert isinstance(activity, list)
     assert activity
+
+
+def test_remote_data_product_client_registers_ports(http_clients):
+    dp_client: RemoteDataProductServiceClient = http_clients["data_product"]
+
+    registration = dp_client.register_input_port(
+        data_product_id="dp.analytics",
+        port_name="orders-input",
+        contract_id="sales.orders",
+        contract_version="1.0.0",
+        source_data_product="dp.source",
+        source_output_port="gold",
+    )
+    assert registration.changed is True
+    assert any(port.name == "orders-input" for port in registration.product.input_ports)
+
+    updated = dp_client.register_output_port(
+        data_product_id="dp.analytics",
+        port_name="forecast",
+        contract_id="sales.forecast",
+        contract_version="2.0.0",
+    )
+    assert updated.changed is True
+    assert any(port.name == "forecast" for port in updated.product.output_ports)
+
+
+def test_remote_data_product_resolve_output_contract(http_clients):
+    dp_client: RemoteDataProductServiceClient = http_clients["data_product"]
+
+    contract_ref = dp_client.resolve_output_contract(
+        data_product_id="dp.analytics",
+        port_name="primary",
+    )
+    assert contract_ref == ("test.orders", "0.1.0")
 
 
 def test_http_clients_require_authentication(service_backend):

--- a/packages/dc43-service-clients/tests/test_remote_clients.py
+++ b/packages/dc43-service-clients/tests/test_remote_clients.py
@@ -16,7 +16,10 @@ from open_data_contract_standard.model import (  # type: ignore
     Server,
 )
 
-from dc43_service_backends.data_products import LocalDataProductServiceBackend
+try:
+    from dc43_service_backends.data_products import LocalDataProductServiceBackend
+except ModuleNotFoundError:  # pragma: no cover - exercise fallback when backends missing
+    from dc43_service_clients.testing import LocalDataProductServiceBackend
 from dc43_service_clients.odps import DataProductInputPort, DataProductOutputPort
 from dc43_service_clients.contracts.client.remote import RemoteContractServiceClient
 from dc43_service_clients.data_quality import ObservationPayload

--- a/src/dc43/core/__init__.py
+++ b/src/dc43/core/__init__.py
@@ -17,11 +17,22 @@ from .odcs import (
     odcs_package_version,
     to_model,
 )
+from .odps import (
+    ODPS_REQUIRED,
+    DataProductInputPort,
+    DataProductOutputPort,
+    OpenDataProductStandard as OpenDataProduct,
+    as_odps_dict as as_odps_product_dict,
+    evolve_to_draft as evolve_odps_to_draft,
+    next_draft_version as next_odps_draft_version,
+    to_model as to_odps_model,
+)
 from .versioning import SemVer
 
 __all__ = [
     "BITOL_SCHEMA_URL",
     "ODCS_REQUIRED",
+    "ODPS_REQUIRED",
     "SemVer",
     "as_odcs_dict",
     "build_odcs",
@@ -34,4 +45,11 @@ __all__ = [
     "normalise_custom_properties",
     "odcs_package_version",
     "to_model",
+    "DataProductInputPort",
+    "DataProductOutputPort",
+    "OpenDataProduct",
+    "as_odps_product_dict",
+    "evolve_odps_to_draft",
+    "next_odps_draft_version",
+    "to_odps_model",
 ]

--- a/src/dc43/core/odps.py
+++ b/src/dc43/core/odps.py
@@ -1,0 +1,372 @@
+"""Open Data Product Standard (ODPS) helpers.
+
+The Open Data Product Standard currently has no official Python model binding,
+so dc43 ships a light-weight representation that focuses on the portions we
+interact with programmatically: input/output port definitions and version
+management.  The helper keeps the following goals in mind:
+
+* Provide a structured representation for ODPS documents while preserving
+  unknown attributes.
+* Offer primitives to add or update input/output ports while ensuring the
+  document evolves into a draft version.
+* Keep the implementation dependency-free (relying only on the standard
+  library) so projects embedding dc43 are not forced to install additional
+  modelling frameworks.
+
+The minimal model implemented here deliberately ignores large sections of the
+ODPS schema that dc43 does not need (for example the SBOM, support contacts or
+team definitions).  The raw payload is preserved so documents can be
+round-tripped even when new fields are added by upstream specifications.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+import copy
+import os
+
+from .versioning import SemVer
+
+
+ODPS_REQUIRED = os.getenv("DC43_ODPS_REQUIRED", "1.0.0")
+
+
+def _normalise_custom_properties(raw: Any) -> List[Dict[str, Any]]:
+    if not raw:
+        return []
+    if isinstance(raw, list):
+        return [dict(item) for item in raw if isinstance(item, Mapping)]
+    if isinstance(raw, Mapping):
+        return [dict(raw)]
+    try:
+        return [dict(item) for item in raw if isinstance(item, Mapping)]
+    except TypeError:
+        return []
+
+
+def _copy_unknown_fields(
+    data: Mapping[str, Any],
+    known: Iterable[str],
+) -> Dict[str, Any]:
+    unknown: Dict[str, Any] = {}
+    known_keys = {str(key) for key in known}
+    for key, value in data.items():
+        if key in known_keys:
+            continue
+        unknown[key] = copy.deepcopy(value)
+    return unknown
+
+
+@dataclass
+class DataProductInputPort:
+    """Representation of an ODPS input port."""
+
+    name: str
+    version: str
+    contract_id: str
+    custom_properties: List[Dict[str, Any]] = field(default_factory=list)
+    authoritative_definitions: List[Dict[str, Any]] = field(default_factory=list)
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "DataProductInputPort":
+        name = str(data.get("name", "")).strip()
+        version = str(data.get("version", "")).strip()
+        contract_id = str(data.get("contractId", "")).strip()
+        if not name or not version or not contract_id:
+            raise ValueError("Input port requires name, version, and contractId")
+        extra = _copy_unknown_fields(data, ["name", "version", "contractId", "customProperties", "authoritativeDefinitions"])
+        return cls(
+            name=name,
+            version=version,
+            contract_id=contract_id,
+            custom_properties=_normalise_custom_properties(data.get("customProperties")),
+            authoritative_definitions=_normalise_custom_properties(data.get("authoritativeDefinitions")),
+            extra=extra,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "name": self.name,
+            "version": self.version,
+            "contractId": self.contract_id,
+        }
+        if self.custom_properties:
+            payload["customProperties"] = [copy.deepcopy(item) for item in self.custom_properties]
+        if self.authoritative_definitions:
+            payload["authoritativeDefinitions"] = [copy.deepcopy(item) for item in self.authoritative_definitions]
+        if self.extra:
+            payload.update(copy.deepcopy(self.extra))
+        return payload
+
+
+@dataclass
+class DataProductOutputPort:
+    """Representation of an ODPS output port."""
+
+    name: str
+    version: str
+    contract_id: str
+    description: Optional[str] = None
+    type: Optional[str] = None
+    sbom: List[Dict[str, Any]] = field(default_factory=list)
+    input_contracts: List[Dict[str, Any]] = field(default_factory=list)
+    custom_properties: List[Dict[str, Any]] = field(default_factory=list)
+    authoritative_definitions: List[Dict[str, Any]] = field(default_factory=list)
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "DataProductOutputPort":
+        name = str(data.get("name", "")).strip()
+        version = str(data.get("version", "")).strip()
+        if not name or not version:
+            raise ValueError("Output port requires name and version")
+        contract_value = data.get("contractId")
+        contract_id = str(contract_value).strip() if contract_value is not None else ""
+        if not contract_id:
+            raise ValueError("Output port requires contractId")
+        known_fields = {
+            "name",
+            "version",
+            "contractId",
+            "description",
+            "type",
+            "sbom",
+            "inputContracts",
+            "customProperties",
+            "authoritativeDefinitions",
+        }
+        extra = _copy_unknown_fields(data, known_fields)
+        return cls(
+            name=name,
+            version=version,
+            contract_id=contract_id,
+            description=str(data["description"]).strip() if data.get("description") else None,
+            type=str(data["type"]).strip() if data.get("type") else None,
+            sbom=_normalise_custom_properties(data.get("sbom")),
+            input_contracts=_normalise_custom_properties(data.get("inputContracts")),
+            custom_properties=_normalise_custom_properties(data.get("customProperties")),
+            authoritative_definitions=_normalise_custom_properties(data.get("authoritativeDefinitions")),
+            extra=extra,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "name": self.name,
+            "version": self.version,
+            "contractId": self.contract_id,
+        }
+        if self.description:
+            payload["description"] = self.description
+        if self.type:
+            payload["type"] = self.type
+        if self.sbom:
+            payload["sbom"] = [copy.deepcopy(item) for item in self.sbom]
+        if self.input_contracts:
+            payload["inputContracts"] = [copy.deepcopy(item) for item in self.input_contracts]
+        if self.custom_properties:
+            payload["customProperties"] = [copy.deepcopy(item) for item in self.custom_properties]
+        if self.authoritative_definitions:
+            payload["authoritativeDefinitions"] = [copy.deepcopy(item) for item in self.authoritative_definitions]
+        if self.extra:
+            payload.update(copy.deepcopy(self.extra))
+        return payload
+
+
+@dataclass
+class OpenDataProductStandard:
+    """Minimal representation of an ODPS document."""
+
+    id: str
+    status: str
+    api_version: str = ODPS_REQUIRED
+    kind: str = "DataProduct"
+    version: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[Mapping[str, Any]] = None
+    input_ports: List[DataProductInputPort] = field(default_factory=list)
+    output_ports: List[DataProductOutputPort] = field(default_factory=list)
+    custom_properties: List[Dict[str, Any]] = field(default_factory=list)
+    tags: List[str] = field(default_factory=list)
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "OpenDataProductStandard":
+        api_version = str(data.get("apiVersion", "")).strip() or ODPS_REQUIRED
+        if api_version != ODPS_REQUIRED:
+            raise ValueError(
+                f"ODPS apiVersion mismatch. Required {ODPS_REQUIRED}, got {api_version}"
+            )
+        product_id = str(data.get("id", "")).strip()
+        status = str(data.get("status", "")).strip()
+        if not product_id or not status:
+            raise ValueError("ODPS document requires 'id' and 'status'")
+        input_ports = []
+        for item in data.get("inputPorts", []) or []:
+            if isinstance(item, Mapping):
+                input_ports.append(DataProductInputPort.from_dict(item))
+        output_ports = []
+        for item in data.get("outputPorts", []) or []:
+            if isinstance(item, Mapping):
+                output_ports.append(DataProductOutputPort.from_dict(item))
+        known_fields = {
+            "apiVersion",
+            "kind",
+            "id",
+            "status",
+            "version",
+            "name",
+            "description",
+            "inputPorts",
+            "outputPorts",
+            "customProperties",
+            "tags",
+        }
+        extra = _copy_unknown_fields(data, known_fields)
+        return cls(
+            api_version=api_version,
+            kind=str(data.get("kind", "DataProduct")) or "DataProduct",
+            id=product_id,
+            status=status,
+            version=str(data.get("version", "")).strip() or None,
+            name=str(data.get("name", "")).strip() or None,
+            description=(
+                copy.deepcopy(data.get("description"))
+                if isinstance(data.get("description"), Mapping)
+                else None
+            ),
+            input_ports=input_ports,
+            output_ports=output_ports,
+            custom_properties=_normalise_custom_properties(data.get("customProperties")),
+            tags=[str(tag) for tag in data.get("tags", []) if isinstance(tag, str)],
+            extra=extra,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "apiVersion": self.api_version,
+            "kind": self.kind,
+            "id": self.id,
+            "status": self.status,
+        }
+        if self.version:
+            payload["version"] = self.version
+        if self.name:
+            payload["name"] = self.name
+        if self.description:
+            payload["description"] = copy.deepcopy(self.description)
+        if self.custom_properties:
+            payload["customProperties"] = [copy.deepcopy(item) for item in self.custom_properties]
+        if self.tags:
+            payload["tags"] = list(self.tags)
+        if self.input_ports:
+            payload["inputPorts"] = [port.to_dict() for port in self.input_ports]
+        if self.output_ports:
+            payload["outputPorts"] = [port.to_dict() for port in self.output_ports]
+        if self.extra:
+            payload.update(copy.deepcopy(self.extra))
+        return payload
+
+    def clone(self) -> "OpenDataProductStandard":
+        return OpenDataProductStandard.from_dict(self.to_dict())
+
+    def find_input_port(self, name: str) -> Optional[DataProductInputPort]:
+        for port in self.input_ports:
+            if port.name == name:
+                return port
+        return None
+
+    def find_output_port(self, name: str) -> Optional[DataProductOutputPort]:
+        for port in self.output_ports:
+            if port.name == name:
+                return port
+        return None
+
+    def ensure_input_port(self, port: DataProductInputPort) -> bool:
+        existing = self.find_input_port(port.name)
+        if existing and existing.contract_id == port.contract_id and existing.version == port.version:
+            return False
+        if existing:
+            self.input_ports = [p for p in self.input_ports if p.name != port.name]
+        self.input_ports.append(port)
+        return True
+
+    def ensure_output_port(self, port: DataProductOutputPort) -> bool:
+        existing = self.find_output_port(port.name)
+        if (
+            existing
+            and existing.contract_id == port.contract_id
+            and existing.version == port.version
+        ):
+            return False
+        if existing:
+            self.output_ports = [p for p in self.output_ports if p.name != port.name]
+        self.output_ports.append(port)
+        return True
+
+
+def as_odps_dict(doc: OpenDataProductStandard) -> Dict[str, Any]:
+    return doc.to_dict()
+
+
+def to_model(data: Mapping[str, Any]) -> OpenDataProductStandard:
+    return OpenDataProductStandard.from_dict(data)
+
+
+def next_draft_version(
+    *,
+    current_version: Optional[str],
+    existing_versions: Iterable[str],
+    bump: str = "minor",
+) -> str:
+    """Return the next draft version string for a data product."""
+
+    existing_set = {str(value) for value in existing_versions}
+    if current_version:
+        base = SemVer.parse(current_version)
+        base = SemVer(base.major, base.minor, base.patch)
+        candidate = base.bump(bump)
+    else:
+        # Follow the same defaults used for contracts: start at 0.1.0
+        candidate = SemVer.parse("0.1.0")
+        if bump == "major":
+            candidate = SemVer.parse("1.0.0")
+        elif bump == "patch":
+            candidate = SemVer.parse("0.0.1")
+    suffix = f"{candidate.major}.{candidate.minor}.{candidate.patch}-draft"
+    version = suffix
+    counter = 1
+    while version in existing_set:
+        counter += 1
+        version = f"{suffix}.{counter}"
+    return version
+
+
+def evolve_to_draft(
+    doc: OpenDataProductStandard,
+    *,
+    existing_versions: Iterable[str],
+    bump: str = "minor",
+) -> None:
+    """Update ``doc`` to represent a draft version."""
+
+    doc.version = next_draft_version(
+        current_version=doc.version,
+        existing_versions=existing_versions,
+        bump=bump,
+    )
+    doc.status = "draft"
+
+
+__all__ = [
+    "ODPS_REQUIRED",
+    "DataProductInputPort",
+    "DataProductOutputPort",
+    "OpenDataProductStandard",
+    "as_odps_dict",
+    "evolve_to_draft",
+    "next_draft_version",
+    "to_model",
+]
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,43 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+
+def _ensure_local_package(module_name: str, local_root: Path) -> None:
+    """Force ``module_name`` to load from ``local_root`` during tests."""
+
+    module = sys.modules.get(module_name)
+    if module is not None:
+        module_file = getattr(module, "__file__", None)
+        if module_file is not None:
+            try:
+                module_path = Path(module_file).resolve()
+                if module_path.is_relative_to(local_root):
+                    return
+            except (OSError, RuntimeError):
+                pass
+
+        # Remove any previously imported module (and submodules) so that Python
+        # re-imports it from the in-repo source path we add below.
+        for loaded in list(sys.modules):
+            if loaded == module_name or loaded.startswith(f"{module_name}."):
+                sys.modules.pop(loaded, None)
+
+    # Import once more to surface a clear error if the local package is missing
+    # or shadowed by an installed distribution.
+    module = __import__(module_name)
+    module_file = getattr(module, "__file__", None)
+    if module_file is None or not Path(module_file).resolve().is_relative_to(local_root):
+        raise ModuleNotFoundError(
+            f"Local package for {module_name!r} not found at {local_root}",
+        )
+
 # Ensure the in-repo package sources are importable without requiring a full
 # editable installation of every wheel that dc43 depends on.  This mirrors
 # what ``pip install -e .`` does, but keeps ``pytest`` usable in lightweight
 # environments (for example, GitHub Actions matrix jobs that build packages in
 # parallel).
 ROOT = Path(__file__).resolve().parent.parent
+LOCAL_CLIENTS_ROOT = ROOT / "packages" / "dc43-service-clients" / "src" / "dc43_service_clients"
 PACKAGE_SRC_DIRS = [
     ROOT / "src",
     ROOT / "packages" / "dc43-service-clients" / "src",
@@ -25,3 +56,6 @@ for src_dir in PACKAGE_SRC_DIRS:
         str_path = str(src_dir)
         if str_path not in sys.path:
             sys.path.insert(0, str_path)
+
+if LOCAL_CLIENTS_ROOT.exists():
+    _ensure_local_package("dc43_service_clients", LOCAL_CLIENTS_ROOT)

--- a/tests/test_odps.py
+++ b/tests/test_odps.py
@@ -1,0 +1,49 @@
+from dc43.core.odps import (
+    DataProductInputPort,
+    DataProductOutputPort,
+    OpenDataProductStandard,
+    evolve_to_draft,
+    next_draft_version,
+)
+
+
+def test_next_draft_version_uniqueness() -> None:
+    existing = ["0.2.0-draft", "0.2.0-draft.2"]
+    version = next_draft_version(
+        current_version="0.1.0",
+        existing_versions=existing,
+        bump="minor",
+    )
+    assert version.startswith("0.2.0-draft")
+    assert version not in existing
+
+
+def test_evolve_to_draft_sets_status_and_version() -> None:
+    product = OpenDataProductStandard(
+        id="dp.orders",
+        status="active",
+        version="1.0.0",
+    )
+    evolve_to_draft(product, existing_versions=["1.0.0"], bump="minor")
+    assert product.status == "draft"
+    assert product.version is not None
+    assert product.version.startswith("1.1.0-draft")
+
+
+def test_ensure_input_port_replaces_existing() -> None:
+    product = OpenDataProductStandard(id="dp.sales", status="draft")
+    port_a = DataProductInputPort(name="orders", version="1.0.0", contract_id="orders")
+    product.ensure_input_port(port_a)
+    port_b = DataProductInputPort(name="orders", version="1.1.0", contract_id="orders")
+    changed = product.ensure_input_port(port_b)
+    assert changed is True
+    assert product.input_ports[0].version == "1.1.0"
+
+
+def test_ensure_output_port_idempotent() -> None:
+    product = OpenDataProductStandard(id="dp.sales", status="draft")
+    port = DataProductOutputPort(name="report", version="2.0.0", contract_id="report")
+    first = product.ensure_output_port(port)
+    second = product.ensure_output_port(port)
+    assert first is True
+    assert second is False


### PR DESCRIPTION
## Summary
- add dedicated Spark helpers for contract-only and data-product-only flows, including `read_from_contract` and `write_with_contract_id`
- introduce a Collibra-backed data product service backend with stub and HTTP adapters and expose the new exports
- document the new helpers and backend options and cover the Collibra stub with tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68deb49e6250832e902b00c23935ef35