### PR TITLE
Fix SQL governance activity dataset version metadata

### DIFF
--- a/packages/dc43-service-backends/CHANGELOG.md
+++ b/packages/dc43-service-backends/CHANGELOG.md
@@ -18,6 +18,11 @@
   of the legacy Spark contract helpers so governance-first pipelines surface the
   same guardrails.
 
+### Fixed
+- SQL governance activity lookups now include the dataset identifier and version
+  from the table columns when payloads omit those fields, ensuring clients can
+  enumerate available dataset versions even for legacy records.
+
 ## [0.22.0.0] - 2025-10-25
 ### Changed
 - No behavioural updates. Bumped version markers for the 0.22.0.0 release.

--- a/packages/dc43-service-backends/tests/test_governance_sql_store.py
+++ b/packages/dc43-service-backends/tests/test_governance_sql_store.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+from dc43_service_backends.governance.storage.sql import SQLGovernanceStore
+
+
+@pytest.fixture()
+def sql_engine(tmp_path: Path):
+    from sqlalchemy import create_engine
+
+    db_path = tmp_path / "governance.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+def test_load_pipeline_activity_injects_dataset_version(sql_engine) -> None:
+    store = SQLGovernanceStore(sql_engine)
+
+    store._write_payload(  # type: ignore[attr-defined]
+        store._activity,  # type: ignore[attr-defined]
+        dataset_id="sales.orders",
+        dataset_version="0.1.0",
+        payload={
+            "contract_id": "sales.orders",
+            "contract_version": "0.1.0",
+            "events": [
+                {
+                    "operation": "write",
+                    "recorded_at": "2025-10-28T09:13:12.628161Z",
+                }
+            ],
+        },
+        extra={"updated_at": "2025-10-28T09:13:12.628161Z"},
+    )
+
+    activities = store.load_pipeline_activity(dataset_id="sales.orders")
+    assert len(activities) == 1
+    record = activities[0]
+    assert record["dataset_id"] == "sales.orders"
+    assert record["dataset_version"] == "0.1.0"
+    assert record["contract_id"] == "sales.orders"
+    assert record["contract_version"] == "0.1.0"
+    assert record["events"] == [
+        {
+            "operation": "write",
+            "recorded_at": "2025-10-28T09:13:12.628161Z",
+        }
+    ]
+
+    single = store.load_pipeline_activity(
+        dataset_id="sales.orders", dataset_version="0.1.0"
+    )
+    assert single == activities


### PR DESCRIPTION
## Summary
- ensure SQL governance pipeline activity entries restore dataset_id and dataset_version when payloads omit them
- add regression coverage for dataset version enrichment in the SQL governance store
- document the fix in the service-backends changelog

## Testing
- pytest -q packages/dc43-service-backends/tests/test_governance_sql_store.py

------
https://chatgpt.com/codex/tasks/task_b_6907464009d8832ebd884aed3f5a17db