### PR TITLE
Add orders 1.2.0 contract slice and update demo records

### DIFF
--- a/packages/dc43-demo-app/src/dc43_demo_app/demo_data/contracts/orders/1.2.0.json
+++ b/packages/dc43-demo-app/src/dc43_demo_app/demo_data/contracts/orders/1.2.0.json
@@ -1,0 +1,51 @@
+{
+  "version": "1.2.0",
+  "kind": "DataContract",
+  "apiVersion": "3.0.2",
+  "id": "orders",
+  "name": "Orders",
+  "description": {"usage": "Sample orders contract"},
+  "status": "active",
+  "servers": [
+    {
+      "server": "local",
+      "type": "filesystem",
+      "path": "data/orders",
+      "format": "json",
+      "customProperties": [
+        {
+          "property": "dc43.core.versioning",
+          "value": {
+            "mode": "delta",
+            "includePriorVersions": false,
+            "subfolder": "{version}",
+            "filePattern": "orders.json"
+          }
+        },
+        {
+          "property": "dc43.pathPattern",
+          "value": "data/orders/{version}/orders.json"
+        }
+      ]
+    }
+  ],
+  "schema": [
+    {
+      "name": "orders",
+      "properties": [
+        {"name": "order_id", "physicalType": "integer", "required": true, "unique": true},
+        {"name": "customer_id", "physicalType": "integer", "required": true},
+        {"name": "order_ts", "physicalType": "string", "required": true},
+        {
+          "name": "amount",
+          "physicalType": "double",
+          "required": true,
+          "quality": [
+            {"mustBeGreaterThan": 0}
+          ]
+        },
+        {"name": "currency", "physicalType": "string", "required": true}
+      ]
+    }
+  ]
+}

--- a/packages/dc43-demo-app/src/dc43_demo_app/demo_data/data/orders/2025-10-05/orders.json
+++ b/packages/dc43-demo-app/src/dc43_demo_app/demo_data/data/orders/2025-10-05/orders.json
@@ -1,0 +1,3 @@
+{"order_id":1,"customer_id":101,"order_ts":"2025-10-05T09:15:00Z","amount":125.0,"currency":"EUR"}
+{"order_id":2,"customer_id":105,"order_ts":"2025-10-05T09:45:00Z","amount":215.5,"currency":"USD"}
+{"order_id":3,"customer_id":106,"order_ts":"2025-10-05T10:15:00Z","amount":310.0,"currency":"GBP"}

--- a/packages/dc43-demo-app/src/dc43_demo_app/demo_data/records/contract_meta.json
+++ b/packages/dc43-demo-app/src/dc43_demo_app/demo_data/records/contract_meta.json
@@ -1,6 +1,7 @@
 [
   {"id": "orders", "version": "1.0.0", "status": "active"},
   {"id": "orders", "version": "1.1.0", "status": "active"},
+  {"id": "orders", "version": "1.2.0", "status": "active"},
   {"id": "customers", "version": "1.0.0", "status": "active"},
   {"id": "orders_enriched", "version": "1.0.0", "status": "active"},
   {"id": "orders_enriched", "version": "1.1.0", "status": "active"},

--- a/packages/dc43-demo-app/src/dc43_demo_app/demo_data/records/data_products.json
+++ b/packages/dc43-demo-app/src/dc43_demo_app/demo_data/records/data_products.json
@@ -1,0 +1,50 @@
+[
+  {
+    "apiVersion": "1.0.0",
+    "kind": "DataProduct",
+    "id": "dp.orders",
+    "name": "Orders",
+    "status": "active",
+    "version": "1.1.0",
+    "outputPorts": [
+      {
+        "name": "orders-latest",
+        "version": "1.2.0",
+        "contractId": "orders",
+        "customProperties": [
+          {"property": "dc43.dataset.id", "value": "orders"},
+          {"property": "dc43.dataset.version", "value": "latest"}
+        ]
+      }
+    ]
+  },
+  {
+    "apiVersion": "1.0.0",
+    "kind": "DataProduct",
+    "id": "dp.analytics",
+    "name": "Analytics",
+    "status": "active",
+    "version": "2.0.0",
+    "inputPorts": [
+      {
+        "name": "orders-feed",
+        "version": "1.2.0",
+        "contractId": "orders",
+        "customProperties": [
+          {"property": "dc43.dataset.id", "value": "orders"},
+          {"property": "dc43.dataset.version", "value": "latest"}
+        ]
+      }
+    ],
+    "outputPorts": [
+      {
+        "name": "primary",
+        "version": "2.0.0",
+        "contractId": "orders_enriched",
+        "customProperties": [
+          {"property": "dc43.dataset.id", "value": "orders_enriched"}
+        ]
+      }
+    ]
+  }
+]

--- a/packages/dc43-demo-app/src/dc43_demo_app/demo_data/records/datasets.json
+++ b/packages/dc43-demo-app/src/dc43_demo_app/demo_data/records/datasets.json
@@ -16,6 +16,14 @@
     "dq_details": {"violations": 0, "metrics": {"row_count": 2}}
   },
   {
+    "contract_id": "orders",
+    "contract_version": "1.2.0",
+    "dataset_name": "orders",
+    "dataset_version": "2025-10-05",
+    "status": "ok",
+    "dq_details": {"violations": 0, "metrics": {"row_count": 3}}
+  },
+  {
     "contract_id": "customers",
     "contract_version": "1.0.0",
     "dataset_name": "customers",

--- a/packages/dc43-demo-app/src/dc43_demo_app/scenarios.py
+++ b/packages/dc43-demo-app/src/dc43_demo_app/scenarios.py
@@ -446,6 +446,30 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
             "output_adjustment": "amplify-negative",
         },
     },
