### PR TITLE
Document dedicated streaming Spark helpers

### DIFF
--- a/docs/component-integration-layer.md
+++ b/docs/component-integration-layer.md
@@ -57,10 +57,12 @@ flows:
 - `read_from_data_product` / `write_to_data_product` resolve contracts directly
   from the data product service when a binding points at an existing port.
 
-All helpers forward to `read_with_contract` / `write_with_contract` under the
-hood so callers can mix and match parameters as needed. Passing both a binding
-and a contract id continues to pin the run to the requested contract while
-recording the port metadata.
+Batch pipelines call into `read_with_contract` / `write_with_contract` while
+streaming jobs reuse the dedicated `read_stream_with_contract` /
+`write_stream_with_contract` entry points. All helpers share the same
+contract-resolution core under the hood so callers can mix and match parameters
+as needed. Passing both a binding and a contract id continues to pin the run to
+the requested contract while recording the port metadata.
 
 Whenever a read or write registers a new input/output port the integration
 layer aborts the pipeline: the service returns a draft ODPS document and dc43

--- a/docs/component-write-violation-strategies.md
+++ b/docs/component-write-violation-strategies.md
@@ -4,7 +4,9 @@ Write violation strategies let integration adapters choose how to persist data w
 Instead of hard-coding a single behaviour, adapters receive a `WriteViolationStrategy` implementation that can split the input
 DataFrame, surface additional datasets, or keep the legacy pass-through behaviour.
 
-The mechanism lives in `dc43_integrations.spark.violation_strategy` and is consumed by `write_with_contract` in the Spark adapter.
+The mechanism lives in `dc43_integrations.spark.violation_strategy` and is
+consumed by both `write_with_contract` and `write_stream_with_contract` in the
+Spark adapter.
 It is runtime-agnostic: other integrations can reuse the protocol to provide the same flexibility in warehouses or streaming engines.
 
 ## Why strategies?
@@ -23,7 +25,9 @@ the right strategy through configuration while reusing the same runtime orchestr
 
 ## Runtime flow
 
-The Spark adapter exposes `write_with_contract`. It first aligns the dataframe to the contract and runs a **preview validation** to
+The Spark adapter exposes `write_with_contract` for batch jobs and
+`write_stream_with_contract` for Structured Streaming. Each helper first aligns
+the dataframe to the contract and runs a **preview validation** to
 decide whether enforcement should block the write and to give strategies enough context to plan additional actions. Once the plan is
 ready the adapter executes the writes and immediately revalidates each persisted subset so that metrics and schema snapshots reflect
 the immutable dataset version produced by the run.

--- a/docs/implementations/integration/spark-dlt.md
+++ b/docs/implementations/integration/spark-dlt.md
@@ -7,7 +7,9 @@ dc43 keeps governance logic decoupled from runtime execution. The integration la
 1. **Resolve runtime identifiers** (paths, tables, dataset versions) and map them to contract ids.
 2. **Validate and coerce data** using helpers from `dc43_integrations.spark.data_quality` while respecting enforcement flags.
 3. **Bridge runtime metrics** to the governance service so it can evaluate observations, record activity, and propose drafts when mismatches occur.
