### PR TITLE
Add in-depth pipeline scenario detail pages

### DIFF
--- a/packages/dc43-demo-app/src/dc43_demo_app/scenarios.py
+++ b/packages/dc43-demo-app/src/dc43_demo_app/scenarios.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 from textwrap import dedent
 from typing import Any, Dict
 
+
+def _section(title: str, body: str) -> dict[str, str]:
+    """Create a guide section with normalised HTML content."""
+
+    return {"title": title, "content": dedent(body).strip()}
+
 _DEFAULT_SLICE = {
     "orders": "2024-01-01",
     "customers": "2024-01-01",
@@ -55,6 +61,99 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
             "dataset_name": "result-no-existing-contract",
             "run_type": "enforce",
         },
+        "guide": [
+            _section(
+                "What this example shows",
+                """
+                <p>
+                  The pipeline is triggered without an output contract, so the
+                  orchestration logic refuses to materialise a dataset. The
+                  UI still walks the user through the planned inputs and
+                  explains why no new slice is created. Use it to demonstrate
+                  that contract registration is a first-class requirement, not
+                  an optional check bolted on at the end.
+                </p>
+                """,
+            ),
+            _section(
+                "Why it matters",
+                """
+                <p>
+                  Contract-aware pipelines must prevent accidental writes when
+                  governance artefacts are missing. This scenario underlines:
+                </p>
+                <ul>
+                  <li>The guard-rail that blocks the run before any files are
+                      written.</li>
+                  <li>How the status message communicates the failure back to
+                      operators.</li>
+                  <li>The relationship between planned datasets and contract
+                      catalogues in DC43.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "Feature focus",
+                """
+                <p>
+                  The example focuses on the enforcement workflow:
+                </p>
+                <ul>
+                  <li><strong>Contract validation</strong> – enforcement mode
+                      requires an active contract. Leaving the field empty is
+                      treated as a hard error.</li>
+                  <li><strong>Planning vs. materialisation</strong> – the
+                      engine plans the write but cancels it before data is
+                      committed, showcasing reversible planning.</li>
+                  <li><strong>User feedback</strong> – the final status message
+                      in the run log tells operators exactly what is missing.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "How it works",
+                """
+                <ol>
+                  <li>The job resolves the latest <code>orders</code> and
+                      <code>customers</code> slices and prepares them for the
+                      join.</li>
+                  <li>When it reaches the publishing step it inspects the
+                      target contract configuration and sees that none was
+                      provided.</li>
+                  <li>The runtime raises an error, records the failure reason,
+                      and keeps the filesystem unchanged.</li>
+                </ol>
+                """,
+            ),
+            _section(
+                "When to use it",
+                """
+                <ul>
+                  <li>During onboarding sessions to explain why contract
+                      registration matters.</li>
+                  <li>When troubleshooting unexpected "no contract" errors –
+                      compare the metadata in this scenario with your run.</li>
+                  <li>As a baseline before exploring
+                      <a href="/pipeline-runs/ok">successful contract runs</a>
+                      or
+                      <a href="/pipeline-runs/contract-draft-block">status-related issues</a>.
+                  </li>
+                </ul>
+                """,
+            ),
+            _section(
+                "What to explore next",
+                """
+                <p>
+                  Trigger the scenario, observe that no dataset version is
+                  produced, and then repeat the run after registering a
+                  contract to see how the behaviour changes. The contrast with
+                  the <a href="/pipeline-runs/ok">Existing contract OK</a>
+                  walkthrough helps cement the happy-path checklist.
+                </p>
+                """,
+            ),
+        ],
     },
     "ok": {
         "label": "Existing contract OK",
@@ -90,6 +189,93 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
             "contract_version": "1.0.0",
             "run_type": "enforce",
         },
