### PR TITLE
Add SQL contract store Terraform wiring and env overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ This architecture separates the libraries that ship with dc43 from the external 
 - **dc43 integrations & clients** include the runtime adapters plus the request/response protocols defined under [`dc43_service_clients`](packages/dc43-service-clients/src/dc43_service_clients). These clients declare how to fetch contracts, submit governance assessments, and register ODPS ports without exposing storage details.
 - **dc43 service backends** live in [`dc43_service_backends`](packages/dc43-service-backends/src/dc43_service_backends). They combine contract stores, the drafting module, the governance orchestrator, ODPS product registries, and the data-quality engine that materialises expectations from ODCS documents.
 - **Stewardship platforms** (Collibra, Unity Catalog UIs, custom consoles) sit outside this repository. The governance backend offers hook points so approval workflows can run there while still receiving compatibility assessments and draft details via [`governance.backend.local`](packages/dc43-service-backends/src/dc43_service_backends/governance/backend/local.py) and the hook interfaces in [`governance.hooks`](packages/dc43-service-backends/src/dc43_service_backends/governance/hooks.py).
-- **Storage & catalog backends** highlight the concrete infrastructure that backs each service: filesystem or Delta-backed contract stores and metadata targets updated by link hooks such as [`governance.unity_catalog`](packages/dc43-service-backends/src/dc43_service_backends/governance/unity_catalog.py).
+- **Storage & catalog backends** highlight the concrete infrastructure that backs each service: filesystem, SQL, or Delta-backed contract stores and metadata targets updated by link hooks such as [`governance.unity_catalog`](packages/dc43-service-backends/src/dc43_service_backends/governance/unity_catalog.py).
 
 ### Node & edge glossary
 
@@ -149,7 +149,7 @@ dc43 now ships as a family of distributions so you can install only the layers y
 | Distribution | Imports | Responsibility | Depends on |
 | --- | --- | --- | --- |
 | `dc43-service-clients` | `dc43_service_clients.*` | Typed service clients, request/response models, and governance helpers that front-end applications can embed. | `open-data-contract-standard` |
-| `dc43-service-backends` | `dc43_service_backends.*` | Reference backend implementations (filesystem store, local drafting, in-memory governance service) that orchestrate the client layer. | `dc43-service-clients` |
+| `dc43-service-backends` | `dc43_service_backends.*` | Reference backend implementations (filesystem/SQL stores, local drafting, in-memory governance service) that orchestrate the client layer. | `dc43-service-clients` |
 | `dc43-integrations` | `dc43_integrations.*` | Runtime adapters such as the Spark helpers that call into client APIs without requiring backend dependencies. | `dc43-service-clients` |
 | `dc43` | `dc43.*` | Aggregating package that wires the CLI/demo and depends on the three modules above. | all of the above |
 
@@ -157,6 +157,7 @@ dc43 now ships as a family of distributions so you can install only the layers y
 
 - **Service contracts only**: `pip install dc43-service-clients`
 - **Backend reference services**: `pip install dc43-service-backends`
+- **Backend services with SQL storage**: `pip install "dc43-service-backends[sql]"`
 - **HTTP service backends**: `pip install "dc43-service-backends[http]"` (see
   [`deploy/http-backend/README.md`](deploy/http-backend/README.md) for a
   containerised deployment recipe)

--- a/deploy/terraform/aws-service-backend/variables.tf
+++ b/deploy/terraform/aws-service-backend/variables.tf
@@ -13,6 +13,17 @@ variable "ecr_image_uri" {
   type        = string
 }
 