-4. **Expose ergonomic APIs** for pipelines (`read_with_contract`, `write_with_contract`).
+4. **Expose ergonomic APIs** for pipelines (batch: `read_with_contract`,
+   `write_with_contract`; streaming: `read_stream_with_contract`,
+   `write_stream_with_contract`).
 
 ```mermaid
 flowchart TD
@@ -25,7 +27,9 @@ flowchart TD
 
 The canonical implementation lives in [`src/dc43_integrations/spark`](../../packages/dc43-integrations/src/dc43_integrations/spark):
 
-* `io.py` — High-level `read_with_contract` and `write_with_contract` wrappers for Spark DataFrames along with dataset resolution helpers.
+* `io.py` — High-level batch (`read_with_contract`, `write_with_contract`) and
+  streaming (`read_stream_with_contract`, `write_stream_with_contract`)
+  wrappers for Spark DataFrames along with dataset resolution helpers.
 * `dlt.py` — Helpers to apply expectation predicates inside Delta Live Tables pipelines. Expectation SQL is supplied by the
   data-quality service via validation results so that Delta expectations mirror backend verdicts.
 * [`dc43_integrations.spark.data_quality`](../../packages/dc43-integrations/src/dc43_integrations/spark/data_quality.py) — Schema snapshots and metric builders that rely on expectation descriptors supplied by the data-quality service.

--- a/docs/implementations/spark-streaming.md
+++ b/docs/implementations/spark-streaming.md
@@ -1,0 +1,139 @@
+# Spark streaming integration
+
+The Spark helpers in `dc43_integrations` can build Structured Streaming
+pipelines that continue to enforce Open Data Contracts and coordinate with the
+data-quality and governance services.  Batch APIs remain unchanged while
+dedicated helpers such as `read_stream_with_contract`,
+`read_stream_from_contract`, and `write_stream_with_contract` route through
+`SparkSession.readStream` / `DataFrame.writeStream` without threading a flag
+through the batch code paths.
+
+Streaming IO still performs contract validation and posts schema observations to
+governance.  When a streaming write is executed the helper also launches a
+dedicated observation writer that materialises the contract expectations for
+each micro-batch via `foreachBatch`, forwarding the resulting metrics back to
+the attached data-quality client and updating the returned validation payload.
+Reads remain schema-only until a sink materialises the stream, but write
+validations now produce live metrics without blocking the ingestion job.  The
+validation result contains every `streaming_query` started by the helpers so
+callers can manage their lifecycle.  Read and write validations also expose the
+`dataset_id` and `dataset_version` they submit to governance so micro-batch
+monitors can query the data-quality service for the latest verdict or trigger
+asynchronous metric computation when a streaming snapshot needs to be
+inspected.
+
+Observation writers are single-use helpers and can be paired with a
+`StreamingInterventionStrategy` to take action after repeated issues: the
+strategy receives the validation result for every batch and can decide to block
+the pipeline, surface warnings, or trigger alternative routing (for example by
+switching over to a rejection sink).  The default implementation never blocks,
+preserving the previous behaviour when no strategy is supplied.
+
+```python
+from pyspark.sql import SparkSession
+from dc43_service_backends.contracts.backend.stores import FSContractStore
+from dc43_service_clients.contracts import LocalContractServiceClient
+from dc43_service_clients.data_quality import ObservationPayload, ValidationResult
+from dc43_integrations.spark.io import (
+    StaticDatasetLocator,
+    StreamingInterventionContext,
+    StreamingInterventionStrategy,
+    read_stream_with_contract,
+    write_stream_with_contract,
+)
+from open_data_contract_standard.model import (
+    Description,
+    OpenDataContractStandard,
+    SchemaObject,
+    SchemaProperty,
+    Server,
+)
+
+
+class NoOpDQService:
+    def describe_expectations(self, *, contract):
+        return []
+
+    def evaluate(self, *, contract, payload: ObservationPayload) -> ValidationResult:
+        return ValidationResult(ok=True, metrics=payload.metrics, schema=payload.schema)
+
+
+class BlockAfterFailures(StreamingInterventionStrategy):
+    def __init__(self, *, max_failures: int = 3) -> None:
+        self._failures = 0
+        self._max_failures = max_failures
+
+    def decide(self, context: StreamingInterventionContext):
+        if not context.validation.ok:
+            self._failures += 1
+            if self._failures >= self._max_failures:
+                return (
+                    f"halt after {self._failures} failed batches for "
+                    f"{context.dataset_id}@{context.dataset_version}"
+                )
+        return None
+
+
+spark = (
+    SparkSession.builder.master("local[2]")
+    .appName("dc43-stream-demo")
+    .config("spark.ui.enabled", "false")
+    .getOrCreate()
+)
+
+contract = OpenDataContractStandard(
+    version="0.1.0",
+    kind="DataContract",
+    apiVersion="3.0.2",
+    id="demo.rate_stream",
+    name="Rate stream",
+    description=Description(usage="Streaming rate source"),
+    schema=[
+        SchemaObject(
+            name="rate",
+            properties=[
+                SchemaProperty(name="timestamp", physicalType="timestamp", required=True),
+                SchemaProperty(name="value", physicalType="bigint", required=True),
+            ],
+        )
+    ],
+    servers=[Server(server="local", type="stream", format="rate")],
+)
+
+store = FSContractStore("/tmp/contracts")
+store.put(contract)
+contract_service = LocalContractServiceClient(store)
+dq_service = NoOpDQService()
+
+stream_df, read_status = read_stream_with_contract(
+    spark=spark,
+    contract_id=contract.id,
+    contract_service=contract_service,
+    expected_contract_version=f"=={contract.version}",
+    data_quality_service=dq_service,
+    dataset_locator=StaticDatasetLocator(format="rate"),
+    options={"rowsPerSecond": "5"},
+)
+
+write_result = write_stream_with_contract(
+    df=stream_df,
+    contract_id=contract.id,
+    contract_service=contract_service,
+    expected_contract_version=f"=={contract.version}",
+    data_quality_service=dq_service,
+    dataset_locator=StaticDatasetLocator(format="memory"),
+    format="memory",
+    options={"queryName": "rate_events"},
+    streaming_intervention_strategy=BlockAfterFailures(max_failures=2),
+)
+
+for query in write_result.details["streaming_queries"]:
+    query.processAllAvailable()
+    query.stop()
+```
+
+Data-product bindings participate in the same streaming workflow: registering a
+streaming port via `read_stream_from_data_product`, `read_stream_with_contract`,
+or the streaming `write_*` counterparts will validate the contract, update the
+governance catalogue, and return any active `StreamingQuery` handles through the
+validation payload.

--- a/packages/dc43-integrations/CHANGELOG.md
+++ b/packages/dc43-integrations/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 ### Added
+- Added explicit streaming read/write helpers (``read_stream_with_contract``,
+  ``read_stream_from_contract``, ``read_stream_from_data_product``,
+  ``write_stream_with_contract``, and ``write_stream_to_data_product``) so
+  Structured Streaming jobs can enforce contracts via
+  ``readStream``/``writeStream`` while still invoking the data-quality service
+  and governance catalogue (metrics are deferred but schema observations
+  continue to flow). Documentation now demonstrates capturing the resulting
+  ``StreamingQuery`` handles and the integration tests cover both read and
+  write pipelines.
+- Streaming validations now surface the ``dataset_id`` and ``dataset_version``
+  submitted to governance so micro-batch monitors can inspect the active
+  snapshot and request asynchronous metric computation when necessary.
+- Streaming writes launch an auxiliary ``foreachBatch`` metrics collector so
+  contract expectations compute Spark metrics per micro-batch, feed the
+  data-quality service, and update the returned validation payloads while the
+  primary sink continues to run.
+- Streaming writes now rely on a dedicated ``StreamingObservationWriter`` that
+  avoids shared-state locking, exposes optional ``StreamingInterventionStrategy``
+  hooks to block or reroute pipelines after repeated issues, and ships
+  convenience wrappers (``read_stream_with_contract`` /
+  ``write_stream_with_contract``) to separate batch and streaming flows in
+  caller code.
 - Enforced Open Data Contract status guardrails in the Spark read/write helpers with
   configurable policies that default to rejecting non-active contracts and expose
   overrides through the existing read and write strategies.

--- a/packages/dc43-integrations/src/dc43_integrations/spark/data_quality.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/data_quality.py
@@ -188,6 +188,7 @@ def build_metrics_payload(
     validation: ValidationResult | None = None,
     include_schema: bool = True,
     expectations: ExpectationPlan | None = None,
+    collect_metrics: bool = True,
 ) -> Tuple[Dict[str, Any], Dict[str, Dict[str, Any]], bool]:
     """Return ``(metrics, schema, reused)`` suitable for governance submission."""
 
@@ -201,7 +202,7 @@ def build_metrics_payload(
         if isinstance(details_plan, Iterable):
             plan = [item for item in details_plan if isinstance(item, Mapping)]
 
-    if not metrics:
+    if collect_metrics and not metrics:
         metrics = compute_metrics(df, contract, expectations=plan)
     if include_schema and not schema:
         schema = schema_snapshot(df)

--- a/packages/dc43-integrations/tests/test_spark_streaming.py
+++ b/packages/dc43-integrations/tests/test_spark_streaming.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+from pathlib import Path
+import time
+
+import pytest
+from pyspark.sql.utils import StreamingQueryException
+
+from open_data_contract_standard.model import (  # type: ignore
+    Description,
+    OpenDataContractStandard,
+    SchemaObject,
+    SchemaProperty,
+    Server,
+)
+
+from dc43_service_backends.contracts.backend.stores import FSContractStore
+from dc43_service_clients.contracts import LocalContractServiceClient
+from dc43_service_clients.data_quality import ObservationPayload, ValidationResult
+from dc43_integrations.spark.io import (
+    StaticDatasetLocator,
+    StreamingInterventionContext,
+    StreamingInterventionError,
+    StreamingInterventionStrategy,
+    read_from_contract,
+    read_stream_with_contract,
+    write_stream_with_contract,
+)
+
+
+class RecordingDQService:
+    """Data quality stub that records evaluation calls."""
+
+    def __init__(self) -> None:
+        self.describe_contracts: list[OpenDataContractStandard] = []
+        self.payloads: list[ObservationPayload] = []
+
+    def describe_expectations(self, *, contract: OpenDataContractStandard):  # type: ignore[override]
+        self.describe_contracts.append(contract)
+        return []
+
+    def evaluate(self, *, contract: OpenDataContractStandard, payload):  # type: ignore[override]
+        self.payloads.append(payload)
+        return ValidationResult(ok=True, errors=[], warnings=[], metrics=payload.metrics)
+
+
+class ControlledDQService(RecordingDQService):
+    """DQ stub that flips to failures after a configurable number of calls."""
+
+    def __init__(self, *, fail_after: int) -> None:
+        super().__init__()
+        self._fail_after = fail_after
+        self._calls = 0
+
+    def evaluate(self, *, contract: OpenDataContractStandard, payload):  # type: ignore[override]
+        self.payloads.append(payload)
+        self._calls += 1
+        if self._calls >= self._fail_after:
+            return ValidationResult(
+                ok=False,
+                errors=[f"failed batch {self._calls}"],
+                warnings=[],
+                metrics=payload.metrics,
+            )
+        return ValidationResult(ok=True, errors=[], warnings=[], metrics=payload.metrics)
+
+
+class RecordingGovernanceService:
+    """Governance stub that records dataset evaluations."""
+
+    class Assessment:
+        def __init__(self, status: ValidationResult) -> None:
+            self.status = status
+            self.draft = False
+
+    def __init__(self) -> None:
+        self.evaluate_calls: list[dict[str, object]] = []
+        self.review_calls: list[dict[str, object]] = []
+        self.link_calls: list[dict[str, object]] = []
+
+    def evaluate_dataset(
+        self,
+        *,
+        contract_id: str,
+        contract_version: str,
+        dataset_id: str,
+        dataset_version: str,
+        validation: ValidationResult,
+        observations,
+        pipeline_context,
+        operation: str,
+    ) -> "RecordingGovernanceService.Assessment":  # type: ignore[override]
+        payload = observations() if callable(observations) else observations
+        self.evaluate_calls.append(
+            {
+                "contract_id": contract_id,
+                "contract_version": contract_version,
+                "dataset_id": dataset_id,
+                "dataset_version": dataset_version,
+                "validation": validation,
+                "payload": payload,
+                "operation": operation,
+            }
+        )
+        return RecordingGovernanceService.Assessment(
+            ValidationResult(ok=True, status="ok")
+        )
+
+    def review_validation_outcome(self, **kwargs):  # type: ignore[override]
+        self.review_calls.append(kwargs)
+        return None
+
+    def link_dataset_contract(self, **kwargs) -> None:  # type: ignore[override]
+        self.link_calls.append(kwargs)
+
+
+def _stream_contract(tmp_path: Path) -> tuple[OpenDataContractStandard, LocalContractServiceClient]:
+    contract = OpenDataContractStandard(
+        version="0.1.0",
+        kind="DataContract",
+        apiVersion="3.0.2",
+        id="demo.rate_stream",
+        name="Rate stream",
+        description=Description(usage="Streaming rate source"),
+        schema=[
+            SchemaObject(
+                name="rate",
+                properties=[
+                    SchemaProperty(name="timestamp", physicalType="timestamp", required=True),
+                    SchemaProperty(name="value", physicalType="bigint", required=True),
+                ],
+            )
+        ],
+        servers=[Server(server="local", type="stream", format="rate")],
+    )
+    store = FSContractStore(str(tmp_path / "contracts"))
+    store.put(contract)
+    return contract, LocalContractServiceClient(store)
+
+
+def test_streaming_read_invokes_dq_without_metrics(spark, tmp_path: Path) -> None:
+    contract, service = _stream_contract(tmp_path)
+    dq = RecordingDQService()
+    locator = StaticDatasetLocator(format="rate")
+
+    df, status = read_stream_with_contract(
+        spark=spark,
+        contract_id=contract.id,
+        contract_service=service,
+        expected_contract_version=f"=={contract.version}",
+        data_quality_service=dq,
+        dataset_locator=locator,
+        options={"rowsPerSecond": "1"},
+    )
+
+    assert df.isStreaming
+    assert status is None
+    assert df.sparkSession is spark
+    assert df.columns == ["timestamp", "value"]
+    assert len(dq.describe_contracts) == 1
+    assert len(dq.payloads) == 1
+    payload = dq.payloads[0]
+    assert payload.metrics == {}
+    assert set(payload.schema) == {"timestamp", "value"}
+    assert payload.schema["timestamp"]["odcs_type"] == "timestamp"
+    assert payload.schema["value"]["odcs_type"] == "bigint"
+
+
+def test_streaming_read_surfaces_dataset_version(spark, tmp_path: Path) -> None:
+    contract, service = _stream_contract(tmp_path)
+    dq = RecordingDQService()
+    governance = RecordingGovernanceService()
+    locator = StaticDatasetLocator(format="rate")
+
+    df, status = read_stream_with_contract(
+        spark=spark,
+        contract_id=contract.id,
+        contract_service=service,
+        expected_contract_version=f"=={contract.version}",
+        data_quality_service=dq,
+        governance_service=governance,
+        dataset_locator=locator,
+        options={"rowsPerSecond": "1"},
+    )
+
+    assert df.isStreaming
+    assert status is not None
+    details = status.details
+    assert details["dataset_id"] == contract.id
+    assert details["dataset_version"]
+    assert details["dataset_version"] != "unknown"
+    assert governance.evaluate_calls
+    call = governance.evaluate_calls[0]
+    assert call["dataset_version"] == details["dataset_version"]
+    validation = call["validation"]
+    assert isinstance(validation, ValidationResult)
+    assert validation.details.get("dataset_version") == details["dataset_version"]
+
+
+def test_streaming_write_returns_query_and_validation(spark, tmp_path: Path) -> None:
+    contract = OpenDataContractStandard(
+        version="0.1.0",
+        kind="DataContract",
+        apiVersion="3.0.2",
+        id="demo.rate_sink",
+        name="Rate sink",
+        description=Description(usage="Streaming rate sink"),
+        schema=[
+            SchemaObject(
+                name="rate",
+                properties=[
+                    SchemaProperty(name="timestamp", physicalType="timestamp", required=True),
+                    SchemaProperty(name="value", physicalType="bigint", required=True),
+                ],
+            )
+        ],
+        servers=[Server(server="memory", type="stream", format="memory")],
+    )
+    store = FSContractStore(str(tmp_path / "contracts"))
+    store.put(contract)
+    service = LocalContractServiceClient(store)
+    dq = RecordingDQService()
+    locator = StaticDatasetLocator(format="memory")
+    governance = RecordingGovernanceService()
+
+    df = (
+        spark.readStream.format("rate")
+        .options(rowsPerSecond="5", numPartitions="1")
+        .load()
+    )
+
+    result = write_stream_with_contract(
+        df=df,
+        contract_id=contract.id,
+        contract_service=service,
+        expected_contract_version=f"=={contract.version}",
+        data_quality_service=dq,
+        dataset_locator=locator,
+        format="memory",
+        options={"queryName": "stream_sink"},
+        governance_service=governance,
+    )
+
+    assert result.ok
+    assert len(dq.describe_contracts) == 1
+    assert len(dq.payloads) >= 1
+    queries = result.details.get("streaming_queries") or []
+    assert len(queries) == 2
+    for handle in queries:
+        handle.processAllAvailable()
+    for handle in queries:
+        handle.stop()
+
+    assert len(dq.payloads) >= 2
+    batch_payload = dq.payloads[-1]
+    assert batch_payload.metrics
+    assert batch_payload.metrics.get("row_count", 0) > 0
+
+    assert result.details.get("dataset_id") == contract.id
+    assert result.details.get("dataset_version")
+    assert result.details.get("dataset_version") != "unknown"
+    streaming_metrics = result.details.get("streaming_metrics") or {}
+    assert streaming_metrics.get("row_count", 0) > 0
+    assert governance.evaluate_calls
+    write_call = governance.evaluate_calls[0]
+    assert write_call["dataset_version"] == result.details["dataset_version"]
+
+
+def test_streaming_intervention_blocks_after_failure(spark, tmp_path: Path) -> None:
+    contract = OpenDataContractStandard(
+        version="0.1.0",
+        kind="DataContract",
+        apiVersion="3.0.2",
+        id="demo.intervention_sink",
+        name="Intervention sink",
+        description=Description(usage="Streaming intervention"),
+        schema=[
+            SchemaObject(
+                name="rate",
+                properties=[
+                    SchemaProperty(name="timestamp", physicalType="timestamp", required=True),
+                    SchemaProperty(name="value", physicalType="bigint", required=True),
+                ],
+            )
+        ],
+        servers=[Server(server="memory", type="stream", format="memory")],
+    )
+    store = FSContractStore(str(tmp_path / "contracts"))
+    store.put(contract)
+    service = LocalContractServiceClient(store)
+    dq = ControlledDQService(fail_after=3)
+    locator = StaticDatasetLocator(format="memory")
+    governance = RecordingGovernanceService()
+
+    df = (
+        spark.readStream.format("rate")
+        .options(rowsPerSecond="5", numPartitions="1")
+        .load()
+    )
+
+    class BlockOnFailure(StreamingInterventionStrategy):
+        def decide(self, context: StreamingInterventionContext):
+            if not context.validation.ok:
+                return f"blocked batch {context.batch_id}"
+            return None
+
+    result = write_stream_with_contract(
+        df=df,
+        contract_id=contract.id,
+        contract_service=service,
+        expected_contract_version=f"=={contract.version}",
+        data_quality_service=dq,
+        dataset_locator=locator,
+        format="memory",
+        options={"queryName": "intervention_sink"},
+        governance_service=governance,
+        enforce=False,
+        streaming_intervention_strategy=BlockOnFailure(),
+    )
+
+    queries = result.details.get("streaming_queries") or []
+    assert len(queries) == 2
+    metrics_query = next(q for q in queries if "dc43_metrics" in (q.name or ""))
+    sink_query = next(q for q in queries if q is not metrics_query)
+
+    sink_query.processAllAvailable()
+    reason: str | None = None
+    for _ in range(5):
+        try:
+            metrics_query.processAllAvailable()
+        except StreamingQueryException:
+            pass
+        captured = result.details.get("streaming_intervention_reason")
+        if isinstance(captured, str):
+            reason = captured
+            break
+        time.sleep(0.2)
+    assert isinstance(reason, str)
+    assert "blocked batch" in reason
+
+    for handle in queries:
+        try:
+            handle.stop()
+        except Exception:
+            pass
+
+    assert len(dq.payloads) >= 3
+    assert result.details.get("streaming_metrics")


### PR DESCRIPTION
## Summary
- document that data product adapters expose dedicated batch and streaming helpers in the integration layer overview
- clarify that write violation strategies apply to both batch and streaming Spark helpers
- update the Spark & DLT adapter guide to reference the new read/write streaming entry points alongside the batch APIs

## Testing
- pytest -q packages/dc43-integrations/tests/test_spark_streaming.py

------
https://chatgpt.com/codex/tasks/task_b_68e497c6f710832ea44f518e2c0f37a1