+        "guide": [
+            _section(
+                "What this example shows",
+                """
+                <p>
+                  This is the reference "green" pipeline execution. It takes
+                  the curated <code>orders</code> and <code>customers</code>
+                  slices, aligns them to the <code>orders_enriched</code>
+                  contract, and publishes a timestamped version with no
+                  warnings. Every other scenario can be compared against this
+                  baseline.
+                </p>
+                """,
+            ),
+            _section(
+                "Why it matters",
+                """
+                <p>
+                  Understanding the successful path helps new users recognise
+                  how contract metadata, run configuration, and DQ feedback look
+                  when everything lines up. It emphasises:
+                </p>
+                <ul>
+                  <li>The relationship between input contract versions and the
+                      chosen output contract.</li>
+                  <li>How timestamped dataset versions avoid collisions between
+                      reruns.</li>
+                  <li>The governance signal that confirms enforcement finished
+                      cleanly.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "Feature focus",
+                """
+                <ul>
+                  <li><strong>Schema alignment helpers</strong> – the pipeline
+                      uses the demo transformations to match the
+                      <code>orders_enriched</code> schema before persisting.</li>
+                  <li><strong>Automatic version stamping</strong> – versions are
+                      suffixed with the run timestamp, so multiple successful
+                      runs remain visible in history.</li>
+                  <li><strong>Governance handshake</strong> – enforcement mode
+                      registers an OK verdict with the stub governance service.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "How it works",
+                """
+                <ol>
+                  <li>Load the configured inputs and standardise the columns.</li>
+                  <li>Apply enrichment logic (join customers, compute
+                      aggregates) and conform to the target contract.</li>
+                  <li>Write the governed dataset and record the validation
+                      status in the workspace registry.</li>
+                </ol>
+                """,
+            ),
+            _section(
+                "When to use it",
+                """
+                <ul>
+                  <li>As the starting tour for the demo – run this before any
+                      other scenario to understand the layout of the results.</li>
+                  <li>To validate that your local workspace is prepared: a
+                      failure here usually signals misconfigured data or
+                      missing demo assets.</li>
+                  <li>To compare DQ payloads against
+                      <a href="/pipeline-runs/dq">failing enforcement</a>
+                      runs.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "What to explore next",
+                """
+                <p>
+                  Inspect the generated dataset folder under
+                  <code>orders_enriched/</code>, then open the corresponding DQ
+                  record. After that, explore
+                  <a href="/pipeline-runs/dq">Existing contract fails DQ</a> to
+                  see how the same pipeline reacts when expectations fail.
+                </p>
+                """,
+            ),
+        ],
     },
     "dq": {
         "label": "Existing contract fails DQ",
@@ -132,6 +318,89 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
             "collect_examples": True,
             "examples_limit": 3,
         },
+        "guide": [
+            _section(
+                "What this example shows",
+                """
+                <p>
+                  The pipeline honours the existing
+                  <code>orders_enriched:1.1.0</code> contract, but the published
+                  slice violates a rule (<code>amount &gt; 100</code>). The
+                  governance client blocks the run, captures failure metadata,
+                  and drafts the proposed <code>1.2.0</code> contract revision.
+                </p>
+                """,
+            ),
+            _section(
+                "Why it matters",
+                """
+                <p>
+                  Real-world data pipelines must communicate when expectations
+                  drift. This scenario highlights:
+                </p>
+                <ul>
+                  <li>How enforcement surfaces failed expectations in the run
+                      summary.</li>
+                  <li>The automatic production of contract drafts documenting
+                      proposed schema or rule updates.</li>
+                  <li>The governance decision to block downstream consumers
+                      until issues are resolved.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "Feature focus",
+                """
+                <ul>
+                  <li><strong>Expectation evaluation</strong> – the failed rule
+                      lists the offending expression, counts, and sample rows.</li>
+                  <li><strong>Draft creation</strong> – violations trigger the
+                      creation of <code>orders_enriched:1.2.0</code>, showing the
+                      incremental contract workflow.</li>
+                  <li><strong>Run metadata</strong> – the <code>dq_details</code>
+                      payload records auxiliary datasets and governance context.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "How it works",
+                """
+                <ol>
+                  <li>Read and join input datasets exactly like the happy path.</li>
+                  <li>Apply the same transformations but deliberately emit
+                      values that break a quality rule.</li>
+                  <li>Submit the slice to governance, which flips the outcome to
+                      <code>block</code> and records violation examples.</li>
+                </ol>
+                """,
+            ),
+            _section(
+                "When to use it",
+                """
+                <ul>
+                  <li>To explain how failed expectations are visualised in the
+                      UI and surfaced through the API.</li>
+                  <li>As a template for building alerting or incident response
+                      workflows on top of DQ payloads.</li>
+                  <li>When comparing lenient strategies such as
+                      <a href="/pipeline-runs/split-lenient">Split invalid rows</a>
+                      against strict enforcement.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "What to explore next",
+                """
+                <p>
+                  Expand the accordion in the run history to inspect failure
+                  examples, then open the draft contract in the contracts app.
+                  Follow up with the
+                  <a href="/pipeline-runs/schema-dq">Contract fails schema and DQ</a>
+                  scenario to see combined drift handling.
+                </p>
+                """,
+            ),
+        ],
     },
     "schema-dq": {
         "label": "Contract fails schema and DQ",
@@ -172,6 +441,89 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
             "contract_version": "2.0.0",
             "run_type": "enforce",
         },
