### PR TITLE
Tag release Docker images with package versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,14 @@ on:
       - main
       - dev
   workflow_dispatch:
+    inputs:
+      publish_docker_images:
+        description: "Build and push the release Docker images to Amazon ECR"
+        type: boolean
+        default: false
+      docker_image_tag:
+        description: "Tag to apply when pushing Docker images (defaults to commit SHA)"
+        required: false
 
 jobs:
   tests:
@@ -74,3 +82,50 @@ jobs:
 
       - name: Run tests
         run: ${{ matrix.test_command }}
+
+  docker-ecr-smoke:
+    name: Docker image smoke publish
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_docker_images == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      IMAGE_TAG: ${{ github.event.inputs.docker_image_tag || github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push smoke-test images
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          CONTRACTS_REPOSITORY: ${{ secrets.AWS_ECR_CONTRACTS_APP_REPOSITORY }}
+          BACKEND_REPOSITORY: ${{ secrets.AWS_ECR_HTTP_BACKEND_REPOSITORY }}
+        run: |
+          set -euo pipefail
+
+          build_and_push() {
+            local image_name=$1
+            local dockerfile=$2
+            local repository=$3
+
+            echo "::group::Building ${image_name} image"
+            docker build -f "$dockerfile" -t "$REGISTRY/$repository:$IMAGE_TAG" .
+            docker push "$REGISTRY/$repository:$IMAGE_TAG"
+            docker tag "$REGISTRY/$repository:$IMAGE_TAG" "$REGISTRY/$repository:latest"
+            docker push "$REGISTRY/$repository:latest"
+            echo "::endgroup::"
+          }
+
+          build_and_push "contracts-app" "deploy/contracts-app/Dockerfile" "$CONTRACTS_REPOSITORY"
+          build_and_push "http-backend" "deploy/http-backend/Dockerfile" "$BACKEND_REPOSITORY"
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,3 +350,83 @@ jobs:
           tag_name: ${{ needs.determine.outputs.contracts_app_tag }}
           files: release-artifacts/dc43-contracts-app/*
           generate_release_notes: true
+
+  docker-images:
+    name: Build and publish Docker images
+    needs:
+      - release
+      - determine
+    if: needs.determine.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTRACTS_APP_TAG: ${{ needs.determine.outputs.contracts_app_tag }}
+      SERVICE_BACKENDS_TAG: ${{ needs.determine.outputs.service_backends_tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push release images
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          CONTRACTS_REPOSITORY: ${{ secrets.AWS_ECR_CONTRACTS_APP_REPOSITORY }}
+          BACKEND_REPOSITORY: ${{ secrets.AWS_ECR_HTTP_BACKEND_REPOSITORY }}
+        run: |
+          set -euo pipefail
+
+          build_and_push() {
+            local image_name=$1
+            local dockerfile=$2
+            local repository=$3
+            local version=$4
+
+            echo "::group::Building ${image_name} image"
+            docker build -f "$dockerfile" -t "$REGISTRY/$repository:$version" .
+            docker push "$REGISTRY/$repository:$version"
+            docker tag "$REGISTRY/$repository:$version" "$REGISTRY/$repository:latest"
+            docker push "$REGISTRY/$repository:latest"
+            echo "::endgroup::"
+          }
+
+          trim_prefix() {
+            local tag=$1
+            local prefix=$2
+
+            if [[ -z "$tag" ]]; then
+              echo ""
+              return
+            fi
+
+            if [[ $tag != ${prefix}* ]]; then
+              echo "::error::Tag '$tag' does not start with expected prefix '$prefix'" >&2
+              exit 1
+            fi
+
+            echo "${tag:${#prefix}}"
+          }
+
+          contracts_version=$(trim_prefix "${CONTRACTS_APP_TAG:-}" "dc43-contracts-app-v")
+          backend_version=$(trim_prefix "${SERVICE_BACKENDS_TAG:-}" "dc43-service-backends-v")
+
+          if [[ -n "$contracts_version" ]]; then
+            build_and_push "contracts-app" "deploy/contracts-app/Dockerfile" "$CONTRACTS_REPOSITORY" "$contracts_version"
+          else
+            echo "Contracts app package not part of this release; skipping Docker publish."
+          fi
+
+          if [[ -n "$backend_version" ]]; then
+            build_and_push "http-backend" "deploy/http-backend/Dockerfile" "$BACKEND_REPOSITORY" "$backend_version"
+          else
+            echo "HTTP backend package not part of this release; skipping Docker publish."
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   Python suite.
 
 ### Changed
+- Updated the release automation to tag the contracts-app and HTTP backend Docker
+  images with their package versions, documented the ECR setup flow, and added a
+  manual smoke publish path for validating AWS credentials.
 - Documented the Gitflow-based branching expectations and clarified how merges from `dev` to `main`
   trigger automated releases in the release guide.
 - Relaxed internal package pins in `setup.py` to resolve pip conflicts when installing extras

--- a/README.md
+++ b/README.md
@@ -457,6 +457,24 @@ pytest -q tests packages/dc43-service-clients/tests \
   packages/dc43-service-backends/tests packages/dc43-integrations/tests
 ```
 
+# Continuous integration
+
+- The GitHub Actions release workflow at `.github/workflows/release.yml` builds
+  the contracts app and HTTP backend Docker images after the release pipeline
+  finishes and publishes them to Amazon ECR using the released package versions
+  as image tags (alongside `latest`).
+- Trigger the `ci` workflow manually with **Publish Docker images to Amazon ECR**
+  enabled to run a smoke test that builds and pushes both images without waiting
+  for a release.
+- Configure the following repository secrets so the workflows can assume an AWS
+  role and push to your registries:
+  - `AWS_REGION`
+  - `AWS_ROLE_TO_ASSUME`
+  - `AWS_ECR_CONTRACTS_APP_REPOSITORY`
+  - `AWS_ECR_HTTP_BACKEND_REPOSITORY`
+- See [`docs/aws-ecr-setup.md`](docs/aws-ecr-setup.md) for full AWS and GitHub
+  configuration guidance.
+
 # Publishing
 
 - Push a tag `v*` on a commit in `main`.

--- a/docs/aws-ecr-setup.md
+++ b/docs/aws-ecr-setup.md
@@ -1,0 +1,109 @@
+# Amazon ECR setup for dc43 Docker publishing
+
+This guide walks through provisioning the Amazon Elastic Container Registry (ECR)
+resources and GitHub configuration that the release and CI workflows expect when
+building and pushing the dc43 Docker images.
+
+## 1. Create the ECR repositories
+
+Provision two repositories in the AWS account that will host your images:
+
+| Repository purpose | Suggested name | GitHub secret |
+| --- | --- | --- |
+| Contracts UI (`deploy/contracts-app/Dockerfile`) | `dc43-contracts-app` | `AWS_ECR_CONTRACTS_APP_REPOSITORY` |
+| HTTP service backends (`deploy/http-backend/Dockerfile`) | `dc43-http-backend` | `AWS_ECR_HTTP_BACKEND_REPOSITORY` |
+
+Both repositories must allow pushes for arbitrary semantic tags. The release
+workflow publishes each image using the package version reported by the
+corresponding tag (for example `1.4.0`) and also updates a mutable `latest`
+tag. The CI smoke test can still push ad-hoc tags (defaults to the commit SHA)
+when you manually dispatch it.
+
+## 2. Configure IAM with GitHub OIDC
+
+1. [Create an IAM identity provider](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html)
+   targeting `token.actions.githubusercontent.com` if your account does not
+   already have one for GitHub Actions.
+2. Create an IAM role that trusts this provider. Scope the trust policy to the
+   GitHub repository (or environment) that will run the workflows. A minimal
+   example condition limits access to the `release` environment:
+
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Effect": "Allow",
+         "Principal": {
+           "Federated": "arn:aws:iam::<ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com"
+         },
+         "Action": "sts:AssumeRoleWithWebIdentity",
+         "Condition": {
+           "StringEquals": {
+             "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+             "token.actions.githubusercontent.com:sub": "repo:<OWNER>/<REPO>:environment:release"
+           }
+         }
+       }
+     ]
+   }
+   ```
+3. Attach a permissions policy that grants the Docker workflows ECR access. At
+   minimum include:
+
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Effect": "Allow",
+         "Action": [
+           "ecr:GetAuthorizationToken",
+           "ecr:BatchCheckLayerAvailability",
+           "ecr:CompleteLayerUpload",
+           "ecr:DescribeImages",
+           "ecr:InitiateLayerUpload",
+           "ecr:PutImage",
+           "ecr:UploadLayerPart"
+         ],
+         "Resource": "*"
+       }
+     ]
+   }
+   ```
+
+   Optionally extend the policy with `ecr:CreateRepository` and
+   `ecr:DescribeRepositories` if you want the workflows to provision missing
+   repositories automatically.
+
+## 3. Add GitHub repository secrets
+
+Populate the secrets that the workflows reference:
+
+- `AWS_REGION` – AWS region that hosts the ECR repositories.
+- `AWS_ROLE_TO_ASSUME` – ARN of the IAM role created above.
+- `AWS_ECR_CONTRACTS_APP_REPOSITORY` – name of the contracts app repository.
+- `AWS_ECR_HTTP_BACKEND_REPOSITORY` – name of the HTTP backend repository.
+- `PYPI_TOKEN` – still required for Python package publishing during releases.
+
+## 4. Configure the release environment
+
+The release workflow runs in the `release` environment. Configure it with the
+required reviewers or deployment protections so Docker publishing only happens
+after manual approval.
+
+## 5. Validate with the CI smoke test
+
+Use the **Run workflow** button on the `ci` workflow to trigger a manual run
+with Docker publishing enabled:
+
+1. Open **Actions → ci → Run workflow**.
+2. Enable **Publish Docker images to Amazon ECR**.
+3. Optionally supply a custom image tag (defaults to the selected commit SHA).
+4. Dispatch the workflow and monitor the `Docker image smoke publish` job. It
+   builds both Dockerfiles and pushes the results to the configured ECR
+   repositories, mirroring the release behavior without waiting for a tagged
+   release.
+
+Once the smoke test succeeds, your release pipeline will publish both images for
+future releases automatically.


### PR DESCRIPTION
## Summary
- derive the contracts app and HTTP backend Docker image tags from their release package versions during the release workflow
- retain latest tags while skipping image publishing when a package is not part of the release
- document the version-based tags in the ECR setup guide and README
- record the release automation updates in the root changelog

## Testing
- not run (workflow and documentation changes only)

------
https://chatgpt.com/codex/tasks/task_b_68f0c23ba7d8832e9f57f8e80777d8e5