### PR TITLE
Add DLT pipeline mode and regression tests

### DIFF
--- a/packages/dc43-demo-app/src/dc43_demo_app/dlt_pipeline.py
+++ b/packages/dc43-demo-app/src/dc43_demo_app/dlt_pipeline.py
@@ -1,0 +1,375 @@
+"""Utilities for running the demo pipeline as a Delta Live Tables job."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from importlib import import_module
+import inspect
+from pathlib import Path
+from typing import Any, Mapping
+
+from . import contracts_api as contracts_server
+from . import pipeline as batch_pipeline
+from .contracts_records import DatasetRecord
+
+
+def _timestamp_slug(moment: datetime) -> str:
+    """Delegate to the batch pipeline timestamp helper."""
+
+    return batch_pipeline._timestamp_slug(moment)  # type: ignore[attr-defined]
+
+
+def _next_version(existing: list[str]) -> str:
+    """Return a fresh dataset version identifier."""
+
+    return batch_pipeline._next_version(existing)  # type: ignore[attr-defined]
+
+
+def _resolve_output_path(contract: Any | None, dataset: str, version: str) -> Path:
+    """Resolve the filesystem destination for ``dataset`` and ``version``."""
+
+    return batch_pipeline._resolve_output_path(  # type: ignore[attr-defined]
+        contract,
+        dataset,
+        version,
+    )
+
+
+def _load_contract_table_module() -> Any:
+    """Import the integration module providing the contract table DLT helper."""
+
+    try:
+        return import_module("dc43_integrations.spark.dlt.contract_table")
+    except ModuleNotFoundError as exc:  # pragma: no cover - surfaced to callers
+        raise RuntimeError(
+            "The Delta Live Tables helpers are not installed. "
+            "Install dc43-integrations with DLT support to run this scenario."
+        ) from exc
+
+
+def _build_contract_table_pipeline(module: Any, config: Mapping[str, Any] | None) -> Any:
+    """Return the callable used to populate the DLT harness."""
+
+    pipeline_override = (config or {}).get("pipeline") if isinstance(config, Mapping) else None
+    pipeline_args = (config or {}).get("pipeline_args", {}) if isinstance(config, Mapping) else {}
+
+    if callable(pipeline_override):
+        return pipeline_override
+    if isinstance(pipeline_override, str):
+        candidate = getattr(module, pipeline_override, None)
+        if callable(candidate):
+            return candidate(**pipeline_args)
+        if candidate is not None:
+            return candidate
+
+    builder = getattr(module, "build_pipeline", None)
+    if callable(builder):
+        return builder(**pipeline_args)
+
+    pipeline_attr = getattr(module, "CONTRACT_TABLE_PIPELINE", None)
+    if pipeline_attr is not None:
+        return pipeline_attr
+
+    pipeline_callable = getattr(module, "pipeline", None)
+    if callable(pipeline_callable):
+        return pipeline_callable
+
+    raise RuntimeError("Contract table pipeline entry point not found in integration module")
+
+
+def _call_with_supported_kwargs(func: Any, *, kwargs: Mapping[str, Any]) -> Any:
+    """Invoke ``func`` filtering keyword arguments the callable understands."""
+
+    signature = inspect.signature(func)
+    accepts_var_kwargs = any(
+        param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values()
+    )
+    if accepts_var_kwargs:
+        return func(**kwargs)
+
+    supported = {
+        name
+        for name, param in signature.parameters.items()
+        if param.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+    }
+    filtered = {key: value for key, value in kwargs.items() if key in supported}
+    return func(**filtered)
+
+
+def _summarise_violations(details: Mapping[str, Any]) -> int:
+    """Return a best-effort violation count from ``details``."""
+
+    total = 0
+    if not isinstance(details, Mapping):
+        return 0
+
+    direct = details.get("violations")
+    if isinstance(direct, (int, float)):
+        total += int(direct)
+
+    metrics = details.get("metrics")
+    if isinstance(metrics, Mapping):
+        for key, value in metrics.items():
+            if not isinstance(value, (int, float)):
+                continue
+            if key.startswith("violations"):
+                total += int(value)
+
+    failed = details.get("failed_expectations")
+    if isinstance(failed, Mapping):
+        for info in failed.values():
+            if isinstance(info, Mapping):
+                count = info.get("count")
+                if isinstance(count, (int, float)):
+                    total += int(count)
+
+    errors = details.get("errors")
+    if isinstance(errors, list):
+        total += len(errors)
+
+    return total
+
+
+def _status_severity(value: str | None) -> int:
+    """Normalise a textual status to a severity bucket."""
+
+    if not value:
+        return 0
+    text = value.lower()
+    if text in {"ok", "success", "passed"}:
+        return 0
+    if text in {"warn", "warning"}:
+        return 1
+    if text in {"block", "error", "fail", "invalid"}:
+        return 2
+    return 1
+
+
+def _ensure_registered(
+    contract: Any | None,
+    dataset: str,
+    version: str,
+    output_details: Mapping[str, Any],
+) -> None:
+    """Register the dataset version along with any auxiliary outputs."""
+
+    output_path = output_details.get("path") if isinstance(output_details, Mapping) else None
+    if isinstance(output_path, str):
+        target = Path(output_path)
+    else:
+        target = _resolve_output_path(contract, dataset, version)
+    target.mkdir(parents=True, exist_ok=True)
+    contracts_server.register_dataset_version(dataset, version, target)
+    try:
+        contracts_server.set_active_version(dataset, version)
+    except FileNotFoundError:
+        pass
+
+    auxiliaries = output_details.get("auxiliary_datasets") if isinstance(output_details, Mapping) else None
+    if isinstance(auxiliaries, list):
+        for aux in auxiliaries:
+            if not isinstance(aux, Mapping):
+                continue
+            aux_dataset = aux.get("dataset")
+            aux_path = aux.get("path")
+            if not isinstance(aux_dataset, str) or not isinstance(aux_path, str):
+                continue
+            aux_target = Path(aux_path)
+            aux_target.mkdir(parents=True, exist_ok=True)
+            try:
+                contracts_server.register_dataset_version(aux_dataset, version, aux_target)
+                contracts_server.set_active_version(aux_dataset, version)
+            except FileNotFoundError:
+                continue
+
+    contracts_server.refresh_dataset_aliases(dataset)
+
+
+def run_dlt_pipeline(
+    contract_id: str | None,
+    contract_version: str | None,
+    dataset_name: str | None,
+    dataset_version: str | None,
+    run_type: str,
+    *,
+    scenario_key: str | None = None,
+    dlt_config: Mapping[str, Any] | None = None,
+) -> tuple[str, str]:
+    """Execute the contract-table DLT demo pipeline via the local harness."""
+
+    module = _load_contract_table_module()
+    harness_cls = getattr(module, "LocalDLTHarness", None)
+    if harness_cls is None:
+        raise RuntimeError("LocalDLTHarness is not available in the DLT integration module")
+
+    pipeline_callable = _build_contract_table_pipeline(module, dlt_config)
+
+    run_timestamp = _timestamp_slug(datetime.now(timezone.utc))
+    base_context: dict[str, Any] = {
+        "pipeline": "dc43_demo_app.dlt_pipeline.run_dlt_pipeline",
+        "run_id": run_timestamp,
+        "run_type": run_type,
+    }
+    if scenario_key:
+        base_context["scenario_key"] = scenario_key
+    if contract_id:
+        base_context["target_contract_id"] = contract_id
+    if contract_version:
+        base_context["target_contract_version"] = contract_version
+
+    records = contracts_server.load_records()
+    output_contract = (
+        contracts_server.store.get(contract_id, contract_version)
+        if contract_id and contract_version
+        else None
+    )
+    if output_contract and getattr(output_contract, "id", None):
+        dataset_name = output_contract.id
+    elif not dataset_name:
+        dataset_name = contract_id or "result"
+
+    existing_versions = [
+        record.dataset_version for record in records if record.dataset_name == dataset_name
+    ]
+    if not dataset_version:
+        dataset_version = _next_version(existing_versions)
+
+    base_context["output_dataset"] = dataset_name
+    base_context["output_dataset_version"] = dataset_version
+
+    harness_config = {}
+    run_overrides = {}
+    if isinstance(dlt_config, Mapping):
+        harness_config = dict(dlt_config.get("harness", {}))
+        run_overrides = dict(dlt_config.get("run", {}))
+
+    try:
+        harness = harness_cls(pipeline_callable, **harness_config)
+    except TypeError:
+        harness = harness_cls(**{**harness_config, "pipeline": pipeline_callable})
+
+    run_callable: Any
+    context_manager = getattr(harness, "__enter__", None)
+    if callable(context_manager):
+        with harness as active:
+            run_callable = getattr(active, "run", None)
+            if run_callable is None:
+                raise RuntimeError("DLT harness does not provide a run method")
+            result = _call_with_supported_kwargs(
+                run_callable,
+                kwargs={
+                    "contract_id": contract_id,
+                    "contract_version": contract_version,
+                    "dataset_name": dataset_name,
+                    "dataset_version": dataset_version,
+                    "run_type": run_type,
+                    "pipeline_context": base_context,
+                    **run_overrides,
+                },
+            )
+    else:
+        run_callable = getattr(harness, "run", None)
+        if run_callable is None:
+            raise RuntimeError("DLT harness does not provide a run method")
+        result = _call_with_supported_kwargs(
+            run_callable,
+            kwargs={
+                "contract_id": contract_id,
+                "contract_version": contract_version,
+                "dataset_name": dataset_name,
+                "dataset_version": dataset_version,
+                "run_type": run_type,
+                "pipeline_context": base_context,
+                **run_overrides,
+            },
+        )
+
+    dq_details: Mapping[str, Any]
+    if isinstance(result, Mapping):
+        dq_details = dict(result)
+    else:
+        dq_details = {"output": {"result": result}}
+
+    reported_dataset = None
+    reported_version = None
+    if isinstance(result, Mapping):
+        reported_dataset = result.get("dataset") or result.get("dataset_name")
+        reported_version = result.get("version") or result.get("dataset_version")
+
+    if isinstance(reported_dataset, str) and reported_dataset:
+        dataset_name = reported_dataset
+    if isinstance(reported_version, str) and reported_version:
+        dataset_version = reported_version
+
+    if not dataset_name or not dataset_version:
+        raise RuntimeError("DLT run did not yield a dataset identifier")
+
+    output_details: Mapping[str, Any]
+    if isinstance(dq_details.get("output"), Mapping):
+        output_details = dq_details["output"]  # type: ignore[index]
+    else:
+        output_details = dq_details
+        dq_details = {"output": output_details}
+
+    output_details = dict(output_details)
+    output_details.setdefault("pipeline_context", base_context)
+
+    _ensure_registered(output_contract, dataset_name, dataset_version, output_details)
+
+    dq_status = output_details.get("dq_status")
+    status_text: str | None = None
+    if isinstance(dq_status, Mapping):
+        raw_status = dq_status.get("status")
+        if isinstance(raw_status, str):
+            status_text = raw_status
+    if isinstance(dq_details.get("status"), str):
+        status_text = str(dq_details["status"])
+
+    severity = _status_severity(status_text)
+    if output_details.get("errors"):
+        severity = max(severity, 2)
+    elif output_details.get("warnings"):
+        severity = max(severity, 1)
+
+    violations = _summarise_violations(output_details)
+    if violations and severity < 2:
+        severity = max(severity, 1)
+
+    status_value = "ok"
+    if severity == 1:
+        status_value = "warning"
+    elif severity >= 2:
+        status_value = "error"
+
+    draft_version = None
+    if isinstance(output_details.get("draft_contract_version"), str):
+        draft_version = output_details.get("draft_contract_version")  # type: ignore[assignment]
+    elif isinstance(dq_details.get("draft_contract_version"), str):
+        draft_version = dq_details.get("draft_contract_version")  # type: ignore[assignment]
+
+    record = DatasetRecord(
+        contract_id or "",
+        contract_version or "",
+        dataset_name,
+        dataset_version,
+        status_value,
+        dict(dq_details),
+        run_type,
+        violations,
+        draft_contract_version=draft_version,
+        scenario_key=scenario_key,
+    )
+
+    records.append(record)
+    contracts_server.save_records(records)
+
+    if run_type == "enforce" and severity >= 2:
+        raise ValueError(
+            f"DLT pipeline reported blocking status: {status_text or 'error'}"
+        )
+
+    return dataset_name, dataset_version
+
+
+__all__ = ["run_dlt_pipeline"]
+

--- a/packages/dc43-demo-app/src/dc43_demo_app/scenarios.py
+++ b/packages/dc43-demo-app/src/dc43_demo_app/scenarios.py
@@ -2373,6 +2373,111 @@ def run_split_invalid_rows(
             ),
         ],
     },
+    "dlt-contract-table": {
+        "label": "DLT: contract table pipeline",
+        "category": "dlt",
+        "description": (
+            "<p>Run the contract-table scenario with a local Delta Live Tables harness.</p>"
+            "<ul>"
+            "<li><strong>Inputs:</strong> Reuses the curated <code>orders</code> and <code>customers</code>"
+            " slices that power the batch demo.</li>"
+            "<li><strong>Execution:</strong> Builds the integration-provided contract table pipeline and"
+            " drives it with <code>LocalDLTHarness</code>.</li>"
+            "<li><strong>Outputs:</strong> Registers the newly materialised <code>orders_enriched</code> version"
+            " and surfaces its validation payload.</li>"
+            "<li><strong>Status:</strong> Mirrors the DQ verdict returned by the harness, raising in enforcement mode when"
+            " violations block the run.</li>"
+            "</ul>"
+        ),
+        "diagram": (
+            "<div class=\"mermaid\">"
+            + dedent(
+                """
+                flowchart TD
+                    Sources["orders + customers\\ncontract slices"] --> DLT["LocalDLTHarness\\ncontract table pipeline"]
+                    DLT --> Output["orders_enriched\\nregistered version"]
+                    DLT --> Governance["DQ & governance\\nstatus and metrics"]
+                """
+            ).strip()
+            + "</div>"
+        ),
+        "activate_versions": dict(_DEFAULT_SLICE, orders="2025-10-05"),
+        "params": {
+            "mode": "dlt",
+            "contract_id": "orders_enriched",
+            "contract_version": "1.1.0",
+            "dataset_name": None,
+            "dataset_version": None,
+            "run_type": "enforce",
+            "dlt": {
+                "run": {
+                    "full_refresh": False,
+                }
+            },
+        },
+        "guide": [
+            _section(
+                "What this example shows",
+                """
+                <p>
+                  The scenario translates the contract-table batch demo into a
+                  Delta Live Tables run. It keeps the same curated source slices,
+                  executes the integration pipeline with the local harness, and
+                  records the resulting dataset version in the demo registry.
+                </p>
+                """,
+            ),
+            _section(
+                "Why it matters",
+                """
+                <p>
+                  Teams experimenting with DLT can see how contract-aware
+                  orchestration carries across engine boundaries. The walkthrough
+                  highlights:
+                </p>
+                <ul>
+                  <li>How <code>LocalDLTHarness</code> wraps the integration
+                      pipeline for local iteration.</li>
+                  <li>The shared dataset history and validation payloads between
+                      batch and DLT executions.</li>
+                  <li>Enforcement semantics that stay consistent regardless of
+                      whether Spark runs the job or Delta Live Tables does.</li>
+                </ul>
+                """,
+            ),
+            _section(
+                "How it works",
+                """
+                <ol>
+                  <li>Build the contract-table pipeline from the
+                      <code>dc43_integrations.spark.dlt</code> module.</li>
+                  <li>Execute it with <code>LocalDLTHarness</code>, which handles
+                      source resolution and Delta Live Tables execution locally.</li>
+                  <li>Use <code>run_dlt_pipeline</code> to record the resulting
+                      dataset version, validation metadata, and governance
+                      status for the UI.</li>
+                </ol>
+                """,
+            ),
+            _code_section(
+                "Run the DLT harness locally",
+                """
+from dc43_integrations.spark.dlt.contract_table import LocalDLTHarness, build_pipeline
+
+pipeline = build_pipeline()
+with LocalDLTHarness(pipeline) as harness:
+    result = harness.run(
+        contract_id="orders_enriched",
+        contract_version="1.1.0",
+        run_type="enforce",
+    )
+    print(f"{result['dataset']} → {result['dataset_version']}")
+                """,
+                "<p>The demo's <code>run_dlt_pipeline</code> helper wraps the same harness so UI-triggered runs capture"
+                " dataset history without additional boilerplate.</p>",
+            ),
+        ],
+    },
     "streaming-valid": {
         "label": "Streaming: healthy pipeline",
         "category": "streaming",

--- a/packages/dc43-demo-app/src/dc43_demo_app/server.py
+++ b/packages/dc43-demo-app/src/dc43_demo_app/server.py
@@ -45,6 +45,7 @@ CATEGORY_LABELS = {
     "contract": "Contract-focused pipelines",
     "data-product": "Data product pipelines",
     "streaming": "Streaming pipelines",
+    "dlt": "Delta Live Tables pipelines",
 }
 
 STATUS_BADGES = {
@@ -981,6 +982,7 @@ async def pipeline_run_detail(request: Request, scenario_key: str) -> HTMLRespon
 @app.post("/pipeline/run", response_class=HTMLResponse)
 async def run_pipeline_endpoint(scenario: str = Form(...)) -> HTMLResponse:
     from .pipeline import run_pipeline
+    from .dlt_pipeline import run_dlt_pipeline
 
     cfg = SCENARIOS.get(scenario)
     if not cfg:
@@ -1006,6 +1008,17 @@ async def run_pipeline_endpoint(scenario: str = Form(...)) -> HTMLResponse:
                 seconds=seconds_int,
                 run_type=params_cfg.get("run_type", "observe"),
                 progress=None,
+            )
+        elif mode == "dlt":
+            dataset_name, new_version = await asyncio.to_thread(
+                run_dlt_pipeline,
+                params_cfg.get("contract_id"),
+                params_cfg.get("contract_version"),
+                params_cfg.get("dataset_name"),
+                params_cfg.get("dataset_version"),
+                params_cfg.get("run_type", "infer"),
+                scenario_key=scenario,
+                dlt_config=params_cfg.get("dlt"),
             )
         else:
             dataset_name, new_version = await asyncio.to_thread(

--- a/packages/dc43-demo-app/tests/test_dlt_pipeline.py
+++ b/packages/dc43-demo-app/tests/test_dlt_pipeline.py
@@ -1,0 +1,178 @@
+import shutil
+import sys
+import types
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+from fastapi.testclient import TestClient
+
+from dc43_demo_app import contracts_api
+from dc43_demo_app.contracts_workspace import current_workspace
+from dc43_demo_app.server import app
+
+
+@pytest.fixture
+def fake_dlt_module(monkeypatch: pytest.MonkeyPatch) -> List[Dict[str, Any]]:
+    runs: List[Dict[str, Any]] = []
+
+    class FakeHarness:
+        def __init__(self, pipeline_callable, **_kwargs: Any) -> None:
+            self._pipeline = pipeline_callable
+
+        def __enter__(self) -> "FakeHarness":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        def run(self, **run_kwargs: Any) -> Dict[str, Any]:
+            runs.append(dict(run_kwargs))
+            return self._pipeline(**run_kwargs)
+
+    def build_pipeline(**_kwargs: Any):
+        def _pipeline(**kwargs: Any) -> Dict[str, Any]:
+            dataset = kwargs.get("dataset_name") or "orders_enriched"
+            version = kwargs.get("dataset_version") or "dlt-version"
+            status = kwargs.get("status") or "ok"
+            return {
+                "dataset": dataset,
+                "dataset_version": version,
+                "output": {
+                    "dq_status": {"status": status},
+                    "metrics": {"violations.total": 0},
+                },
+                "status": status,
+            }
+
+        return _pipeline
+
+    module = types.SimpleNamespace(
+        LocalDLTHarness=FakeHarness,
+        build_pipeline=build_pipeline,
+    )
+
+    monkeypatch.setitem(
+        sys.modules,
+        "dc43_integrations.spark.dlt.contract_table",
+        module,
+    )
+    return runs
+
+
+def _active_version(dataset: str) -> str | None:
+    workspace = current_workspace()
+    latest = workspace.data_dir / dataset / "latest"
+    if not latest.exists():
+        return None
+    try:
+        resolved = latest.resolve()
+    except OSError:
+        resolved = latest
+    if resolved.is_dir():
+        marker = resolved / ".dc43_version"
+        if marker.exists():
+            try:
+                text = marker.read_text().strip()
+            except OSError:
+                text = ""
+            if text:
+                return text
+        return resolved.name
+    return None
+
+
+def test_dlt_pipeline_records_run(fake_dlt_module: List[Dict[str, Any]]) -> None:
+    from dc43_demo_app.dlt_pipeline import run_dlt_pipeline
+
+    original_records = contracts_api.load_records()
+    dataset = "orders_enriched"
+    previous_version = _active_version(dataset)
+    dataset_version: str | None = None
+
+    try:
+        dataset_name, dataset_version = run_dlt_pipeline(
+            contract_id="orders_enriched",
+            contract_version="1.1.0",
+            dataset_name=None,
+            dataset_version=None,
+            run_type="enforce",
+            scenario_key="dlt-contract-table",
+            dlt_config={"run": {"full_refresh": True}},
+        )
+
+        assert dataset_name == "orders_enriched"
+        assert fake_dlt_module, "DLT harness should be invoked"
+        run_kwargs = fake_dlt_module[-1]
+        assert run_kwargs["contract_id"] == "orders_enriched"
+        assert run_kwargs["pipeline_context"]["pipeline"] == "dc43_demo_app.dlt_pipeline.run_dlt_pipeline"
+        assert run_kwargs["pipeline_context"]["scenario_key"] == "dlt-contract-table"
+        assert run_kwargs["full_refresh"] is True
+
+        records = contracts_api.load_records()
+        last = records[-1]
+        assert last.dataset_name == dataset_name
+        assert last.dataset_version == dataset_version
+        assert last.scenario_key == "dlt-contract-table"
+        assert last.status == "ok"
+        output = last.dq_details.get("output", {})
+        assert output.get("dq_status", {}).get("status") == "ok"
+    finally:
+        contracts_api.save_records(original_records)
+        if previous_version:
+            try:
+                contracts_api.set_active_version(dataset, previous_version)
+            except FileNotFoundError:
+                pass
+        if dataset_version:
+            out_dir = Path(contracts_api.DATA_DIR) / dataset / dataset_version
+            if out_dir.exists():
+                shutil.rmtree(out_dir, ignore_errors=True)
+
+
+def test_run_pipeline_endpoint_dispatches_dlt(fake_dlt_module: List[Dict[str, Any]]) -> None:
+    client = TestClient(app)
+
+    original_records = contracts_api.load_records()
+    dataset = "orders_enriched"
+    previous_enriched = _active_version(dataset)
+    previous_orders = _active_version("orders")
+    previous_customers = _active_version("customers")
+
+    try:
+        response = client.post(
+            "/pipeline/run",
+            data={"scenario": "dlt-contract-table"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+        assert response.headers["location"].startswith("/pipeline-runs")
+        assert fake_dlt_module, "DLT harness should be invoked by the endpoint"
+        run_kwargs = fake_dlt_module[-1]
+        assert run_kwargs.get("full_refresh") is False
+        assert run_kwargs.get("pipeline_context", {}).get("scenario_key") == "dlt-contract-table"
+
+        records = contracts_api.load_records()
+        last = records[-1]
+        assert last.scenario_key == "dlt-contract-table"
+        assert last.status == "ok"
+        assert last.dataset_name == dataset
+    finally:
+        contracts_api.save_records(original_records)
+        for name, version in (
+            (dataset, previous_enriched),
+            ("orders", previous_orders),
+            ("customers", previous_customers),
+        ):
+            if version:
+                try:
+                    contracts_api.set_active_version(name, version)
+                except FileNotFoundError:
+                    pass
+        produced_version = None
+        if fake_dlt_module:
+            produced_version = fake_dlt_module[-1].get("dataset_version")
+        if produced_version:
+            out_dir = Path(contracts_api.DATA_DIR) / dataset / str(produced_version)
+            if out_dir.exists():
+                shutil.rmtree(out_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary
- add a run_dlt_pipeline helper that wraps the contract-table LocalDLTHarness while recording dataset metadata
- surface a DLT-focused scenario and route the server endpoint based on the new mode flag
- add regression tests that exercise the harness and FastAPI endpoint through a fake DLT module

## Testing
- pytest packages/dc43-demo-app/tests -q

------
https://chatgpt.com/codex/tasks/task_b_68ed018f4274832e9275eb93b8ecd7fe