+        "guide": [
+            _section(
+                "What this example shows",
+                """
+                <p>
+                  A tougher governance scenario where the pipeline targets
+                  <code>orders_enriched:2.0.0</code>, but both schema alignment
+                  and expectation checks fail. The run records schema drift and
+                  data quality violations while drafting
+                  <code>orders_enriched:2.1.0</code>.
+                </p>
+                """,
+            ),
+            _section(
+                "Why it matters",
+                """
+                <p>
+                  Changes often land in batches – columns are added while rules
+                  evolve. This scenario demonstrates how DC43 provides full
+                  context for multi-dimensional failures:
+                </p>
+                <ul>
+                  <li>Schema mismatches are listed alongside expectation
+                      breaches.</li>
+                  <li>The failure still creates a draft contract so data model
+                      discussions start from the observed drift.</li>
+                  <li>Downstream teams receive an explicit <code>block</code>
+                      verdict, avoiding silent data corruption.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "Feature focus",
+                """
+                <ul>
+                  <li><strong>Schema alignment diagnostics</strong> – the run
+                      summarises missing/extra columns and type conflicts.</li>
+                  <li><strong>Combined DQ payload</strong> – schema errors and
+                      failed expectations live in the same payload, making it
+                      easier to triage.</li>
+                  <li><strong>Draft propagation</strong> – the demo stores the
+                      suggested contract changes for future approvals.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "How it works",
+                """
+                <ol>
+                  <li>Produce an output that intentionally diverges from the
+                      <code>2.0.0</code> schema.</li>
+                  <li>Run enforcement, which flags the schema drift before
+                      evaluating expectations.</li>
+                  <li>Surface both failure sets to the operator and draft the
+                      <code>2.1.0</code> contract for review.</li>
+                </ol>
+                """,
+            ),
+            _section(
+                "When to use it",
+                """
+                <ul>
+                  <li>To train data producers on how schema evolution is
+                      reported and negotiated.</li>
+                  <li>When demonstrating that DQ results remain available even
+                      when schema checks fail first.</li>
+                  <li>As a comparison point for
+                      <a href="/pipeline-runs/dq">single-rule failures</a>.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "What to explore next",
+                """
+                <p>
+                  Review the schema error list in the run history, then inspect
+                  the generated draft contract. Follow up with
+                  <a href="/pipeline-runs/contract-draft-block">Draft contract blocked</a>
+                  to understand how contract status ties back into enforcement.
+                </p>
+                """,
+            ),
+        ],
     },
     "contract-draft-block": {
         "label": "Draft contract blocked",
@@ -205,6 +557,87 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
             "contract_version": "3.0.0",
             "run_type": "enforce",
         },
+        "guide": [
+            _section(
+                "What this example shows",
+                """
+                <p>
+                  Even though <code>orders_enriched:3.0.0</code> exists, it is in
+                  <em>draft</em> status. Enforcement mode refuses to use it and
+                  aborts the run before materialising data, highlighting the
+                  importance of contract status in change management.
+                </p>
+                """,
+            ),
+            _section(
+                "Why it matters",
+                """
+                <p>
+                  Draft contracts should not be shipped to production without an
+                  explicit review. This walkthrough demonstrates:
+                </p>
+                <ul>
+                  <li>How the runtime inspects contract status metadata before
+                      proceeding.</li>
+                  <li>The clear error message that points at the offending
+                      status.</li>
+                  <li>Why change approval processes map neatly into contract
+                      lifecycle states.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "Feature focus",
+                """
+                <ul>
+                  <li><strong>Status enforcement</strong> – the policy defaults
+                      to <code>active</code>-only contracts in enforcement mode.</li>
+                  <li><strong>Fast failure</strong> – the pipeline stops before
+                      writing any files, keeping the workspace clean.</li>
+                  <li><strong>Operator guidance</strong> – the recorded reason
+                      explains which contract must be promoted or overridden.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "How it works",
+                """
+                <ol>
+                  <li>The pipeline looks up <code>orders_enriched:3.0.0</code>
+                      from the contract store.</li>
+                  <li>The guard checks the contract status, sees it is draft, and
+                      raises a blocking error.</li>
+                  <li>The failure is recorded along with the status metadata so
+                      teams can request an approval or switch scenarios.</li>
+                </ol>
+                """,
+            ),
+            _section(
+                "When to use it",
+                """
+                <ul>
+                  <li>To discuss release management between platform and
+                      analytics teams.</li>
+                  <li>While documenting why production pipelines need explicit
+                      overrides before consuming drafts.</li>
+                  <li>As a precursor to the
+                      <a href="/pipeline-runs/contract-draft-override">Allow draft contract</a>
+                      scenario.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "What to explore next",
+                """
+                <p>
+                  Compare the failure message here with the override strategy in
+                  <a href="/pipeline-runs/contract-draft-override">Allow draft contract</a>.
+                  The contrast shows how policy changes are intentional and
+                  auditable.
+                </p>
+                """,
+            ),
+        ],
     },
     "contract-draft-override": {
         "label": "Allow draft contract",
@@ -256,6 +689,88 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
                 }
             },
         },
+        "guide": [
+            _section(
+                "What this example shows",
+                """
+                <p>
+                  A deliberate override of the draft status policy. The run uses
+                  <code>orders_enriched:3.0.0</code> despite it being a draft and
+                  documents the policy change in the run metadata.
+                </p>
+                """,
+            ),
+            _section(
+                "Why it matters",
+                """
+                <p>
+                  Sometimes teams need to test draft contracts in lower
+                  environments or run controlled experiments. The scenario shows
+                  how to do this responsibly:
+                </p>
+                <ul>
+                  <li>Overrides are explicit and auditable in the run summary.</li>
+                  <li>Inputs can point at curated datasets (the
+                      <code>orders::valid</code> slice) so you can validate the
+                      draft with safe data.</li>
+                  <li>Governance metadata tracks that a non-default policy was
+                      applied.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "Feature focus",
+                """
+                <ul>
+                  <li><strong>Status policy overrides</strong> –
+                      <code>violation_strategy</code> declares the allowed status
+                      set.</li>
+                  <li><strong>Input substitution</strong> – the scenario swaps in
+                      <code>orders::valid</code> to mirror real mitigation
+                      tactics.</li>
+                  <li><strong>Output adjustment</strong> – it uses the
+                      <code>boost-amounts</code> helper to keep the data within
+                      expectation thresholds.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "How it works",
+                """
+                <ol>
+                  <li>Read the curated valid input slice and apply enrichment.</li>
+                  <li>Adjust the amounts upward so quality rules still pass.</li>
+                  <li>Write the dataset under the draft contract while recording
+                      the override note.</li>
+                </ol>
+                """,
+            ),
+            _section(
+                "When to use it",
+                """
+                <ul>
+                  <li>When preparing sandboxes or pre-production rehearsals with
+                      draft contracts.</li>
+                  <li>To illustrate how override requests should be justified in
+                      the run metadata.</li>
+                  <li>As a complement to
+                      <a href="/pipeline-runs/read-override-full">Force blocked slice</a>
+                      for comparing override types.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "What to explore next",
+                """
+                <p>
+                  Inspect the run metadata to see the stored override strategy
+                  and follow up by promoting the draft contract in the contracts
+                  app. Re-run the scenario to confirm it succeeds without the
+                  override once the status flips to active.
+                </p>
+                """,
+            ),
+        ],
     },
     "read-invalid-block": {
         "label": "Invalid input blocked",
@@ -295,6 +810,86 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
                 }
             },
         },
+        "guide": [
+            _section(
+                "What this example shows",
+                """
+                <p>
+                  The governance layer marks the most recent
+                  <code>orders</code> slice as <code>block</code>. The pipeline
+                  honours that verdict and fails fast, highlighting the
+                  safeguards around upstream data quality statuses.
+                </p>
+                """,
+            ),
+            _section(
+                "Why it matters",
+                """
+                <p>
+                  Pipelines should respect domain teams' verdicts on input
+                  readiness. This scenario explains:
+                </p>
+                <ul>
+                  <li>How dataset-level DQ statuses influence read decisions.</li>
+                  <li>The link between governance metadata and the read
+                      strategies you configure.</li>
+                  <li>The diagnostic hints pointing toward curated alternatives
+                      (<code>valid</code> and <code>reject</code> slices).</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "Feature focus",
+                """
+                <ul>
+                  <li><strong>Input status enforcement</strong> – the default
+                      read policy refuses blocked slices.</li>
+                  <li><strong>Auxiliary dataset hints</strong> – DQ metadata lists
+                      the curated subsets that remain available.</li>
+                  <li><strong>Fast feedback</strong> – failure occurs before any
+                      transformation costs accumulate.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "How it works",
+                """
+                <ol>
+                  <li>The runtime asks the governance client for the latest
+                      <code>orders</code> slice verdict.</li>
+                  <li>Because the status is <code>block</code>, the read strategy
+                      prevents the dataset from being loaded.</li>
+                  <li>The run exits with an error and lists the recommended
+                      curated slices to consider instead.</li>
+                </ol>
+                """,
+            ),
+            _section(
+                "When to use it",
+                """
+                <ul>
+                  <li>During runbook discussions about how pipelines react to
+                      blocked datasets.</li>
+                  <li>When building automated remediation that switches to the
+                      <a href="/pipeline-runs/read-valid-subset">valid subset</a>
+                      scenario.</li>
+                  <li>To show stakeholders what happens before manual overrides
+                      are approved.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "What to explore next",
+                """
+                <p>
+                  Compare this failure with
+                  <a href="/pipeline-runs/read-override-full">Force blocked slice</a>
+                  to see the documented override required to bypass the
+                  governance verdict.
+                </p>
+                """,
+            ),
+        ],
     },
     "read-valid-subset": {
         "label": "Prefer valid subset",
@@ -341,6 +936,85 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
                 }
             },
         },
