### PR TITLE
Align integrations test extra with backend release

### DIFF
--- a/packages/dc43-integrations/CHANGELOG.md
+++ b/packages/dc43-integrations/CHANGELOG.md
@@ -53,9 +53,9 @@
   demo application now hosts the streaming walkthrough.
 
 ### Fixed
-- Relaxed the ``test`` extra's ``dc43-service-backends`` requirement so CI can
-  install the published backend package instead of failing while waiting for the
-  latest release to propagate.
+- Tightened the ``test`` extra's ``dc43-service-backends`` requirement to
+  ``>=0.18.0.0`` so dependency resolution stays aligned with the bundled
+  backend package and avoids downgrading to older PyPI releases during CI.
 - Installing the ``test`` extra now pulls in ``dc43-service-backends`` with its
   SQL dependencies and ``httpx`` so the integration suite runs without tweaking
   import guards.

--- a/packages/dc43-integrations/pyproject.toml
+++ b/packages/dc43-integrations/pyproject.toml
@@ -26,7 +26,7 @@ spark = [
   "pyspark>=3.4",
 ]
 test = [
-  "dc43-service-backends[sql]>=0.17.0.0",
+  "dc43-service-backends[sql]>=0.18.0.0",
   "httpx>=0.24",
 ]
 


### PR DESCRIPTION
## Summary
- require dc43-service-backends[sql] 0.18.0.0 or newer for the integrations test extra to avoid resolver downgrades
- document the tightened constraint in the dc43-integrations changelog

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68ec0703e50c832e93746eeef48f9385