### PR TITLE
Filter streaming metric warnings from demo records

### DIFF
--- a/packages/dc43-demo-app/src/dc43_demo_app/streaming.py
+++ b/packages/dc43-demo-app/src/dc43_demo_app/streaming.py
@@ -296,7 +296,7 @@ def _serialise_streaming_details(
 ) -> Dict[str, Any]:
     """Return a shallow copy of ``details`` with serialisable streaming metadata."""
 
-    payload: Dict[str, Any] = dict(details or {})
+    payload: Dict[str, Any] = _sanitize_validation_details(details)
     metadata: List[Mapping[str, Any]] = []
     handles = list(queries or [])
     if not handles:
@@ -364,7 +364,12 @@ def _normalise_status(validation: Optional[ValidationResult]) -> str:
         return "warning"
     if validation.errors:
         return "error"
-    if validation.warnings:
+    warnings = [
+        warning
+        for warning in validation.warnings
+        if not _is_metric_warning(warning)
+    ]
+    if warnings:
         return "warning"
     return "ok"
 


### PR DESCRIPTION
## Summary
- sanitize streaming validation payloads before adding streaming metadata to remove noisy missing-metric warnings
- treat metric-only warnings as non-blocking when normalising streaming scenario record status so healthy runs stay "ok"

## Testing
- pytest tests/test_streaming_demo.py::test_streaming_scenarios_record_dataset_runs -q *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_b_68e7d0603260832ea0b7deaa02450a7a