+variable "contract_store_mode" {
+  description = "Contract store backing implementation (filesystem or sql)"
+  type        = string
+  default     = "filesystem"
+
+  validation {
+    condition     = contains(["filesystem", "sql"], lower(var.contract_store_mode))
+    error_message = "contract_store_mode must be either 'filesystem' or 'sql'."
+  }
+}
+
 variable "backend_token" {
   description = "Bearer token enforced by the service"
   type        = string
@@ -20,14 +31,39 @@ variable "backend_token" {
 }
 
 variable "contract_filesystem" {
-  description = "Identifier for the EFS file system"
+  description = "Identifier for the EFS file system (filesystem mode)"
   type        = string
 }
 
 variable "contract_storage_path" {
-  description = "Mount path inside the container for the contract store"
+  description = "Mount path inside the container for the contract store (filesystem mode)"
   type        = string
   default     = "/contracts"
+}
+
+variable "contract_store_dsn" {
+  description = "SQLAlchemy DSN used when contract_store_mode = 'sql'"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "contract_store_dsn_secret_arn" {
+  description = "Secrets Manager ARN or SSM Parameter ARN containing the DSN (sql mode optional alternative to contract_store_dsn)"
+  type        = string
+  default     = ""
+}
+
+variable "contract_store_table" {
+  description = "Contracts table name when using the SQL store"
+  type        = string
+  default     = "contracts"
+}
+
+variable "contract_store_schema" {
+  description = "Optional schema/namespace used by the SQL contract store"
+  type        = string
+  default     = ""
 }
 
 variable "private_subnet_ids" {

--- a/deploy/terraform/azure-service-backend/README.md
+++ b/deploy/terraform/azure-service-backend/README.md
@@ -6,7 +6,10 @@ It provisions:
 - A resource group
 - Log Analytics workspace for diagnostics
 - A Container Apps environment
-- A storage account and Azure Files share for the contract store
+- A storage account and Azure Files share for the contract store when
+  `contract_store_mode = "filesystem"`
+- Container App configuration for the SQL contract store when
+  `contract_store_mode = "sql"`
 - The container app with ingress enabled and registry credentials configured
 
 ## Usage
@@ -33,14 +36,27 @@ It provisions:
 | `container_registry_password` | Password or token for the registry. |
 | `image_tag` | Repository and tag of the container image (e.g. `dc43-service-backends-http:latest`). |
 | `backend_token` | Optional bearer token enforced by the service backends. |
-| `contract_storage` | Mount path used by the service to persist contracts. |
+| `contract_storage` | Mount path used by the service to persist contracts (filesystem mode). |
 
 Optional variables let you customise the container app name, ingress port, and
 scaling settings—see `variables.tf` for the full list.
 
+### Switching to the SQL contract store
+
+Set `contract_store_mode = "sql"` to disable the Azure Files share and inject
+the relational backend configuration instead. In this mode you must also
+provide:
+
+| Variable | Description |
+| -------- | ----------- |
+| `contract_store_dsn` | SQLAlchemy DSN with credentials (for example `postgresql+psycopg://user:pass@db.internal/dc43`). |
+| `contract_store_table` | Optional table name (defaults to `contracts`). |
+| `contract_store_schema` | Optional schema/namespace containing the table. |
+
 ## Outputs
 
 - `container_app_fqdn` – Public FQDN of the container app.
-- `storage_account_name` – Azure Storage account that holds the contracts share.
+- `storage_account_name` – Azure Storage account that holds the contracts share
+  (null when `contract_store_mode = "sql"`).
 
 Use the storage account to upload existing contracts or to back up drafts.

--- a/deploy/terraform/azure-service-backend/variables.tf
+++ b/deploy/terraform/azure-service-backend/variables.tf
@@ -40,22 +40,52 @@ variable "backend_token" {
   default     = ""
 }
 
+variable "contract_store_mode" {
+  description = "Contract store backing implementation (filesystem or sql)"
+  type        = string
+  default     = "filesystem"
+
+  validation {
+    condition     = contains(["filesystem", "sql"], lower(var.contract_store_mode))
+    error_message = "contract_store_mode must be either 'filesystem' or 'sql'."
+  }
+}
+
 variable "contract_storage" {
-  description = "Path mounted inside the container for contracts"
+  description = "Path mounted inside the container for contracts (filesystem mode only)"
   type        = string
   default     = "/contracts"
 }
 
 variable "contract_share_name" {
-  description = "Azure Files share used for contract storage"
+  description = "Azure Files share used for contract storage when contract_store_mode = 'filesystem'"
   type        = string
   default     = "contracts"
 }
 
 variable "contract_share_quota_gb" {
-  description = "Quota for the Azure Files share"
+  description = "Quota for the Azure Files share when contract_store_mode = 'filesystem'"
   type        = number
   default     = 100
+}
+
+variable "contract_store_dsn" {
+  description = "SQLAlchemy DSN used when contract_store_mode = 'sql'"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "contract_store_table" {
+  description = "Contracts table name when using the SQL store"
+  type        = string
+  default     = "contracts"
+}
+
+variable "contract_store_schema" {
+  description = "Optional schema/namespace used by the SQL contract store"
+  type        = string
+  default     = ""
 }
 
 variable "container_app_environment_name" {

--- a/docs/component-contract-store.md
+++ b/docs/component-contract-store.md
@@ -48,6 +48,7 @@ source of truth maintained by the contract store.
 | Store | Ideal Use Case | Characteristics |
 | --- | --- | --- |
 | [`FSContractStore`](../packages/dc43-service-backends/src/dc43_service_backends/contracts/backend/stores/filesystem.py) | Simple deployments, Databricks Repos, dev/test | Persists JSON files under a base path (DBFS, mounted volume). Easy to inspect and version with Git or object storage. |
+| [`SQLContractStore`](../packages/dc43-service-backends/src/dc43_service_backends/contracts/backend/stores/sql.py) | Teams that standardise on managed databases (Azure SQL, Amazon RDS, PostgreSQL, MySQL) | Uses SQLAlchemy to persist contracts in relational tables. Works with any engine supported by SQLAlchemy and keeps governance metadata queryable via SQL. |
 | [`DeltaContractStore`](../packages/dc43-service-backends/src/dc43_service_backends/contracts/backend/stores/delta.py) | Teams standardizing on Delta or Unity Catalog | Stores contracts and metadata rows inside a Delta table. Supports ACID writes, SQL discovery, and time travel. Requires `pyspark`. |
 | [`CollibraContractStore`](../packages/dc43-service-backends/src/dc43_service_backends/contracts/backend/stores/collibra.py) | Organizations with Collibra-driven governance | Delegates storage and lifecycle to Collibra via the `CollibraContractAdapter`. Allows filtering by Collibra status (Draft, Validated, Deprecated) and can share workflows with Collibra stewards. Compatibility aliases for the old gateway naming remain available. |
 
@@ -79,6 +80,7 @@ Guides for existing stores live under
 
 - [Filesystem store](implementations/contract-store/fs.md)
 - [Delta-backed store](implementations/contract-store/delta.md)
+- [SQL-backed store](implementations/contract-store/sql.md)
 - [Collibra-backed store](implementations/contract-store/collibra.md)
 
 Document additional backends (REST services, Git, object storage, …)

--- a/docs/getting-started/spark-remote.md
+++ b/docs/getting-started/spark-remote.md
@@ -9,7 +9,7 @@ Ask your operations team for:
 
 - The base URL of the governance service (for example `https://governance.example.com`).
 - The shared `DC43_BACKEND_TOKEN` secret, if authentication is enabled.
-- Context about the backing contract store (filesystem, Collibra, Delta) so you can mirror behaviour locally when needed.
+- Context about the backing contract store (filesystem, SQL, Collibra, Delta) so you can mirror behaviour locally when needed.
 
 ## 2. Install the runtime helpers
 

--- a/docs/implementations/contract-store/delta.md
+++ b/docs/implementations/contract-store/delta.md
@@ -6,8 +6,9 @@ Catalog and unlocks ACID writes, SQL discovery, and time travel.
 
 ## Characteristics
 
-* Persists contract payloads alongside metadata columns (id, version,
-  status, timestamps) in a managed Delta table.
+* Persists contract payloads alongside metadata columns (identifier,
+  version, names, fingerprints, timestamps) in a managed Delta table that
+  mirrors the relational SQL backend.
 * Supports `latest(...)` resolution by semantic version or additional
   filters (for example a Collibra status synced through metadata).
 * Allows governance teams to query contract inventories with standard SQL
@@ -19,24 +20,30 @@ The backing table stores each contract version as one row:
 
 | Column | Type | Description |
 | --- | --- | --- |
-| `id` | STRING | Contract identifier (e.g., `sales.orders`). |
+| `contract_id` | STRING | Contract identifier (e.g., `sales.orders`). |
 | `version` | STRING | Semantic version tag. |
-| `status` | STRING | Optional lifecycle label (`Draft`, `Validated`, …). |
-| `updated_at` | TIMESTAMP | Last write timestamp. |
-| `payload` | STRING | Raw ODCS JSON document. |
+| `name` | STRING | Human friendly display name (falls back to the identifier). |
+| `description` | STRING | Optional usage description from the ODCS document. |
+| `json` | STRING | Canonical ODCS JSON payload. |
+| `fingerprint` | STRING | SHA-256 fingerprint for change detection. |
+| `created_at` | TIMESTAMP | Timestamp for the latest write. |
 
 You can extend the schema with governance-specific metadata (owners,
 review ticket, steward notes) and create Z-order indexes for faster
-lookups by `id`.
+lookups by `contract_id`.
+
+The implementation reuses the same serialisation helper as the
+SQL-backed store, so failover between Unity Catalog tables and regular
+relational databases does not change the contract payload structure.
 
 Configure it via:
 
 ```python
 from dc43_service_backends.contracts.backend.stores import DeltaContractStore
 
-store = DeltaContractStore(table_path="/mnt/contracts_delta")
+store = DeltaContractStore(table="governance.meta.contracts")
 store.put(contract)
-validated = store.latest("sales.orders", status="Validated")
+validated = store.latest("sales.orders")
 ```
 
 When deploying in Unity Catalog, grant the table to the teams that need

--- a/docs/implementations/contract-store/sql.md
+++ b/docs/implementations/contract-store/sql.md
@@ -1,0 +1,132 @@
+# SQL-backed contract store
+
+`SQLContractStore` keeps Open Data Contract Standard (ODCS) documents in a
+relational database using SQLAlchemy Core. It complements the filesystem and
+Delta implementations by targeting managed SQL services—Azure SQL Database,
+Amazon RDS (PostgreSQL/MySQL), Google Cloud SQL, self-hosted PostgreSQL, MySQL,
+SQL Server, or even SQLite for quick tests.
+
+## When to choose it
+
+- **Managed relational databases** – reuse existing backup, replication, and
+  audit policies provided by your cloud database service.
+- **Central governance warehouses** – expose contracts and metadata via SQL so
+  analytics teams can join them with catalog or monitoring tables.
+- **Hybrid deployments** – keep the same backend for authors running locally
+  (SQLite) and production environments (Azure SQL, RDS) by swapping the DSN.
+
+Use the Delta-backed store when you specifically need Spark-native Delta Lake
+features such as time travel or lakehouse optimisations. Delta already relies
+on SQL for discovery, but it requires a Spark runtime. The SQL store works with
+standard SQL servers and drivers and therefore covers “regular” SQL use cases.
+Both implementations share the same contract schema and serialisation helpers,
+so switching between them simply changes the execution engine (Spark vs.
+SQLAlchemy) without rewriting documents.
+
+## Configuration
+
+Enable the store through the service backend configuration:
+
+```toml
+[contract_store]
+type = "sql"
+dsn = "postgresql+psycopg://user:password@db.internal/dc43"
+table = "contracts"           # Optional (defaults to "contracts")
+schema = "governance"         # Optional
+```
+
+Key fields:
+
+- `dsn` – SQLAlchemy connection string. Works with drivers such as `psycopg`
+  (PostgreSQL), `pymysql` (MySQL/MariaDB), `pyodbc` (SQL Server), or `sqlite`. Set
+  environment variable `DC43_CONTRACT_STORE_DSN` to override at runtime.
+- `table` – Custom table name. Defaults to `contracts`.
+- `schema` – Optional database schema/namespace when your engine supports it.
+
+Install SQL support using the optional dependency:
+
+```bash
+pip install dc43-service-backends[sql]
+```
+
+Alternatively, add `sqlalchemy>=2.0` to your environment manually.
+
+## Table schema
+
+The store automatically creates the table (within the optional schema) when it
+initialises. Columns:
+
+| Column | Type | Notes |
+| ------ | ---- | ----- |
+| `contract_id` | `VARCHAR(255)` | Part of the primary key. |
+| `version` | `VARCHAR(64)` | Part of the primary key. Stores semantic versions. |
+| `name` | `VARCHAR(255)` | Display name of the contract (falls back to the identifier). |
+| `description` | `TEXT` | Optional usage description extracted from the ODCS document. |
+| `json` | `TEXT` | Canonical ODCS JSON payload. |
+| `fingerprint` | `VARCHAR(64)` | SHA-256 fingerprint for change detection. |
+| `created_at` | `TIMESTAMP WITH TIME ZONE` | Automatically populated on insert. |
+
+Existing rows are updated when a contract with the same `contract_id` and
+`version` is written again, keeping the table compatible with migrations that
+replay historical documents.
+
+## Environment-specific guidance
+
+### Local development
+
+1. Install the optional SQL extra: `pip install dc43-service-backends[sql]`.
+2. Start a local database. For quick iteration use SQLite by pointing the DSN
+   at a file (for example `sqlite:///./contracts.db`). If you already run a
+   PostgreSQL or MySQL instance locally, reuse it by constructing the matching
+   SQLAlchemy DSN (for example
+   `postgresql+psycopg://postgres:postgres@localhost:5432/dc43`).
+3. Update `dc43-service-backends.toml` in your repository or override the
+   `DC43_CONTRACT_STORE_DSN` environment variable before starting the service.
+4. Launch the backend (for example with `dc43 service-backends serve ...`). The
+   store will automatically create the table and keep it in sync as you edit
+   contracts.
+
+### Azure deployment
+
+1. Provision an Azure SQL Database (or Azure Database for PostgreSQL/MySQL)
+   alongside your service. Note the fully qualified connection string.
+2. Store credentials in Azure Key Vault or configure managed identity access
+   for the compute surface (Azure Container Apps, AKS, App Service).
+3. Expose the DSN to the service via `DC43_CONTRACT_STORE_DSN`. When using
+   managed identity, create a DSN that leverages the appropriate authentication
+   plugin (for example `sqlserver+pyodbc://@server.database.windows.net/db` with
+   `Authentication=ActiveDirectoryMsi` in `odbc_connect`).
+4. Deploy the service container or function with the SQL extra installed. On
+   Azure Container Apps or AKS, bake `pip install dc43-service-backends[sql]`
+   into the image or layer it during startup.
+5. Apply firewall rules or private endpoints so the service can reach the SQL
+   database, then restart the workload. The contract table will appear in the
+   configured schema during the first run.
+
+The Terraform stacks under `deploy/terraform/azure-service-backend` and
+`deploy/terraform/aws-service-backend` expose `contract_store_mode = "sql"`
+switches. When enabled, the modules provision the correct environment variables
+for `DC43_CONTRACT_STORE_TYPE` and `DC43_CONTRACT_STORE_DSN` so the service uses
+the relational backend without mounting shared storage.
+
+### AWS deployment
+
+1. Create an Amazon RDS or Aurora instance that matches your preferred engine
+   (PostgreSQL/MySQL). Capture the host, port, and database name.
+2. Manage credentials with AWS Secrets Manager or IAM database authentication
+   tokens. For IAM tokens, generate them during startup and inject them into the
+   DSN (for example
+   `postgresql+psycopg://db_user:<token>@instance.cluster-XYZ.us-east-1.rds.amazonaws.com:5432/dc43`).
+3. Configure the hosting environment (ECS, EKS, Lambda, or EC2) to export
+   `DC43_CONTRACT_STORE_DSN`. Rotate the secret by updating the environment
+   variable or task definition; the store will pick up the change on restart.
+4. Ensure the workload can reach the database through VPC security groups or
+   PrivateLink endpoints.
+5. Deploy the service container with the SQL extra installed. The store will
+   create or migrate the contracts table automatically during bootstrap.
+
+Because SQLAlchemy abstracts vendors, the same `SQLContractStore` works across
+providers. Pair it with your preferred high availability configuration, backup
+policies, and credential rotation workflows. For Google Cloud SQL deployments,
+reuse the same pattern by running the Cloud SQL Auth proxy or using the Python
+connector dialects in the DSN.

--- a/docs/service-backends-configuration.md
+++ b/docs/service-backends-configuration.md
@@ -30,6 +30,13 @@ single field without editing the TOML file:
 * Service backends:
   * `DC43_CONTRACT_STORE` – overrides the filesystem path or stub base path used
     by the active contract store.
+  * `DC43_CONTRACT_STORE_TYPE` – forces the contract store implementation
+    without editing the TOML file (`filesystem`, `sql`, `delta`, `collibra_stub`,
+    `collibra_http`).
+  * `DC43_CONTRACT_STORE_DSN` – provides a SQLAlchemy DSN when using the SQL
+    backend.
+  * `DC43_CONTRACT_STORE_TABLE` / `DC43_CONTRACT_STORE_SCHEMA` – override the
+    table or schema used by SQL and Delta stores.
   * `DC43_BACKEND_TOKEN` – overrides the bearer token required by the HTTP API.
 * Contracts app:
   * `DC43_CONTRACTS_APP_WORK_DIR` / `DC43_DEMO_WORK_DIR` – overrides the
@@ -62,7 +69,8 @@ expose. Supported values are:
 | Type | Description |
 | ---- | ----------- |
 | `filesystem` | Stores contracts on the local filesystem using `FSContractStore`. |
-| `delta` | Persists contracts in a Delta table or Unity Catalog object via `DeltaContractStore`. Requires `pyspark`. |
+| `sql` | Persists contracts in a relational database through `SQLContractStore`. Compatible with PostgreSQL, MySQL, SQL Server, SQLite, and any SQLAlchemy-supported backend. |
+| `delta` | Persists contracts in a Delta table or Unity Catalog object via `DeltaContractStore`. Requires `pyspark` and a Spark runtime. |
 | `collibra_stub` | Wraps the in-repo Collibra stub adapter, useful for integration tests and demos that emulate Collibra workflows locally. |
 | `collibra_http` | Connects to a real Collibra Data Products deployment through `HttpCollibraContractAdapter`. |
 
@@ -85,6 +93,16 @@ Set `type = "delta"` to activate the Delta-backed store. The service attempts to
 import `pyspark` and uses `SparkSession.builder.getOrCreate()` to access the
 workspace catalog. Provide either `table` or `base_path`; if both are defined
 the table takes precedence.
+
+#### SQL contract store
+
+| Key | Type | Description |
+| --- | ---- | ----------- |
+| `dsn` | string | **Required.** SQLAlchemy connection string (e.g. `postgresql+psycopg://user:pass@host/db`). Works with Azure SQL, Amazon RDS, Google Cloud SQL, or local engines such as SQLite. |
+| `table` | string | Optional table name used for persistence. Defaults to `contracts`. |
+| `schema` | string | Optional database schema or namespace that contains the contracts table. |
+
+Install the `sql` optional dependency (`pip install dc43-service-backends[sql]`) or add `sqlalchemy` to your environment before enabling this backend. Delta-backed storage already covers Spark-native Delta tables, so use the SQL store for managed relational services on Azure, AWS, or self-hosted databases.
 
 #### Collibra stub contract store
 

--- a/docs/templates/dc43-service-backends.toml
+++ b/docs/templates/dc43-service-backends.toml
@@ -2,6 +2,10 @@
 # Copy this file to a writable location (e.g. /etc/dc43/service-backends.toml)
 # and adjust the values to match your environment.
 
+# Environment variables (`DC43_CONTRACT_STORE_TYPE`, `DC43_CONTRACT_STORE_DSN`,
+# etc.) override the values below at runtime, which is helpful for Terraform or
+# container orchestrators that inject secrets without editing the file.
+
 # ---------------------------------------------------------------------------
 # Filesystem-backed contract store
 # ---------------------------------------------------------------------------
@@ -28,6 +32,16 @@ root = "./contracts"
 # [contract_store.catalog."product-quality"]
 # data_product = "data-products/customer"
 # port = "gold-quality"
+
+# ---------------------------------------------------------------------------
+# SQL contract store (uncomment to persist contracts in PostgreSQL, MySQL,
+# SQLite, etc.). Install the ``sql`` extra or ensure ``sqlalchemy`` is available.
+# ---------------------------------------------------------------------------
+# [contract_store]
+# type = "sql"
+# dsn = "postgresql+psycopg://user:password@db.internal/dc43"
+# table = "contracts"
+# schema = "governance"
 
 # ---------------------------------------------------------------------------
 # Collibra HTTP contract store (uncomment when pointing at a live Collibra

--- a/packages/dc43-demo-app/src/dc43_demo_app/scenarios.py
+++ b/packages/dc43-demo-app/src/dc43_demo_app/scenarios.py
@@ -2,12 +2,24 @@ from __future__ import annotations
 
 from textwrap import dedent
 from typing import Any, Dict
+import html
 
 
 def _section(title: str, body: str) -> dict[str, str]:
     """Create a guide section with normalised HTML content."""
 
     return {"title": title, "content": dedent(body).strip()}
+
+
+def _code_section(title: str, code: str, lead: str | None = None) -> dict[str, str]:
+    """Create a section that embeds a syntax-highlighted Python snippet."""
+
+    snippet = html.escape(dedent(code).strip())
+    parts: list[str] = []
+    if lead:
+        parts.append(dedent(lead).strip())
+    parts.append(f"<pre><code class=\"language-python\">{snippet}</code></pre>")
+    return {"title": title, "content": "\n\n".join(parts).strip()}
 
 _DEFAULT_SLICE = {
     "orders": "2024-01-01",
@@ -124,6 +136,59 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
                       and keeps the filesystem unchanged.</li>
                 </ol>
                 """,
+            ),
+            _code_section(
+                "Pipeline example",
+                """
+from pyspark.sql import SparkSession
+from dc43_integrations.spark.io import (
+    DefaultReadStatusStrategy,
+    StaticDatasetLocator,
+    read_from_data_product,
+)
+from dc43_service_clients.contracts.client.interface import ContractServiceClient
+from dc43_service_clients.data_products import DataProductServiceClient
+from dc43_service_clients.data_quality.client.interface import (
+    DataQualityServiceClient,
+)
+
+
+def run_no_contract(
+    spark: SparkSession,
+    *,
+    contract_service: ContractServiceClient,
+    data_products: DataProductServiceClient,
+    dq_service: DataQualityServiceClient,
+) -> None:
+    """Resolve inputs and fail fast when no output contract is supplied."""
+
+    orders_df = read_from_data_product(
+        spark,
+        data_product_service=data_products,
+        data_product_input={"data_product": "orders", "port_name": "latest"},
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(dataset_version="2025-10-05"),
+        status_strategy=DefaultReadStatusStrategy(),
+        return_status=False,
+    )
+    customers_df = read_from_data_product(
+        spark,
+        data_product_service=data_products,
+        data_product_input={"data_product": "customers", "port_name": "latest"},
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(dataset_version="2024-01-01"),
+        status_strategy=DefaultReadStatusStrategy(),
+        return_status=False,
+    )
+    _ = orders_df.join(customers_df, "customer_id", "left")
+
+    target_contract = None  # Scenario intentionally omits the contract id.
+    if not target_contract:
+        raise RuntimeError("Output contract must be configured before publishing data.")
+                """,
+                "<p>The demo job stops before publishing because the contract id is missing. Guard the write step explicitly so orchestration halts before any files are materialised.</p>",
             ),
             _section(
                 "When to use it",
@@ -253,6 +318,78 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
                 </ol>
                 """,
             ),
+            _code_section(
+                "Pipeline example",
+                """
+from datetime import datetime, timezone
+from pyspark.sql import SparkSession
+from dc43_integrations.spark.io import (
+    DefaultReadStatusStrategy,
+    StaticDatasetLocator,
+    read_from_data_product,
+    write_with_contract,
+)
+from dc43_service_clients.contracts.client.interface import ContractServiceClient
+from dc43_service_clients.data_products import DataProductServiceClient
+from dc43_service_clients.data_quality.client.interface import (
+    DataQualityServiceClient,
+)
+
+
+def run_orders_enriched_ok(
+    spark: SparkSession,
+    *,
+    contract_service: ContractServiceClient,
+    data_products: DataProductServiceClient,
+    dq_service: DataQualityServiceClient,
+) -> None:
+    """Execute the happy-path pipeline for orders_enriched:1.0.0."""
+
+    orders_df = read_from_data_product(
+        spark,
+        data_product_service=data_products,
+        data_product_input={"data_product": "orders", "port_name": "latest"},
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(dataset_version="2025-10-05__pinned"),
+        status_strategy=DefaultReadStatusStrategy(),
+        return_status=False,
+    )
+    customers_df = read_from_data_product(
+        spark,
+        data_product_service=data_products,
+        data_product_input={"data_product": "customers", "port_name": "latest"},
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(dataset_version="2024-01-01"),
+        status_strategy=DefaultReadStatusStrategy(),
+        return_status=False,
+    )
+    enriched_df = orders_df.join(customers_df, "customer_id", "left")
+
+    run_version = datetime.now(timezone.utc).isoformat()
+    result = write_with_contract(
+        df=enriched_df,
+        contract_id="orders_enriched",
+        expected_contract_version="==1.0.0",
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        data_product_service=data_products,
+        data_product_output={
+            "data_product": "demo.analytics",
+            "port_name": "orders-enriched",
+        },
+        dataset_locator=StaticDatasetLocator(
+            dataset_id="orders_enriched",
+            dataset_version=run_version,
+        ),
+        pipeline_context={"scenario": "existing-contract-ok"},
+    )
+    if result.status != "ok":
+        raise RuntimeError(f"Validation failed: {result.details}")
+                """,
+                "<p>Replicate the successful run by resolving curated inputs, writing with <code>orders_enriched:1.0.0</code>, and checking the validation result before completing the job.</p>",
+            ),
             _section(
                 "When to use it",
                 """
@@ -379,6 +516,72 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
                 </ol>
                 """,
             ),
+            _code_section(
+                "Pipeline example",
+                """
+from datetime import datetime, timezone
+from pyspark.sql import SparkSession, functions as F
+from dc43_integrations.spark.io import (
+    DefaultReadStatusStrategy,
+    StaticDatasetLocator,
+    read_from_data_product,
+    write_with_contract,
+)
+from dc43_service_clients.contracts.client.interface import ContractServiceClient
+from dc43_service_clients.data_products import DataProductServiceClient
+from dc43_service_clients.data_quality.client.interface import (
+    DataQualityServiceClient,
+)
+
+
+def run_orders_enriched_dq_failure(
+    spark: SparkSession,
+    *,
+    contract_service: ContractServiceClient,
+    data_products: DataProductServiceClient,
+    dq_service: DataQualityServiceClient,
+) -> None:
+    """Intentionally break a quality rule to surface a blocking verdict."""
+
+    orders_df = read_from_data_product(
+        spark,
+        data_product_service=data_products,
+        data_product_input={"data_product": "orders", "port_name": "latest"},
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(dataset_version="2024-01-01"),
+        status_strategy=DefaultReadStatusStrategy(),
+        return_status=False,
+    )
+    customers_df = read_from_data_product(
+        spark,
+        data_product_service=data_products,
+        data_product_input={"data_product": "customers", "port_name": "latest"},
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(dataset_version="2024-01-01"),
+        status_strategy=DefaultReadStatusStrategy(),
+        return_status=False,
+    )
+    enriched_df = orders_df.join(customers_df, "customer_id", "left")
+    failing_df = enriched_df.withColumn("amount", F.col("amount") - F.lit(120))
+
+    run_version = datetime.now(timezone.utc).isoformat()
+    result = write_with_contract(
+        df=failing_df,
+        contract_id="orders_enriched",
+        expected_contract_version="==1.1.0",
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        data_product_service=data_products,
+        dataset_locator=StaticDatasetLocator(dataset_version=run_version),
+        pipeline_context={"scenario": "dq"},
+    )
+    if result.status == "block":
+        raise RuntimeError(f"DQ failure detected: {result.details}")
+                """,
+                "<p>The demo forces <code>amount</code> below the expectation to show how enforcement surfaces a blocking verdict and draft metadata.</p>",
+            ),
             _section(
                 "When to use it",
                 """
@@ -504,6 +707,75 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
                 </ol>
                 """,
             ),
+            _code_section(
+                "Pipeline example",
+                """
+from datetime import datetime, timezone
+from pyspark.sql import SparkSession, functions as F
+from dc43_integrations.spark.io import (
+    DefaultReadStatusStrategy,
+    StaticDatasetLocator,
+    read_from_data_product,
+    write_with_contract,
+)
+from dc43_service_clients.contracts.client.interface import ContractServiceClient
+from dc43_service_clients.data_products import DataProductServiceClient
+from dc43_service_clients.data_quality.client.interface import (
+    DataQualityServiceClient,
+)
+
+
+def run_orders_enriched_schema_and_dq(
+    spark: SparkSession,
+    *,
+    contract_service: ContractServiceClient,
+    data_products: DataProductServiceClient,
+    dq_service: DataQualityServiceClient,
+) -> None:
+    """Trigger combined schema and DQ failures for orders_enriched:2.0.0."""
+
+    orders_df = read_from_data_product(
+        spark,
+        data_product_service=data_products,
+        data_product_input={"data_product": "orders", "port_name": "latest"},
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(dataset_version="2024-01-01"),
+        status_strategy=DefaultReadStatusStrategy(),
+        return_status=False,
+    )
+    customers_df = read_from_data_product(
+        spark,
+        data_product_service=data_products,
+        data_product_input={"data_product": "customers", "port_name": "latest"},
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(dataset_version="2024-01-01"),
+        status_strategy=DefaultReadStatusStrategy(),
+        return_status=False,
+    )
+    enriched_df = orders_df.join(customers_df, "customer_id", "left")
+    broken_df = (
+        enriched_df.drop("customer_id")
+        .withColumn("amount", F.col("amount") - F.lit(200))
+    )
+
+    run_version = datetime.now(timezone.utc).isoformat()
+    result = write_with_contract(
+        df=broken_df,
+        contract_id="orders_enriched",
+        expected_contract_version="==2.0.0",
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        data_product_service=data_products,
+        dataset_locator=StaticDatasetLocator(dataset_version=run_version),
+        pipeline_context={"scenario": "schema-dq"},
+    )
+    if result.status == "block":
+        raise RuntimeError(f"Schema or DQ drift detected: {result.details}")
+                """,
+                "<p>The code intentionally drops <code>customer_id</code> and reduces <code>amount</code> so both schema alignment and quality checks fail under <code>orders_enriched:2.0.0</code>.</p>",
+            ),
             _section(
                 "When to use it",
                 """
@@ -616,6 +888,27 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
                       teams can request an approval or switch scenarios.</li>
                 </ol>
                 """,
+            ),
+            _code_section(
+                "Pipeline example",
+                """
+from dc43_service_clients.contracts.client.interface import ContractServiceClient
+
+
+def enforce_active_contract_only(
+    *,
+    contract_service: ContractServiceClient,
+) -> None:
+    """Abort publishing when the target contract remains in draft status."""
+
+    contract = contract_service.get("orders_enriched", "3.0.0")
+    status = (getattr(contract, "status", "") or "").lower()
+    if status != "active":
+        raise RuntimeError(
+            "orders_enriched:3.0.0 must be promoted to 'active' before enforcement",
+        )
+                """,
+                "<p>Check the contract metadata up front – enforcement refuses to proceed while <code>orders_enriched:3.0.0</code> stays in <code>draft</code>.</p>",
             ),
             _section(
                 "When to use it",
@@ -750,6 +1043,91 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
                 </ol>
                 """,
             ),
+            _code_section(
+                "Pipeline example",
+                """
+from datetime import datetime, timezone
+from pyspark.sql import SparkSession, functions as F
+from dc43_integrations.spark.io import (
+    DefaultReadStatusStrategy,
+    StaticDatasetLocator,
+    read_from_data_product,
+    write_with_contract,
+)
+from dc43_integrations.spark.violation_strategy import NoOpWriteViolationStrategy
+from dc43_service_clients.contracts.client.interface import ContractServiceClient
+from dc43_service_clients.data_products import DataProductServiceClient
+from dc43_service_clients.data_quality.client.interface import (
+    DataQualityServiceClient,
+)
+
+
+def run_allow_draft_contract(
+    spark: SparkSession,
+    *,
+    contract_service: ContractServiceClient,
+    data_products: DataProductServiceClient,
+    dq_service: DataQualityServiceClient,
+) -> None:
+    """Accept a draft contract while recording the override decision."""
+
+    status_strategy = DefaultReadStatusStrategy(
+        allowed_contract_statuses=("active", "draft"),
+        allow_missing_contract_status=False,
+    )
+    orders_df = read_from_data_product(
+        spark,
+        data_product_service=data_products,
+        data_product_input={"data_product": "orders", "port_name": "latest"},
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(
+            dataset_id="orders::valid",
+            dataset_version="latest__valid",
+        ),
+        status_strategy=status_strategy,
+        return_status=False,
+    )
+    customers_df = read_from_data_product(
+        spark,
+        data_product_service=data_products,
+        data_product_input={"data_product": "customers", "port_name": "latest"},
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(dataset_version="2024-01-01"),
+        status_strategy=status_strategy,
+        return_status=False,
+    )
+    enriched_df = orders_df.join(customers_df, "customer_id", "left")
+    boosted_df = (
+        enriched_df.withColumn("amount", F.col("amount") * F.lit(1.1))
+        .withColumn(
+            "customer_segment",
+            F.coalesce(F.col("customer_segment"), F.lit("placeholder")),
+        )
+    )
+
+    violation_strategy = NoOpWriteViolationStrategy(
+        allowed_contract_statuses=("active", "draft"),
+        allow_missing_contract_status=False,
+    )
+    run_version = datetime.now(timezone.utc).isoformat()
+    result = write_with_contract(
+        df=boosted_df,
+        contract_id="orders_enriched",
+        expected_contract_version="==3.0.0",
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        data_product_service=data_products,
+        dataset_locator=StaticDatasetLocator(dataset_version=run_version),
+        violation_strategy=violation_strategy,
+        pipeline_context={"scenario": "contract-draft-override"},
+    )
+    if result.status != "ok":
+        raise RuntimeError(f"Draft override failed: {result.details}")
+                """,
+                "<p>The override widens the allowed contract statuses to include <code>draft</code> and boosts amounts so the draft contract still satisfies the quality rules.</p>",
+            ),
             _section(
                 "When to use it",
                 """
@@ -868,6 +1246,49 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
                       curated slices to consider instead.</li>
                 </ol>
                 """,
+            ),
+            _code_section(
+                "Pipeline example",
+                """
+from pyspark.sql import SparkSession
+from dc43_integrations.spark.io import (
+    DefaultReadStatusStrategy,
+    StaticDatasetLocator,
+    read_from_data_product,
+)
+from dc43_service_clients.contracts.client.interface import ContractServiceClient
+from dc43_service_clients.data_products import DataProductServiceClient
+from dc43_service_clients.data_quality.client.interface import (
+    DataQualityServiceClient,
+)
+
+
+def fail_on_blocked_input(
+    spark: SparkSession,
+    *,
+    contract_service: ContractServiceClient,
+    data_products: DataProductServiceClient,
+    dq_service: DataQualityServiceClient,
+) -> None:
+    """Raise immediately when the latest orders slice is blocked."""
+
+    try:
+        read_from_data_product(
+            spark,
+            data_product_service=data_products,
+            data_product_input={"data_product": "orders", "port_name": "latest"},
+            contract_service=contract_service,
+            data_quality_service=dq_service,
+            dataset_locator=StaticDatasetLocator(dataset_version="latest"),
+            status_strategy=DefaultReadStatusStrategy(),
+            return_status=False,
+        )
+    except ValueError as exc:  # default enforcement rejects the slice
+        raise RuntimeError(
+            "orders latest → 2025-09-28 is blocked – switch to a curated subset",
+        ) from exc
+                """,
+                "<p>The default read status strategy raises when the governance verdict is <code>block</code>, so the job aborts before any downstream processing occurs.</p>",
             ),
             _section(
                 "When to use it",
@@ -996,6 +1417,77 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
                 </ol>
                 """,
             ),
+            _code_section(
+                "Pipeline example",
+                """
+from datetime import datetime, timezone
+from pyspark.sql import SparkSession
+from dc43_integrations.spark.io import (
+    DefaultReadStatusStrategy,
+    StaticDatasetLocator,
+    read_from_data_product,
+    write_with_contract,
+)
+from dc43_service_clients.contracts.client.interface import ContractServiceClient
+from dc43_service_clients.data_products import DataProductServiceClient
+from dc43_service_clients.data_quality.client.interface import (
+    DataQualityServiceClient,
+)
+
+
+def run_prefer_valid_subset(
+    spark: SparkSession,
+    *,
+    contract_service: ContractServiceClient,
+    data_products: DataProductServiceClient,
+    dq_service: DataQualityServiceClient,
+) -> None:
+    """Switch reads to the curated valid slice while running in observe mode."""
+
+    orders_df = read_from_data_product(
+        spark,
+        data_product_service=data_products,
+        data_product_input={"data_product": "orders", "port_name": "latest"},
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(
+            dataset_id="orders::valid",
+            dataset_version="latest__valid",
+        ),
+        status_strategy=DefaultReadStatusStrategy(),
+        return_status=False,
+    )
+    customers_df = read_from_data_product(
+        spark,
+        data_product_service=data_products,
+        data_product_input={"data_product": "customers", "port_name": "latest"},
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(dataset_version="2024-01-01"),
+        status_strategy=DefaultReadStatusStrategy(),
+        return_status=False,
+    )
+    enriched_df = orders_df.join(customers_df, "customer_id", "left")
+
+    run_version = datetime.now(timezone.utc).isoformat()
+    write_with_contract(
+        df=enriched_df,
+        contract_id="orders_enriched",
+        expected_contract_version="==1.1.0",
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        data_product_service=data_products,
+        dataset_locator=StaticDatasetLocator(dataset_version=run_version),
+        enforce=False,  # observe mode – do not raise on warnings
+        pipeline_context={
+            "mode": "observe",
+            "collect_examples": True,
+            "examples_limit": 3,
+        },
+    )
+                """,
+                "<p>Repoint the read locator to <code>orders::valid/latest__valid</code> and run in observe mode so the pipeline records telemetry without blocking downstream tasks.</p>",
+            ),
             _section(
                 "When to use it",
                 """
@@ -1123,6 +1615,78 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
                       verdict along with draft metadata.</li>
                 </ol>
                 """,
+            ),
+            _code_section(
+                "Pipeline example",
+                """
+from datetime import datetime, timezone
+from pyspark.sql import SparkSession, functions as F
+from dc43_integrations.spark.io import (
+    DefaultReadStatusStrategy,
+    StaticDatasetLocator,
+    read_from_data_product,
+    write_with_contract,
+)
+from dc43_service_clients.contracts.client.interface import ContractServiceClient
+from dc43_service_clients.data_products import DataProductServiceClient
+from dc43_service_clients.data_quality.client.interface import (
+    DataQualityServiceClient,
+)
+
+
+def run_valid_subset_violation(
+    spark: SparkSession,
+    *,
+    contract_service: ContractServiceClient,
+    data_products: DataProductServiceClient,
+    dq_service: DataQualityServiceClient,
+) -> None:
+    """Demonstrate that clean inputs can still produce a blocking output."""
+
+    orders_df = read_from_data_product(
+        spark,
+        data_product_service=data_products,
+        data_product_input={"data_product": "orders", "port_name": "latest"},
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(
+            dataset_id="orders::valid",
+            dataset_version="latest__valid",
+        ),
+        status_strategy=DefaultReadStatusStrategy(),
+        return_status=False,
+    )
+    customers_df = read_from_data_product(
+        spark,
+        data_product_service=data_products,
+        data_product_input={"data_product": "customers", "port_name": "latest"},
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(dataset_version="2024-01-01"),
+        status_strategy=DefaultReadStatusStrategy(),
+        return_status=False,
+    )
+    enriched_df = orders_df.join(customers_df, "customer_id", "left")
+    broken_df = enriched_df.withColumn(
+        "amount",
+        F.when(F.col("order_id") == F.lit(1), F.lit(60.0)).otherwise(F.col("amount")),
+    )
+
+    run_version = datetime.now(timezone.utc).isoformat()
+    result = write_with_contract(
+        df=broken_df,
+        contract_id="orders_enriched",
+        expected_contract_version="==1.1.0",
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        data_product_service=data_products,
+        dataset_locator=StaticDatasetLocator(dataset_version=run_version),
+        pipeline_context={"scenario": "read-valid-subset-violation"},
+    )
+    if result.status == "block":
+        raise RuntimeError(f"Post-write validation failed: {result.details}")
+                """,
+                "<p>Even though the pipeline reads <code>orders::valid/latest__valid</code>, lowering one amount to 60 triggers a blocking verdict and drafts <code>orders_enriched:1.2.0</code>.</p>",
             ),
             _section(
                 "When to use it",
@@ -1278,6 +1842,103 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
                 </ol>
                 """,
             ),
+            _code_section(
+                "Pipeline example",
+                """
+from datetime import datetime, timezone
+from pyspark.sql import SparkSession
+from dc43_integrations.spark.io import (
+    DefaultReadStatusStrategy,
+    StaticDatasetLocator,
+    read_from_data_product,
+    read_with_contract,
+    write_with_contract,
+    write_to_data_product,
+)
+from dc43_service_clients.contracts.client.interface import ContractServiceClient
+from dc43_service_clients.data_products import DataProductServiceClient
+from dc43_service_clients.data_quality.client.interface import (
+    DataQualityServiceClient,
+)
+
+
+def run_data_product_roundtrip(
+    spark: SparkSession,
+    *,
+    contract_service: ContractServiceClient,
+    data_products: DataProductServiceClient,
+    dq_service: DataQualityServiceClient,
+) -> None:
+    """Consume a published port, persist a governed stage, and publish a new port."""
+
+    orders_df = read_from_data_product(
+        spark,
+        data_product_service=data_products,
+        data_product_input={
+            "data_product": "dp.orders",
+            "port_name": "orders-latest",
+            "source_data_product": "dp.orders",
+            "source_output_port": "orders-latest",
+        },
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(dataset_version="latest"),
+        status_strategy=DefaultReadStatusStrategy(),
+        return_status=False,
+    )
+    customers_df = read_with_contract(
+        spark,
+        contract_id="customers",
+        expected_contract_version="==1.0.0",
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(dataset_version="2024-01-01"),
+        return_status=False,
+    )
+    enriched_df = orders_df.join(customers_df, "customer_id", "left")
+
+    run_version = datetime.now(timezone.utc).isoformat()
+    stage_result = write_with_contract(
+        df=enriched_df,
+        contract_id="dp.analytics.stage",
+        expected_contract_version="==1.0.0",
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(dataset_version=run_version),
+        pipeline_context={"step": "stage"},
+    )
+    if stage_result.status != "ok":
+        raise RuntimeError(f"Stage validation failed: {stage_result.details}")
+
+    stage_df = read_with_contract(
+        spark,
+        contract_id="dp.analytics.stage",
+        expected_contract_version="==1.0.0",
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(dataset_version=run_version),
+        return_status=False,
+    )
+
+    publish_result = write_to_data_product(
+        df=stage_df,
+        data_product_service=data_products,
+        data_product_output={
+            "data_product": "dp.analytics",
+            "port_name": "orders-enriched",
+        },
+        contract_id="orders_enriched",
+        contract_service=contract_service,
+        expected_contract_version="==1.1.0",
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(dataset_version=run_version),
+        pipeline_context={"step": "publish"},
+    )
+    if publish_result.status != "ok":
+        raise RuntimeError(f"Publish validation failed: {publish_result.details}")
+                """,
+                "<p>The end-to-end flow resolves the upstream data product binding, persists a governed stage contract, then republishes through the analytics data product while checking both validation results.</p>",
+            ),
             _section(
                 "When to use it",
                 """
@@ -1413,6 +2074,104 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
                 </ol>
                 """,
             ),
+            _code_section(
+                "Pipeline example",
+                """
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pyspark.sql import SparkSession
+from dc43_integrations.spark.io import (
+    DefaultReadStatusStrategy,
+    ReadStatusStrategy,
+    StaticDatasetLocator,
+    read_from_data_product,
+    write_with_contract,
+)
+from dc43_service_clients.data_quality import ValidationResult
+from dc43_service_clients.contracts.client.interface import ContractServiceClient
+from dc43_service_clients.data_products import DataProductServiceClient
+from dc43_service_clients.data_quality.client.interface import (
+    DataQualityServiceClient,
+)
+
+
+@dataclass
+class DowngradeBlockingReadStrategy(ReadStatusStrategy):
+    """Custom read strategy that downgrades blocking verdicts to a warning."""
+
+    note: str
+    target_status: str = "warn"
+
+    def apply(self, *, dataframe, status, enforce, context):  # type: ignore[override]
+        if status and status.status == "block":
+            details = dict(status.details)
+            overrides = list(details.get("overrides", []))
+            overrides.append(self.note)
+            details["overrides"] = overrides
+            details["status_before_override"] = status.status
+            return dataframe, ValidationResult(
+                status=self.target_status,
+                reason=status.reason,
+                details=details,
+            )
+        return dataframe, status
+
+
+def run_force_blocked_slice(
+    spark: SparkSession,
+    *,
+    contract_service: ContractServiceClient,
+    data_products: DataProductServiceClient,
+    dq_service: DataQualityServiceClient,
+) -> None:
+    """Force a blocked slice through the pipeline while recording the override."""
+
+    override_strategy = DowngradeBlockingReadStrategy(
+        note="Manual override: forced latest slice (→2025-09-28)",
+        target_status="warn",
+    )
+    orders_df, orders_status = read_from_data_product(
+        spark,
+        data_product_service=data_products,
+        data_product_input={"data_product": "orders", "port_name": "latest"},
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(dataset_version="latest"),
+        status_strategy=override_strategy,
+        return_status=True,
+    )
+    customers_df = read_from_data_product(
+        spark,
+        data_product_service=data_products,
+        data_product_input={"data_product": "customers", "port_name": "latest"},
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(dataset_version="2024-01-01"),
+        status_strategy=DefaultReadStatusStrategy(),
+        return_status=False,
+    )
+    enriched_df = orders_df.join(customers_df, "customer_id", "left")
+
+    run_version = datetime.now(timezone.utc).isoformat()
+    result = write_with_contract(
+        df=enriched_df,
+        contract_id="orders_enriched",
+        expected_contract_version="==1.1.0",
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        data_product_service=data_products,
+        dataset_locator=StaticDatasetLocator(dataset_version=run_version),
+        enforce=False,
+        pipeline_context={
+            "override_note": override_strategy.note,
+            "status_before_override": orders_status.status if orders_status else None,
+        },
+    )
+    if result.status not in {"ok", "warn"}:
+        raise RuntimeError(f"Override run failed: {result.details}")
+                """,
+                "<p>Implement a small read-status strategy that downgrades <code>block</code> to <code>warn</code> while annotating the governance payload so the manual override is fully auditable.</p>",
+            ),
             _section(
                 "When to use it",
                 """
@@ -1546,6 +2305,79 @@ SCENARIOS: Dict[str, Dict[str, Any]] = {
                       for traceability.</li>
                 </ol>
                 """,
+            ),
+            _code_section(
+                "Pipeline example",
+                """
+from datetime import datetime, timezone
+from pyspark.sql import SparkSession
+from dc43_integrations.spark.io import (
+    DefaultReadStatusStrategy,
+    StaticDatasetLocator,
+    read_from_data_product,
+    write_with_contract,
+)
+from dc43_integrations.spark.violation_strategy import SplitWriteViolationStrategy
+from dc43_service_clients.contracts.client.interface import ContractServiceClient
+from dc43_service_clients.data_products import DataProductServiceClient
+from dc43_service_clients.data_quality.client.interface import (
+    DataQualityServiceClient,
+)
+
+
+def run_split_invalid_rows(
+    spark: SparkSession,
+    *,
+    contract_service: ContractServiceClient,
+    data_products: DataProductServiceClient,
+    dq_service: DataQualityServiceClient,
+) -> None:
+    """Write primary, valid, and reject datasets when violations occur."""
+
+    orders_df = read_from_data_product(
+        spark,
+        data_product_service=data_products,
+        data_product_input={"data_product": "orders", "port_name": "latest"},
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(dataset_version="2024-01-01"),
+        status_strategy=DefaultReadStatusStrategy(),
+        return_status=False,
+    )
+    customers_df = read_from_data_product(
+        spark,
+        data_product_service=data_products,
+        data_product_input={"data_product": "customers", "port_name": "latest"},
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        dataset_locator=StaticDatasetLocator(dataset_version="2024-01-01"),
+        status_strategy=DefaultReadStatusStrategy(),
+        return_status=False,
+    )
+    enriched_df = orders_df.join(customers_df, "customer_id", "left")
+
+    strategy = SplitWriteViolationStrategy(
+        include_valid=True,
+        include_reject=True,
+        write_primary_on_violation=True,
+    )
+    run_version = datetime.now(timezone.utc).isoformat()
+    result = write_with_contract(
+        df=enriched_df,
+        contract_id="orders_enriched",
+        expected_contract_version="==1.1.0",
+        contract_service=contract_service,
+        data_quality_service=dq_service,
+        data_product_service=data_products,
+        dataset_locator=StaticDatasetLocator(dataset_version=run_version),
+        violation_strategy=strategy,
+        enforce=False,
+        pipeline_context={"strategy": "split"},
+    )
+    if result.status not in {"ok", "warn"}:
+        raise RuntimeError(f"Split strategy run failed: {result.details}")
+                """,
+                "<p>The split strategy keeps the contracted dataset while emitting <code>::valid</code> and <code>::reject</code> companions so remediation teams can analyse each portion independently.</p>",
             ),
             _section(
                 "When to use it",

--- a/packages/dc43-service-backends/CHANGELOG.md
+++ b/packages/dc43-service-backends/CHANGELOG.md
@@ -20,6 +20,12 @@
 - Added bootstrap helpers (`build_backends`, `build_contract_store`,
   `build_data_product_backend`) that translate the TOML configuration into
   concrete backends for notebooks, services, or tests.
+- Introduced `SQLContractStore` so deployments can persist contracts in
+  relational databases (PostgreSQL, MySQL, SQL Server, SQLite) via SQLAlchemy.
+- Documented SQL-backed deployment guidance and configuration templates covering
+  managed databases on Azure, AWS, and other clouds.
+- Terraform blueprints for Azure Container Apps and AWS Fargate now accept
+  `contract_store_mode = "sql"` to inject DSNs and skip shared storage mounts.
 - Documented and tested Unity Catalog tagging when the governance backend is
   wired to remote contract/data product services, ensuring remote databases such
   as PostgreSQL or Azure Files remain compatible.
@@ -40,3 +46,8 @@
 - Contract and data product store configuration now accept `table` entries and
   `data_product` settings so Unity Catalog tables or alternative storage layers
   can be selected without modifying the service code.
+- Contract store configuration adds `dsn`/`schema` keys plus corresponding
+  environment overrides for SQL deployments.
+- Configuration loaders respect `DC43_CONTRACT_STORE_TYPE`, enabling IaC tools
+  to switch backends without editing TOML files, and the Delta store reuses the
+  SQL serialisation helper to keep schemas aligned.

--- a/packages/dc43-service-backends/README.md
+++ b/packages/dc43-service-backends/README.md
@@ -8,5 +8,5 @@ governance, or quality enforcement backends.
 
 The service backend HTTP application reads its settings from TOML files. Refer
 to [docs/service-backends-configuration.md](../../docs/service-backends-configuration.md)
-for the supported options—including filesystem, Collibra stub, and Collibra HTTP
-contract stores—alongside editable templates.
+for the supported options—including filesystem, SQL, Delta, Collibra stub, and
+Collibra HTTP contract stores—alongside editable templates.

--- a/packages/dc43-service-backends/pyproject.toml
+++ b/packages/dc43-service-backends/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "dc43>=0.16.0",
   "dc43-service-clients>=0.0.3",
   "open-data-contract-standard==3.0.2",
+  "sqlalchemy>=2.0",
 ]
 
 [project.optional-dependencies]
@@ -27,6 +28,7 @@ spark = ["pyspark>=3.4"]
 http = [
   "fastapi>=0.118.0",
 ]
+sql = ["sqlalchemy>=2.0"]
 test = [
   "fastapi>=0.118.0",
 ]

--- a/packages/dc43-service-backends/src/dc43_service_backends/config.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/config.py
@@ -29,6 +29,8 @@ class ContractStoreConfig:
     base_path: Path | None = None
     table: str | None = None
     base_url: str | None = None
+    dsn: str | None = None
+    schema: str | None = None
     token: str | None = None
     timeout: float = 10.0
     contracts_endpoint_template: str | None = None
@@ -204,6 +206,8 @@ def load_config(path: str | os.PathLike[str] | None = None) -> ServiceBackendsCo
     base_path_value = None
     table_value = None
     base_url_value = None
+    dsn_value = None
+    schema_value = None
     store_token_value = None
     timeout_value = 10.0
     endpoint_template = None
@@ -222,6 +226,12 @@ def load_config(path: str | os.PathLike[str] | None = None) -> ServiceBackendsCo
         base_url_raw = store_section.get("base_url")
         if base_url_raw is not None:
             base_url_value = str(base_url_raw).strip() or None
+        dsn_raw = store_section.get("dsn")
+        if dsn_raw is not None:
+            dsn_value = str(dsn_raw).strip() or None
+        schema_raw = store_section.get("schema")
+        if schema_raw is not None:
+            schema_value = str(schema_raw).strip() or None
         token_raw = store_section.get("token")
         if token_raw is not None:
             store_token_value = str(token_raw).strip() or None
@@ -291,6 +301,12 @@ def load_config(path: str | os.PathLike[str] | None = None) -> ServiceBackendsCo
                 if text:
                     link_builder_specs.append(text)
 
+    env_contract_type = os.getenv("DC43_CONTRACT_STORE_TYPE")
+    if env_contract_type:
+        normalised_type = env_contract_type.strip().lower()
+        if normalised_type:
+            store_type = normalised_type
+
     env_root = os.getenv("DC43_CONTRACT_STORE")
     if env_root:
         root_value = _coerce_path(env_root)
@@ -299,6 +315,14 @@ def load_config(path: str | os.PathLike[str] | None = None) -> ServiceBackendsCo
     env_contract_table = os.getenv("DC43_CONTRACT_STORE_TABLE")
     if env_contract_table:
         table_value = env_contract_table.strip() or table_value
+
+    env_contract_dsn = os.getenv("DC43_CONTRACT_STORE_DSN")
+    if env_contract_dsn:
+        dsn_value = env_contract_dsn.strip() or dsn_value
+
+    env_contract_schema = os.getenv("DC43_CONTRACT_STORE_SCHEMA")
+    if env_contract_schema:
+        schema_value = env_contract_schema.strip() or schema_value
 
     env_dp_root = os.getenv("DC43_DATA_PRODUCT_STORE")
     if env_dp_root:
@@ -357,6 +381,8 @@ def load_config(path: str | os.PathLike[str] | None = None) -> ServiceBackendsCo
             base_path=base_path_value,
             table=table_value,
             base_url=base_url_value,
+            dsn=dsn_value,
+            schema=schema_value,
             token=store_token_value,
             timeout=timeout_value,
             contracts_endpoint_template=endpoint_template,

--- a/packages/dc43-service-backends/src/dc43_service_backends/config/default.toml
+++ b/packages/dc43-service-backends/src/dc43_service_backends/config/default.toml
@@ -4,6 +4,10 @@ type = "filesystem"
 # Path to the filesystem contract store. Defaults to a "contracts" directory
 # inside the current working directory when unset.
 root = ""
+# DSN used by the SQL contract store (e.g. postgresql+psycopg://user:pass@host/db).
+dsn = ""
+# Optional schema name when using SQL-backed storage.
+schema = ""
 # Use ``table`` to back the service with a Unity Catalog table instead of a
 # filesystem directory. Requires ``type = "delta"`` and a Spark runtime.
 table = ""

--- a/packages/dc43-service-backends/src/dc43_service_backends/contracts/backend/stores/__init__.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/contracts/backend/stores/__init__.py
@@ -2,6 +2,11 @@
 
 from .filesystem import FSContractStore
 from .delta import DeltaContractStore
+
+try:  # pragma: no cover - optional dependency
+    from .sql import SQLContractStore
+except ModuleNotFoundError:  # pragma: no cover
+    SQLContractStore = None  # type: ignore
 from .collibra import (
     CollibraContractAdapter,
     CollibraContractGateway,
@@ -25,3 +30,6 @@ __all__ = [
     "StubCollibraContractAdapter",
     "StubCollibraContractGateway",
 ]
+
+if SQLContractStore is not None:
+    __all__.append("SQLContractStore")

--- a/packages/dc43-service-backends/src/dc43_service_backends/contracts/backend/stores/_sql_common.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/contracts/backend/stores/_sql_common.py
@@ -1,0 +1,50 @@
+"""Shared helpers for SQL-flavoured contract stores."""
+
+from __future__ import annotations
+
+import json
+from typing import Optional, Tuple, Dict, Any
+
+from dc43.core.odcs import (
+    as_odcs_dict,
+    contract_identity,
+    ensure_version,
+    fingerprint,
+)
+from open_data_contract_standard.model import OpenDataContractStandard  # type: ignore
+
+
+def prepare_contract_row(
+    contract: OpenDataContractStandard,
+) -> Tuple[str, str, Dict[str, Any]]:
+    """Return canonical row payload for persisting ``contract``.
+
+    The helper normalises the ODCS document into the shared column layout used by
+    both the relational SQL and Delta-backed stores. It guarantees ``contract``
+    has a semantic version, extracts a stable fingerprint, and flattens optional
+    description fields so callers can upsert without duplicating serialisation
+    logic.
+    """
+
+    ensure_version(contract)
+    contract_id, version = contract_identity(contract)
+    odcs_dict = as_odcs_dict(contract)
+    json_payload = json.dumps(odcs_dict, separators=(",", ":"))
+    name_value = contract.name or odcs_dict.get("id", "")
+    description_value: Optional[str] = None
+    if contract.description and getattr(contract.description, "usage", None):
+        description_value = str(contract.description.usage)
+
+    payload: Dict[str, Any] = {
+        "contract_id": contract_id,
+        "version": version,
+        "name": name_value,
+        "description": description_value,
+        "json": json_payload,
+        "fingerprint": fingerprint(contract),
+    }
+    return contract_id, version, payload
+
+
+__all__ = ["prepare_contract_row"]
+

--- a/packages/dc43-service-backends/src/dc43_service_backends/contracts/backend/stores/sql.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/contracts/backend/stores/sql.py
@@ -1,0 +1,109 @@
+"""SQL-backed contract store implementation."""
+
+from __future__ import annotations
+
+from typing import List
+import json
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    MetaData,
+    String,
+    Table,
+    Text,
+    and_,
+    create_engine,
+    func,
+    insert,
+    select,
+    update,
+)
+from sqlalchemy.engine import Engine
+
+from ._sql_common import prepare_contract_row
+from .interface import ContractStore
+from dc43.core.odcs import to_model
+from open_data_contract_standard.model import OpenDataContractStandard  # type: ignore
+
+
+class SQLContractStore(ContractStore):
+    """Persist contracts in a relational database using SQLAlchemy Core."""
+
+    def __init__(self, engine: Engine, table_name: str = "contracts", schema: str | None = None):
+        self.engine = engine
+        self.metadata = MetaData(schema=schema)
+        self.table = Table(
+            table_name,
+            self.metadata,
+            Column("contract_id", String(255), primary_key=True, nullable=False),
+            Column("version", String(64), primary_key=True, nullable=False),
+            Column("name", String(255), nullable=False),
+            Column("description", Text),
+            Column("json", Text, nullable=False),
+            Column("fingerprint", String(64), nullable=False),
+            Column("created_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
+        )
+        self.metadata.create_all(self.engine)
+
+    def put(self, contract: OpenDataContractStandard) -> None:
+        """Insert or update a contract document."""
+
+        cid, ver, payload = prepare_contract_row(contract)
+
+        with self.engine.begin() as conn:
+            stmt = select(self.table.c.contract_id).where(
+                and_(
+                    self.table.c.contract_id == cid,
+                    self.table.c.version == ver,
+                )
+            )
+            exists = conn.execute(stmt).first() is not None
+            if exists:
+                conn.execute(
+                    update(self.table)
+                    .where(
+                        and_(
+                            self.table.c.contract_id == cid,
+                            self.table.c.version == ver,
+                        )
+                    )
+                    .values(payload)
+                )
+            else:
+                conn.execute(insert(self.table).values(payload))
+
+    def get(self, contract_id: str, version: str) -> OpenDataContractStandard:
+        """Fetch a contract from the relational table and return it as a model."""
+
+        with self.engine.begin() as conn:
+            stmt = select(self.table.c.json).where(
+                and_(
+                    self.table.c.contract_id == contract_id,
+                    self.table.c.version == version,
+                )
+            )
+            row = conn.execute(stmt).first()
+
+        if not row:
+            raise KeyError(f"Contract {contract_id}:{version} not found")
+
+        return to_model(json.loads(row[0]))
+
+    def list_contracts(self) -> List[str]:
+        with self.engine.begin() as conn:
+            stmt = select(self.table.c.contract_id).distinct().order_by(self.table.c.contract_id)
+            rows = conn.execute(stmt).scalars().all()
+        return list(rows)
+
+    def list_versions(self, contract_id: str) -> List[str]:
+        with self.engine.begin() as conn:
+            stmt = (
+                select(self.table.c.version)
+                .where(self.table.c.contract_id == contract_id)
+                .order_by(self.table.c.version)
+            )
+            rows = conn.execute(stmt).scalars().all()
+        return list(rows)
+
+__all__ = ["SQLContractStore", "create_engine"]

--- a/packages/dc43-service-backends/tests/test_bootstrap.py
+++ b/packages/dc43-service-backends/tests/test_bootstrap.py
@@ -50,6 +50,18 @@ def test_build_contract_store_filesystem(tmp_path: Path) -> None:
     assert isinstance(store, FSContractStore)
 
 
+def test_build_contract_store_sql(tmp_path: Path) -> None:
+    pytest.importorskip("sqlalchemy")
+    dsn = f"sqlite:///{tmp_path / 'contracts.db'}"
+    cfg = ContractStoreConfig(type="sql", dsn=dsn, table="contracts")
+
+    store = build_contract_store(cfg)
+
+    from dc43_service_backends.contracts.backend.stores.sql import SQLContractStore
+
+    assert isinstance(store, SQLContractStore)
+
+
 def test_build_data_product_backend_memory() -> None:
     backend = build_data_product_backend(DataProductStoreConfig(type="memory"))
     assert isinstance(backend, LocalDataProductServiceBackend)

--- a/packages/dc43-service-backends/tests/test_config.py
+++ b/packages/dc43-service-backends/tests/test_config.py
@@ -53,6 +53,19 @@ def test_load_config_env_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     assert config.governance.dataset_contract_link_builders == ()
 
 
+def test_env_overrides_contract_store_type(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_path = tmp_path / "backends.toml"
+    config_path.write_text("", encoding="utf-8")
+
+    monkeypatch.setenv("DC43_SERVICE_BACKENDS_CONFIG", str(config_path))
+    monkeypatch.setenv("DC43_CONTRACT_STORE_TYPE", "SQL")
+    monkeypatch.setenv("DC43_CONTRACT_STORE_DSN", "sqlite:///example.db")
+
+    config = load_config()
+    assert config.contract_store.type == "sql"
+    assert config.contract_store.dsn == "sqlite:///example.db"
+
+
 def test_load_collibra_stub_config(tmp_path: Path) -> None:
     config_path = tmp_path / "backends.toml"
     config_path.write_text(

--- a/packages/dc43-service-backends/tests/test_contract_store_sql.py
+++ b/packages/dc43-service-backends/tests/test_contract_store_sql.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+from open_data_contract_standard.model import Description, OpenDataContractStandard, SchemaObject, SchemaProperty  # type: ignore
+
+from dc43_service_backends.contracts.backend.stores.sql import SQLContractStore
+
+
+def _build_contract(version: str = "1.0.0", description: str = "Orders facts") -> OpenDataContractStandard:
+    return OpenDataContractStandard(
+        version=version,
+        kind="DataContract",
+        apiVersion="3.0.2",
+        id="test.orders",
+        name="Orders",
+        description=Description(usage=description),
+        schema=[
+            SchemaObject(
+                name="orders",
+                properties=[
+                    SchemaProperty(name="order_id", physicalType="bigint", required=True),
+                ],
+            )
+        ],
+    )
+
+
+@pytest.fixture()
+def sql_engine(tmp_path: Path):
+    pytest.importorskip("sqlalchemy")
+    from sqlalchemy import create_engine
+
+    db_path = tmp_path / "contracts.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    yield engine
+    engine.dispose()
+
+
+def test_sql_contract_store_round_trip(sql_engine) -> None:
+    store = SQLContractStore(sql_engine)
+    contract = _build_contract()
+
+    store.put(contract)
+
+    retrieved = store.get("test.orders", "1.0.0")
+    assert retrieved.id == "test.orders"
+    assert retrieved.description
+    assert retrieved.description.usage == "Orders facts"
+
+    contracts = store.list_contracts()
+    assert contracts == ["test.orders"]
+
+    versions = store.list_versions("test.orders")
+    assert versions == ["1.0.0"]
+
+
+def test_sql_contract_store_updates_existing_version(sql_engine) -> None:
+    store = SQLContractStore(sql_engine)
+    original = _build_contract()
+    updated = _build_contract(description="Orders facts v2")
+
+    store.put(original)
+    store.put(updated)
+
+    latest = store.get("test.orders", "1.0.0")
+    assert latest.description
+    assert latest.description.usage == "Orders facts v2"
+
+
+def test_sql_contract_store_serialises_contract(sql_engine) -> None:
+    store = SQLContractStore(sql_engine)
+    contract = _build_contract()
+
+    store.put(contract)
+
+    from sqlalchemy import text
+
+    with sql_engine.begin() as conn:
+        payload = conn.execute(
+            text("SELECT json FROM contracts WHERE contract_id = :cid AND version = :version"),
+            {"cid": "test.orders", "version": "1.0.0"},
+        ).scalar_one()
+
+    decoded = json.loads(payload)
+    assert decoded["id"] == "test.orders"
+    assert decoded["version"] == "1.0.0"


### PR DESCRIPTION
## Summary
- add a shared SQL serialisation helper, expose DC43_CONTRACT_STORE_TYPE, and update SQL/Delta docs to reflect the unified schema
- extend the Azure and AWS Terraform blueprints with a contract_store_mode switch that injects SQL DSNs instead of mounting shared storage
- document the new Terraform options and environment overrides across guides and templates

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68e3535b60a0832e89245d97717f29b4