### PR TITLE
Skip Spark checkpointing on serverless clusters

### DIFF
--- a/packages/dc43-integrations/src/dc43_integrations/spark/io.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io.py
@@ -142,6 +142,38 @@ def _normalise_path_ref(path: Optional[str | Iterable[str]]) -> Optional[str]:
     return path
 
 
+def _supports_dataframe_checkpointing(df: DataFrame) -> bool:
+    """Return ``True`` when the active Spark cluster supports checkpointing."""
+
+    try:
+        spark = df.sparkSession
+    except Exception:  # pragma: no cover - defensive, matches write path guard
+        return True
+
+    try:
+        conf = spark.sparkContext.getConf()
+    except Exception:  # pragma: no cover - fallback to legacy behaviour
+        return True
+
+    indicators: tuple[tuple[str, tuple[str, ...]], ...] = (
+        ("spark.databricks.service.serverless.enabled", ("true", "1", "yes")),
+        ("spark.databricks.service.serverless", ("true", "1", "yes")),
+        ("spark.databricks.service.clusterSource", ("serverless",)),
+        ("spark.databricks.clusterUsageTags.clusterAllType", ("serverless",)),
+    )
+
+    for key, matches in indicators:
+        try:
+            raw_value = conf.get(key, "")
+        except Exception:  # pragma: no cover - SparkConf guards can raise
+            raw_value = ""
+        value = str(raw_value).lower()
+        if value and any(match in value for match in matches):
+            return False
+
+    return True
+
+
 def _looks_like_table_reference(value: str) -> bool:
     """Return ``True`` when ``value`` resembles a table identifier."""
 
@@ -3376,9 +3408,20 @@ def _execute_write_request(
     df_to_write = request.df
     checkpointed = False
     streaming_handles: list[Any] = []
+    mode = (request.mode or "").lower()
+    should_checkpoint = (
+        not request.streaming and request.path and mode == "overwrite"
+    )
+    if should_checkpoint and not _supports_dataframe_checkpointing(df_to_write):
+        logger.info(
+            "Skipping dataframe checkpoint for %s because caching is unsupported",
+            request.path,
+        )
+        should_checkpoint = False
+
     if request.streaming:
         pass
-    elif request.path and request.mode.lower() == "overwrite":
+    elif should_checkpoint:
         try:
             df_to_write = df_to_write.localCheckpoint(eager=True)
         except Exception:  # pragma: no cover - defensive fallback


### PR DESCRIPTION
## Summary
- add a helper to detect serverless Spark environments that do not support dataframe checkpointing
- guard the overwrite checkpoint logic so serverless clusters skip the persist/unpersist path

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68fcb2b1fa2c832ea4ea63471e5a42a2