### PR TITLE
Bootstrap governance backend in build_backends

### DIFF
--- a/packages/dc43-service-backends/tests/test_bootstrap.py
+++ b/packages/dc43-service-backends/tests/test_bootstrap.py
@@ -27,6 +27,7 @@ from dc43_service_backends.data_quality.backend import (
     LocalDataQualityServiceBackend,
     RemoteDataQualityServiceBackend,
 )
+from dc43_service_backends.governance.backend import LocalGovernanceServiceBackend
 from dc43_service_backends.governance.storage import InMemoryGovernanceStore
 from dc43_service_backends.governance.storage.filesystem import FilesystemGovernanceStore
 
@@ -92,6 +93,9 @@ def test_build_backends_delta(monkeypatch: pytest.MonkeyPatch) -> None:
     assert isinstance(suite.data_product, DeltaDataProductServiceBackend)
     assert isinstance(suite.data_quality, LocalDataQualityServiceBackend)
     assert isinstance(suite.governance_store, InMemoryGovernanceStore)
+    assert isinstance(suite.governance, LocalGovernanceServiceBackend)
+    assert isinstance(suite.contract_store, DeltaContractStore)
+    assert isinstance(suite.link_hooks, tuple)
 
 
 def test_build_data_quality_backend_local() -> None:

--- a/packages/dc43-service-clients/src/dc43_service_clients/bootstrap.py
+++ b/packages/dc43-service-clients/src/dc43_service_clients/bootstrap.py
@@ -8,8 +8,6 @@ from typing import Optional
 
 from dc43_service_backends.bootstrap import BackendSuite, build_backends
 from dc43_service_backends.config import ServiceBackendsConfig, load_config
-from dc43_service_backends.governance.bootstrap import build_dataset_contract_link_hooks
-from dc43_service_backends.governance.backend import LocalGovernanceServiceBackend
 from dc43_service_clients.contracts import ContractServiceClient, LocalContractServiceClient
 from dc43_service_clients.data_products import (
     DataProductServiceClient,
@@ -65,16 +63,7 @@ def load_service_clients(
         return ServiceClientsSuite(config=config, governance=governance)
 
     backends = build_backends(config)
-    link_hooks = build_dataset_contract_link_hooks(config)
-    governance_backend = LocalGovernanceServiceBackend(
-        contract_client=backends.contract,
-        dq_client=backends.data_quality,
-        data_product_client=backends.data_product,
-        draft_store=getattr(backends.contract, "_store", None),
-        link_hooks=link_hooks,
-        store=backends.governance_store,
-    )
-    governance = LocalGovernanceServiceClient(governance_backend)
+    governance = LocalGovernanceServiceClient(backends.governance)
     contract_client = LocalContractServiceClient(backends.contract)
     dq_client = LocalDataQualityServiceClient(backends.data_quality)
     data_product_client: Optional[DataProductServiceClient] = None


### PR DESCRIPTION
## Summary
- initialize the governance backend and hooks inside `build_backends`
- update service client and webapp bootstrappers to use the richer backend suite
- extend bootstrap tests to cover the governance backend and exposed stores

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68ff2ebaa9ac832eb2c996f236ed1baf