### PR TITLE
Fix Delta governance reads for remote folders

### DIFF
--- a/packages/dc43-service-backends/src/dc43_service_backends/governance/storage/delta.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/governance/storage/delta.py
@@ -197,7 +197,7 @@ class DeltaGovernanceStore(GovernanceStore):
             if table:
                 return self._spark.table(table)
             if folder:
-                if not Path(folder).exists():
+                if not self._delta_folder_exists(folder):
                     return None
                 return self._spark.read.format("delta").load(folder)
         except AnalysisException:


### PR DESCRIPTION
## Summary
- ensure Delta governance reads rely on the same folder existence check used for bootstrap so remote storage works

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68fce68db6cc832eb4acd99bd8e1440f