+        "guide": [
+            _section(
+                "What this example shows",
+                """
+                <p>
+                  The pipeline reacts to the blocked default slice by switching
+                  to the curated <code>orders::valid</code> subset. It keeps the
+                  run in observe mode while collecting violation examples.
+                </p>
+                """,
+            ),
+            _section(
+                "Why it matters",
+                """
+                <p>
+                  Governance verdicts often come with remediation guidance. This
+                  scenario demonstrates how to programmatically follow that
+                  guidance:
+                </p>
+                <ul>
+                  <li>Inputs can be re-pointed to curated subsets without
+                      modifying the pipeline code.</li>
+                  <li>Observe mode lets you experiment safely before promoting a
+                      new contract version.</li>
+                  <li>DQ payloads include examples to help teams confirm the
+                      subset behaves as expected.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "Feature focus",
+                """
+                <ul>
+                  <li><strong>Input overrides</strong> – the scenario specifies
+                      an alternate dataset identifier and version.</li>
+                  <li><strong>Observation runs</strong> – no blocking enforcement
+                      occurs, but full validation telemetry is recorded.</li>
+                  <li><strong>Example collection</strong> – the run captures
+                      failing and passing rows for quick inspection.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "How it works",
+                """
+                <ol>
+                  <li>Read <code>orders::valid latest__valid</code> alongside the
+                      standard customers slice.</li>
+                  <li>Join, enrich, and align to the
+                      <code>orders_enriched:1.1.0</code> contract.</li>
+                  <li>Write the dataset and record the observe-mode governance
+                      verdict.</li>
+                </ol>
+                """,
+            ),
+            _section(
+                "When to use it",
+                """
+                <ul>
+                  <li>As part of playbooks for reacting to blocked inputs.</li>
+                  <li>To showcase how curated subsets keep data products running
+                      while remediation happens.</li>
+                  <li>To compare with
+                      <a href="/pipeline-runs/read-valid-subset-violation">Valid subset, invalid output</a>
+                      where the output still fails.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "What to explore next",
+                """
+                <p>
+                  Inspect the DQ payload to review collected examples, then
+                  rerun in enforcement mode by toggling the run type to understand
+                  the trade-offs between observe and enforce.
+                </p>
+                """,
+            ),
+        ],
     },
     "read-valid-subset-violation": {
         "label": "Valid subset, invalid output",
@@ -389,6 +1063,86 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
             },
             "output_adjustment": "valid-subset-violation",
         },
+        "guide": [
+            _section(
+                "What this example shows",
+                """
+                <p>
+                  Even with curated <code>orders::valid</code> inputs, the
+                  pipeline can still create an output that fails enforcement. A
+                  deliberate transformation lowers an amount so the DQ rule is
+                  breached.
+                </p>
+                """,
+            ),
+            _section(
+                "Why it matters",
+                """
+                <p>
+                  Clean inputs do not guarantee compliant outputs. This run
+                  illustrates:
+                </p>
+                <ul>
+                  <li>How transformation logic itself can introduce
+                      regressions.</li>
+                  <li>The value of post-write validation even when upstream data
+                      is trusted.</li>
+                  <li>Draft creation for output-side issues so contract updates
+                      remain traceable.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "Feature focus",
+                """
+                <ul>
+                  <li><strong>Custom output adjustments</strong> – the scenario
+                      uses the <code>valid-subset-violation</code> helper to
+                      simulate a bug.</li>
+                  <li><strong>Post-write governance</strong> – the failure is
+                      caught after the dataset is written.</li>
+                  <li><strong>Draft propagation</strong> – enforcement proposes
+                      <code>orders_enriched:1.2.0</code> just like the strict DQ
+                      scenario.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "How it works",
+                """
+                <ol>
+                  <li>Read the curated subset and apply the usual enrichments.</li>
+                  <li>Intentionally degrade one amount to 60 via the adjustment
+                      hook.</li>
+                  <li>Write the slice, run validation, and record the blocking
+                      verdict along with draft metadata.</li>
+                </ol>
+                """,
+            ),
+            _section(
+                "When to use it",
+                """
+                <ul>
+                  <li>When teaching teams to debug pipeline logic errors.</li>
+                  <li>To motivate unit tests or assertions around transformation
+                      code.</li>
+                  <li>To contrast with
+                      <a href="/pipeline-runs/read-valid-subset">Prefer valid subset</a>,
+                      which succeeds.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "What to explore next",
+                """
+                <p>
+                  Open the DQ payload to review the captured examples, then fix
+                  the adjustment helper (set it to
+                  <code>boost-amounts</code>) and rerun to validate your change.
+                </p>
+                """,
+            ),
+        ],
     },
     "data-product-roundtrip": {
         "label": "Data product roundtrip",
@@ -463,6 +1217,86 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
                 "output_adjustment": "boost-amounts",
             },
         },
