### PR TITLE
Fix missing dataset versions for streaming rejects in demo

### DIFF
--- a/packages/dc43-demo-app/src/dc43_demo_app/retail_demo/timeline.py
+++ b/packages/dc43-demo-app/src/dc43_demo_app/retail_demo/timeline.py
@@ -119,6 +119,7 @@ def _quality_reject_sample(run: RetailDemoRun) -> dict[str, Any]:
     return {
         "dataset": "retail_sales_fact::reject",
         "contract_version": dataset_version,
+        "dataset_version": dataset_version,
         "valid_rows": valid_rows,
         "reject_rows": reject_rows,
         "valid_sample": valid_sample,

--- a/packages/dc43-demo-app/src/dc43_demo_app/server.py
+++ b/packages/dc43-demo-app/src/dc43_demo_app/server.py
@@ -39,7 +39,7 @@ from .retail_demo import (
     run_retail_demo,
     simulate_retail_timeline,
 )
-from .streaming import run_streaming_scenario
+from . import streaming as streaming_demo
 
 CATEGORY_LABELS = {
     "contract": "Contract-focused pipelines",
@@ -995,7 +995,7 @@ async def run_pipeline_endpoint(scenario: str = Form(...)) -> HTMLResponse:
             except (TypeError, ValueError):
                 seconds_int = 5
             dataset_name, new_version = await asyncio.to_thread(
-                run_streaming_scenario,
+                streaming_demo.run_streaming_scenario,
                 scenario,
                 seconds=seconds_int,
                 run_type=params_cfg.get("run_type", "observe"),
@@ -1075,7 +1075,7 @@ async def run_streaming_endpoint(scenario: str = Form(...)) -> JSONResponse:
     async def _runner() -> None:
         try:
             dataset_name, dataset_version = await asyncio.to_thread(
-                run_streaming_scenario,
+                streaming_demo.run_streaming_scenario,
                 scenario,
                 seconds=seconds,
                 run_type=params_cfg.get("run_type", "observe"),

--- a/packages/dc43-demo-app/src/dc43_demo_app/streaming.py
+++ b/packages/dc43-demo-app/src/dc43_demo_app/streaming.py
@@ -837,6 +837,7 @@ def _scenario_dq_rejects(
         reject_result.details, queries=reject_queries
     )
     reject_details.setdefault("dataset_id", _REJECT_CONTRACT)
+    reject_details.setdefault("dataset_version", dataset_version)
     batches: List[Mapping[str, Any]] = []
     candidate_batches = details.get("streaming_batches")
     if isinstance(candidate_batches, list):


### PR DESCRIPTION
## Summary
- surface the dataset version in the retail reject timeline sample metadata
- retain the recorded version for streaming reject details and reference the streaming helper via the module

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68e624f910ac832ebbb8443a73859482