### PR TITLE
docs: document gitflow release flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# dc43 changelog
+
+## [Unreleased]
+### Changed
+- Documented the Gitflow-based branching expectations and clarified how merges from `dev` to `main`
+  trigger automated releases in the release guide.


### PR DESCRIPTION
## Summary
- document the Gitflow-style branching workflow clarifying how dev and main interact for releases
- add an Unreleased changelog entry capturing the documentation update for the root package

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68e23bfd532c832e903543d6ba7ae0f6