### PR TITLE
Relax dc43-integrations test extra dependency

### DIFF
--- a/packages/dc43-integrations/CHANGELOG.md
+++ b/packages/dc43-integrations/CHANGELOG.md
@@ -53,6 +53,9 @@
   demo application now hosts the streaming walkthrough.
 
 ### Fixed
+- Relaxed the ``test`` extra's ``dc43-service-backends`` requirement so CI can
+  install the published backend package instead of failing while waiting for the
+  latest release to propagate.
 - Installing the ``test`` extra now pulls in ``dc43-service-backends`` with its
   SQL dependencies and ``httpx`` so the integration suite runs without tweaking
   import guards.

--- a/packages/dc43-integrations/pyproject.toml
+++ b/packages/dc43-integrations/pyproject.toml
@@ -26,7 +26,7 @@ spark = [
   "pyspark>=3.4",
 ]
 test = [
-  "dc43-service-backends[sql]>=0.18.0.0",
+  "dc43-service-backends[sql]>=0.17.0.0",
   "httpx>=0.24",
 ]
 


### PR DESCRIPTION
## Summary
- relax the dc43-integrations test extra dependency to accept the published dc43-service-backends build
- document the installation fix in the package changelog

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68ec04a462e8832e92d11232ae1a1aab