+        "guide": [
+            _section(
+                "What this example shows",
+                """
+                <p>
+                  A complete data product lifecycle: consume a published port,
+                  stage governed intermediates, and publish a new port under the
+                  analytics data product. It demonstrates how contracts and data
+                  products interact.
+                </p>
+                """,
+            ),
+            _section(
+                "Why it matters",
+                """
+                <p>
+                  Data products often depend on each other. This scenario shows
+                  how DC43 provides consistent governance signals across that
+                  dependency chain:
+                </p>
+                <ul>
+                  <li>Input resolution uses the registry binding to ensure the
+                      right port and contract combination.</li>
+                  <li>An intermediate governed dataset (<code>dp.analytics.stage</code>)
+                      keeps transformations transparent.</li>
+                  <li>The published output records metadata back into the data
+                      product catalogue.
+                </ul>
+                """,
+            ),
+            _section(
+                "Feature focus",
+                """
+                <ul>
+                  <li><strong>Data product bindings</strong> – the configuration
+                      maps ports to concrete dataset versions.</li>
+                  <li><strong>Multi-contract enforcement</strong> – the run
+                      validates both the stage contract and the final output.</li>
+                  <li><strong>Governance metadata</strong> – the DQ payload shows
+                      how data product identifiers flow through validation.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "How it works",
+                """
+                <ol>
+                  <li>Resolve <code>dp.orders/orders-latest</code> via the data
+                      product registry.</li>
+                  <li>Join with customers, persist the stage dataset under its
+                      own contract, then re-read it.</li>
+                  <li>Publish the <code>dp.analytics</code> output port and store
+                      the validation outcome.</li>
+                </ol>
+                """,
+            ),
+            _section(
+                "When to use it",
+                """
+                <ul>
+                  <li>To demonstrate cross-product dependencies during platform
+                      walkthroughs.</li>
+                  <li>When designing governance workflows for federated teams.</li>
+                  <li>As a template for roundtrip orchestration that keeps stage
+                      artefacts governed.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "What to explore next",
+                """
+                <p>
+                  Inspect the data product metadata recorded in the run history
+                  and follow the links to the contracts and data product detail
+                  pages. Experiment by changing the expected contract versions to
+                  see how strict bindings protect consumers.
+                </p>
+                """,
+            ),
+        ],
     },
     "read-override-full": {
         "label": "Force blocked slice (manual override)",
@@ -519,6 +1353,87 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
             },
             "output_adjustment": "amplify-negative",
         },
+        "guide": [
+            _section(
+                "What this example shows",
+                """
+                <p>
+                  A manual override that downgrades a blocked input slice to
+                  <code>warn</code>. The pipeline proceeds but records a warning
+                  verdict and the override note.
+                </p>
+                """,
+            ),
+            _section(
+                "Why it matters",
+                """
+                <p>
+                  Occasionally teams must ship despite governance blocks. This
+                  scenario illustrates the safeguards around such decisions:
+                </p>
+                <ul>
+                  <li>Overrides require an explicit note that documents the
+                      rationale.</li>
+                  <li>Governance status is downgraded, not cleared, so consumers
+                      understand the residual risk.</li>
+                  <li>Validation still runs, capturing draft metadata for
+                      follow-up work.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "Feature focus",
+                """
+                <ul>
+                  <li><strong>Status strategy overrides</strong> – the
+                      <code>allow-block</code> strategy forces the read while
+                      recording the decision.</li>
+                  <li><strong>Observe mode</strong> – chosen to avoid double
+                      enforcement while still recording warnings.</li>
+                  <li><strong>Example capture</strong> – keeps traces of
+                      problematic rows for future triage.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "How it works",
+                """
+                <ol>
+                  <li>Request the latest <code>orders</code> slice even though it
+                      is blocked.</li>
+                  <li>Apply the override policy to downgrade the verdict to
+                      <code>warn</code>.</li>
+                  <li>Run the pipeline, which writes the dataset, records
+                      warnings, and keeps the override note in metadata.</li>
+                </ol>
+                """,
+            ),
+            _section(
+                "When to use it",
+                """
+                <ul>
+                  <li>To train operators on the governance exceptions process.</li>
+                  <li>When designing approval flows that require justification
+                      before forcing blocked data.</li>
+                  <li>To compare with
+                      <a href="/pipeline-runs/read-invalid-block">Invalid input blocked</a>
+                      (no override) and
+                      <a href="/pipeline-runs/contract-draft-override">Allow draft contract</a>
+                      (different override type).</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "What to explore next",
+                """
+                <p>
+                  Review the recorded override note in the run history, then
+                  remove the override configuration and rerun to observe the hard
+                  failure. This emphasises why overrides should be temporary.
+                </p>
+                """,
+            ),
+        ],
     },
     "split-lenient": {
         "label": "Split invalid rows",
@@ -571,6 +1486,87 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
                 "write_primary_on_violation": True,
             },
         },
+        "guide": [
+            _section(
+                "What this example shows",
+                """
+                <p>
+                  A lenient enforcement mode that keeps the main dataset while
+                  routing invalid rows to auxiliary outputs
+                  (<code>::valid</code> and <code>::reject</code>). The run ends
+                  with a warning instead of a block.
+                </p>
+                """,
+            ),
+            _section(
+                "Why it matters",
+                """
+                <p>
+                  Not every data quality issue justifies halting the pipeline.
+                  This scenario demonstrates a middle ground:
+                </p>
+                <ul>
+                  <li>Consumers can continue using the main dataset with full
+                      awareness of issues.</li>
+                  <li>Curated auxiliary datasets capture clean and problematic
+                      rows for downstream remediation.</li>
+                  <li>The run status is <code>warn</code>, signalling attention
+                      is needed without discarding all results.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "Feature focus",
+                """
+                <ul>
+                  <li><strong>Split violation strategy</strong> – demonstrates the
+                      configuration knobs for lenient handling.</li>
+                  <li><strong>Auxiliary dataset registration</strong> – links to
+                      the generated <code>::valid</code> and <code>::reject</code>
+                      slices are recorded in the run metadata.</li>
+                  <li><strong>Governance signalling</strong> – the warning status
+                      keeps monitoring tooling informed.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "How it works",
+                """
+                <ol>
+                  <li>Read and align inputs exactly like the standard
+                      enforcement run.</li>
+                  <li>Apply the split strategy so violations are written to
+                      dedicated datasets.</li>
+                  <li>Record the warning verdict and auxiliary dataset metadata
+                      for traceability.</li>
+                </ol>
+                """,
+            ),
+            _section(
+                "When to use it",
+                """
+                <ul>
+                  <li>To discuss service-level agreements where partial delivery
+                      is acceptable.</li>
+                  <li>When designing pipelines that feed quarantine workflows.</li>
+                  <li>As a contrast to
+                      <a href="/pipeline-runs/dq">strict enforcement</a>, which
+                      blocks the run outright.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "What to explore next",
+                """
+                <p>
+                  Inspect the generated auxiliary datasets in the workspace and
+                  use them to rehearse remediation strategies. Consider switching
+                  <code>include_valid</code> to <code>false</code> to observe how
+                  the outputs change.
+                </p>
+                """,
+            ),
+        ],
     },
 }
 