+    "data-product-roundtrip": {
+        "label": "Data product roundtrip",
+        "description": (
+            "<p>Reads the curated <code>dp.orders</code> output and republishes it "
+            "through <code>dp.analytics</code>.</p>"
+        ),
+        "activate_versions": dict(_DEFAULT_SLICE),
+        "data_product_flow": {
+            "input": {
+                "data_product": "dp.orders",
+                "port_name": "orders-latest",
+                "expected_contract_version": "==1.2.0",
+            },
+            "output": {
+                "data_product": "dp.analytics",
+                "port_name": "primary",
+            },
+        },
+        "params": {
+            "contract_id": "orders_enriched",
+            "contract_version": "1.0.0",
+            "run_type": "observe",
+        },
+    },
     "split-lenient": {
         "label": "Split invalid rows",
         "description": (

--- a/tests/test_server_pages.py
+++ b/tests/test_server_pages.py
@@ -332,3 +332,19 @@ def test_dq_version_records_excludes_other_contract_versions():
     statuses = {entry["version"]: entry["status"] for entry in entries}
     assert statuses["2025-09-28"] == "block"
 
+    latest_contract = store.get("orders", "1.2.0")
+    latest_records = [
+        record
+        for record in load_records()
+        if record.contract_id == "orders" and record.contract_version == "1.2.0"
+    ]
+    latest_entries = dq_version_records(
+        "orders",
+        contract=latest_contract,
+        dataset_records=latest_records,
+    )
+    latest_versions = [entry["version"] for entry in latest_entries]
+    assert latest_versions == ["2025-10-05"]
+    latest_statuses = {entry["version"]: entry["status"] for entry in latest_entries}
+    assert latest_statuses["2025-10-05"] == "ok"
+


### PR DESCRIPTION
## Summary
- add an orders 1.2.0 contract payload that reads a single slice
- seed the 2025-10-05 orders dataset and expose the version via demo metadata
- refresh data product wiring, scenarios, and tests to target the new contract version

## Testing
- PYTHONPATH=packages/dc43-demo-app/src python - <<'PY'
from dc43_demo_app import pipeline

pipeline.set_active_version("orders", "2025-10-05")
pipeline.set_active_version("customers", "2024-01-01")
try:
    dataset_name, version = pipeline.run_pipeline(
        contract_id="orders_enriched",
        contract_version="1.0.0",
        dataset_name=None,
        dataset_version=None,
        run_type="observe",
    )
    print("RUN_RESULT", dataset_name, version)
finally:
    pipeline.set_active_version("orders", "2024-01-01")
PY
- PYTHONPATH=packages/dc43-demo-app/src pytest -q


------
https://chatgpt.com/codex/tasks/task_b_68e188b98820832eaa53a171809c5a9f