--- a/packages/dc43-demo-app/src/dc43_demo_app/templates/pipeline_run_detail.html
+++ b/packages/dc43-demo-app/src/dc43_demo_app/templates/pipeline_run_detail.html
@@ -1,0 +1,338 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="mb-3">
+  <a class="text-decoration-none" href="/pipeline-runs">&larr; Back to pipeline scenarios</a>
+</div>
+
+<div class="d-flex flex-wrap align-items-start gap-3 mb-3">
+  <div>
+    <h1 class="h2 mb-1">{{ scenario_row.label }}</h1>
+    <div class="text-muted small">Scenario key: {{ scenario_key }}</div>
+  </div>
+  {% if category_label %}
+  <span class="badge bg-secondary align-self-center">{{ category_label }}</span>
+  {% endif %}
+</div>
+
+<form id="scenario-run-form" class="mb-4" method="post" action="/pipeline/run">
+  <input type="hidden" name="scenario" value="{{ scenario_key }}"/>
+  <button class="btn btn-primary" type="submit">Run this scenario</button>
+</form>
+
+<div class="card mb-4">
+  <div class="card-body">
+    <h2 class="h5">Quick reference</h2>
+    <dl class="row small mb-0">
+      <dt class="col-sm-4">Primary dataset</dt>
+      <dd class="col-sm-8">
+        {% if dataset_name %}
+          <a href="/datasets/{{ dataset_name }}">{{ dataset_name }}</a>
+        {% else %}
+          <span class="text-muted">None recorded</span>
+        {% endif %}
+      </dd>
+      <dt class="col-sm-4">Contract</dt>
+      <dd class="col-sm-8">
+        {% set contract_id = (latest_record.contract_id if latest_record and latest_record.contract_id else scenario_row.contract_id) %}
+        {% set contract_version = (latest_record.contract_version if latest_record and latest_record.contract_version else scenario_row.contract_version) %}
+        {% if contract_id %}
+          <a href="/contracts/{{ contract_id }}">{{ contract_id }}</a>
+          {% if contract_version %}
+            <span class="text-muted">/</span>
+            <a href="/contracts/{{ contract_id }}/{{ contract_version }}">{{ contract_version }}</a>
+          {% endif %}
+        {% elif contract_version %}
+          {{ contract_version }}
+        {% else %}
+          <span class="text-muted">No output contract</span>
+        {% endif %}
+      </dd>
+      <dt class="col-sm-4">Default run type</dt>
+      <dd class="col-sm-8">{{ scenario_row.run_type }}</dd>
+      {% if latest_record and latest_record.draft_contract_version %}
+      <dt class="col-sm-4">Latest draft</dt>
+      <dd class="col-sm-8">
+        {% if latest_record.contract_id %}
+          <a href="/contracts/{{ latest_record.contract_id }}/{{ latest_record.draft_contract_version }}">{{ latest_record.draft_contract_version }}</a>
+        {% else %}
+          {{ latest_record.draft_contract_version }}
+        {% endif %}
+      </dd>
+      {% endif %}
+      {% if latest_record and latest_record.data_product_id %}
+      <dt class="col-sm-4">Data product</dt>
+      <dd class="col-sm-8">
+        <a href="/data-products/{{ latest_record.data_product_id }}">{{ latest_record.data_product_id }}</a>
+        {% if latest_record.data_product_port %}
+          <span class="text-muted">/</span>
+          <code>{{ latest_record.data_product_port }}</code>
+        {% endif %}
+        {% if latest_record.data_product_role %}
+          <span class="badge bg-secondary text-uppercase ms-1">{{ latest_record.data_product_role }}</span>
+        {% endif %}
+      </dd>
+      {% endif %}
+    </dl>
+    {% if activate_versions %}
+    <div class="mt-3">
+      <h3 class="h6">Default input slices</h3>
+      <ul class="small mb-0 ps-3">
+        {% for dataset, version in activate_versions.items() %}
+          <li><code>{{ dataset }}</code> → <code>{{ version }}</code></li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
+    {% if scenario_params.inputs or scenario_params.data_product_flow %}
+    <details class="mt-3 small">
+      <summary>Show raw configuration</summary>
+      <pre class="small mb-0">{{ scenario_params | tojson(indent=2) }}</pre>
+    </details>
+    {% endif %}
+  </div>
+</div>
+
+{% if scenario_row.description or scenario_row.diagram %}
+<div class="card mb-4">
+  <div class="card-body">
+    <h2 class="h5">Scenario flow</h2>
+    {% if scenario_row.description %}
+      <div class="mb-3">{{ scenario_row.description | safe }}</div>
+    {% endif %}
+    {% if scenario_row.diagram %}
+      {{ scenario_row.diagram | safe }}
+    {% endif %}
+  </div>
+</div>
+{% endif %}
+
+{% if guide_sections %}
+<div class="card mb-4">
+  <div class="card-body">
+    <h2 class="h5">Deep dive guide</h2>
+    {% for section in guide_sections %}
+      <section class="mb-4">
+        <h3 class="h6">{{ section.title }}</h3>
+        <div class="small">{{ section.content | safe }}</div>
+      </section>
+    {% endfor %}
+  </div>
+</div>
+{% endif %}
+
+{% if latest_record %}
+<div class="card mb-4">
+  <div class="card-body">
+    <h2 class="h5">Latest outcome</h2>
+    <p class="small mb-2">
+      The most recent run produced
+      {% if latest_record.dataset_version %}
+        <strong>{{ latest_record.dataset_version }}</strong>
+      {% else %}
+        no materialised dataset
+      {% endif %}
+      with status <span class="badge {{ status_badges.get(latest_record.status|lower, 'bg-secondary') }}">{{ latest_record.status }}</span>.
+    </p>
+    {% if latest_record.reason %}
+    <p class="small text-muted mb-0">Reason: {{ latest_record.reason }}</p>
+    {% endif %}
+  </div>
+</div>
+{% endif %}
+
+<h2 class="h4">Run history</h2>
+{% if has_history %}
+  {% for entry in history_entries %}
+    {% set record = entry.record %}
+    <div class="card mb-3">
+      <div class="card-body">
+        <div class="d-flex flex-wrap justify-content-between align-items-start gap-2 mb-2">
+          <div>
+            <h3 class="h6 mb-1">
+              {% if record.dataset_version %}
+                Version {{ record.dataset_version }}
+              {% else %}
+                Planned run (no write)
+              {% endif %}
+            </h3>
+            <div class="text-muted small">Run type: {{ record.run_type }}</div>
+          </div>
+          <span class="badge {{ status_badges.get(record.status|lower, 'bg-secondary') }}">{{ record.status }}</span>
+        </div>
+        <dl class="row small mb-0">
+          {% if record.contract_id %}
+          <dt class="col-sm-4">Contract</dt>
+          <dd class="col-sm-8">
+            <a href="/contracts/{{ record.contract_id }}">{{ record.contract_id }}</a>
+            {% if record.contract_version %}
+              <span class="text-muted">/</span>
+              <a href="/contracts/{{ record.contract_id }}/{{ record.contract_version }}">{{ record.contract_version }}</a>
+            {% endif %}
+          </dd>
+          {% elif record.contract_version %}
+          <dt class="col-sm-4">Contract version</dt>
+          <dd class="col-sm-8">{{ record.contract_version }}</dd>
+          {% endif %}
+          {% if record.draft_contract_version %}
+          <dt class="col-sm-4">Draft proposed</dt>
+          <dd class="col-sm-8">{{ record.draft_contract_version }}</dd>
+          {% endif %}
+          {% if record.data_product_id %}
+          <dt class="col-sm-4">Data product</dt>
+          <dd class="col-sm-8">
+            <a href="/data-products/{{ record.data_product_id }}">{{ record.data_product_id }}</a>
+            {% if record.data_product_port %}
+              <span class="text-muted">/</span>
+              <code>{{ record.data_product_port }}</code>
+            {% endif %}
+            {% if record.data_product_role %}
+              <span class="badge bg-secondary text-uppercase ms-1">{{ record.data_product_role }}</span>
+            {% endif %}
+          </dd>
+          {% endif %}
+          {% if record.reason %}
+          <dt class="col-sm-4">Reason</dt>
+          <dd class="col-sm-8">{{ record.reason }}</dd>
+          {% endif %}
+          {% if entry.output_details.get('violation_strategy') %}
+          <dt class="col-sm-4">Violation strategy</dt>
+          <dd class="col-sm-8">{{ entry.output_details.get('violation_strategy') }}</dd>
+          {% endif %}
+          {% if record.violations %}
+          <dt class="col-sm-4">Violations</dt>
+          <dd class="col-sm-8">{{ record.violations }}</dd>
+          {% endif %}
+        </dl>
+        {% if entry.failed_expectations or entry.schema_errors or entry.dq_aux or entry.input_payloads or entry.output_details.get('warnings') %}
+        <details class="mt-3">
+          <summary class="small">Validation payload</summary>
+          <div class="mt-2">
+            {% if entry.failed_expectations %}
+            <div class="mb-3">
+              <strong class="small d-block mb-1">Failed expectations</strong>
+              <ul class="small mb-0 ps-3">
+                {% for key, info in entry.failed_expectations.items() %}
+                  <li>
+                    <code>{{ key }}</code> – {{ info.count }} rows
+                    {% if info.expression %}
+                      <span class="text-muted">({{ info.expression }})</span>
+                    {% endif %}
+                    {% if info.examples %}
+                      <details class="mt-1">
+                        <summary class="small">Examples</summary>
+                        <pre class="small mb-0">{{ info.examples | tojson(indent=2) }}</pre>
+                      </details>
+                    {% endif %}
+                  </li>
+                {% endfor %}
+              </ul>
+            </div>
+            {% endif %}
+            {% if entry.schema_errors %}
+            <div class="mb-3">
+              <strong class="small d-block mb-1">Schema errors</strong>
+              <ul class="small mb-0 ps-3">
+                {% for err in entry.schema_errors %}
+                  <li>{{ err }}</li>
+                {% endfor %}
+              </ul>
+            </div>
+            {% endif %}
+            {% if entry.output_details.get('warnings') %}
+            <div class="mb-3">
+              <strong class="small d-block mb-1">Warnings</strong>
+              <ul class="small mb-0 ps-3">
+                {% for warning in entry.output_details.get('warnings') %}
+                  <li>{{ warning }}</li>
+                {% endfor %}
+              </ul>
+            </div>
+            {% endif %}
+            {% if entry.output_details.get('auxiliary_datasets') %}
+            <div class="mb-3">
+              <strong class="small d-block mb-1">Auxiliary datasets</strong>
+              <ul class="small mb-0 ps-3">
+                {% for aux in entry.output_details.get('auxiliary_datasets') %}
+                  <li>
+                    <span class="text-capitalize">{{ aux.kind }}</span> → <code>{{ aux.dataset }}</code>
+                    {% if aux.path %}
+                      <span class="text-muted">({{ aux.path }})</span>
+                    {% endif %}
+                  </li>
+                {% endfor %}
+              </ul>
+            </div>
+            {% endif %}
+            {% if entry.dq_aux %}
+            <div class="mb-3">
+              <strong class="small d-block mb-1">Auxiliary DQ statuses</strong>
+              <ul class="small mb-0 ps-3">
+                {% for aux in entry.dq_aux %}
+                  {% set details = aux.get('details') if aux.get('details') is mapping else {} %}
+                  <li>
+                    <code>{{ aux.get('dataset_id') }}</code> → {{ aux.get('status') }}
+                    {% if details.get('draft_contract_version') %}
+                      <span class="text-muted">(draft {{ details.get('draft_contract_version') }})</span>
+                    {% endif %}
+                    {% if details.get('reason') %}
+                      <span class="text-muted"> – {{ details.get('reason') }}</span>
+                    {% endif %}
+                  </li>
+                {% endfor %}
+              </ul>
+            </div>
+            {% endif %}
+            {% if entry.input_payloads %}
+            <div class="mb-0">
+              <strong class="small d-block mb-1">Input validation</strong>
+              {% for payload in entry.input_payloads %}
+                <details class="small mb-2">
+                  <summary>{{ payload.name }}</summary>
+                  <pre class="small mb-0">{{ payload.payload | tojson(indent=2) }}</pre>
+                </details>
+              {% endfor %}
+            </div>
+            {% endif %}
+          </div>
+        </details>
+        {% endif %}
+      </div>
+    </div>
+  {% endfor %}
+{% else %}
+  <div class="alert alert-info">This scenario has not been run yet. Use the button above to trigger the first execution.</div>
+{% endif %}
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    const form = document.getElementById('scenario-run-form');
+    if (form) {
+      form.addEventListener('submit', function () {
+        const button = form.querySelector('button[type="submit"]');
+        if (!button || button.disabled) {
+          return;
+        }
+        button.disabled = true;
+        button.innerHTML = '';
+        const spinner = document.createElement('span');
+        spinner.className = 'spinner-border spinner-border-sm me-2';
+        spinner.setAttribute('role', 'status');
+        spinner.setAttribute('aria-hidden', 'true');
+        button.appendChild(spinner);
+        const label = document.createElement('span');
+        label.textContent = 'Running…';
+        button.appendChild(label);
+      });
+    }
+
+    const mermaidNodes = document.querySelectorAll('.mermaid');
+    if (mermaidNodes.length && window.mermaid) {
+      if (typeof window.mermaid.run === 'function') {
+        window.mermaid.run({ nodes: mermaidNodes });
+      } else if (typeof window.mermaid.init === 'function') {
+        window.mermaid.init(undefined, mermaidNodes);
+      }
+    }
+  });
+</script>
+{% endblock %}

--- a/packages/dc43-demo-app/src/dc43_demo_app/templates/pipeline_runs.html
+++ b/packages/dc43-demo-app/src/dc43_demo_app/templates/pipeline_runs.html
@@ -31,7 +31,7 @@
       <th scope="row" class="w-25">
         <div class="d-flex align-items-start gap-2">
           <div>
-            <div class="fw-semibold">{{ scenario.label }}</div>
+            <div class="fw-semibold"><a href="/pipeline-runs/{{ scenario.key }}">{{ scenario.label }}</a></div>
             <div class="text-muted small">{{ scenario.key }}</div>
           </div>
           {% if scenario.description or scenario.diagram %}
@@ -318,6 +318,7 @@
       </td>
       <td class="text-center">{{ scenario.run_count }}</td>
       <td class="text-end">
+        <a class="btn btn-outline-secondary btn-sm me-1" href="/pipeline-runs/{{ scenario.key }}">Details</a>
         <form class="d-inline" method="post" action="/pipeline/run">
           <input type="hidden" name="scenario" value="{{ scenario.key }}"/>
           <button class="btn btn-primary btn-sm" type="submit">Run</button>


### PR DESCRIPTION
## Summary
- add structured guide content to every demo pipeline scenario
- serve dedicated detail pages with run history, guidance, and configuration context
- link the overview table to the new pages for easier navigation

## Testing
- pytest -q *(fails: missing httpx and fastapi optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68e24bfb1c28832eae1d7b8327370c2b