### PR TITLE
Enable Test PyPI publishing from PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,16 +90,38 @@ jobs:
     needs: tests
     if: >-
       github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      contains(github.event.pull_request.labels.*.name, 'publish-test-pypi')
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
     env:
       TEST_PYPI_TOKEN: ${{ secrets.TEST_PYPI_TOKEN }}
     steps:
+      - name: Check for publish label
+        id: label
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request.number;
+            const { data } = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number: pull_number,
+            });
+            const hasLabel = data.labels.some(
+              (label) => label.name === 'publish-test-pypi'
+            );
+            core.setOutput('has_label', hasLabel ? 'true' : 'false');
+
+      - name: Skip publishing when label is missing
+        if: ${{ steps.label.outputs.has_label != 'true' }}
+        run: echo "publish-test-pypi label not present; skipping publish job." >> "$GITHUB_STEP_SUMMARY"
+
       - name: Detect Test PyPI token
         id: token
+        if: ${{ steps.label.outputs.has_label == 'true' }}
         run: |
           if [ -z "${TEST_PYPI_TOKEN:-}" ]; then
             echo "has_token=false" >> "$GITHUB_OUTPUT"
@@ -112,22 +134,22 @@ jobs:
         with:
           fetch-depth: 0
           tags: true
-        if: ${{ steps.token.outputs.has_token == 'true' }}
+        if: ${{ steps.label.outputs.has_label == 'true' && steps.token.outputs.has_token == 'true' }}
 
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-        if: ${{ steps.token.outputs.has_token == 'true' }}
+        if: ${{ steps.label.outputs.has_label == 'true' && steps.token.outputs.has_token == 'true' }}
 
       - name: Prepare build tooling
-        if: ${{ steps.token.outputs.has_token == 'true' }}
+        if: ${{ steps.label.outputs.has_label == 'true' && steps.token.outputs.has_token == 'true' }}
         run: |
           python -m pip install --upgrade pip
           pip install packaging build twine
 
       - name: Compute release plan
         id: plan
-        if: ${{ steps.token.outputs.has_token == 'true' }}
+        if: ${{ steps.label.outputs.has_label == 'true' && steps.token.outputs.has_token == 'true' }}
         run: |
           set -euo pipefail
           python scripts/release.py \
@@ -137,7 +159,7 @@ jobs:
 
       - name: Determine packages to publish
         id: packages
-        if: ${{ steps.token.outputs.has_token == 'true' }}
+        if: ${{ steps.label.outputs.has_label == 'true' && steps.token.outputs.has_token == 'true' }}
         run: |
           python - <<'PY'
           import json
@@ -187,11 +209,11 @@ jobs:
           PY
 
       - name: Bail out when nothing to publish
-        if: ${{ steps.token.outputs.has_token == 'true' && steps.packages.outputs.packages == '' }}
+        if: ${{ steps.label.outputs.has_label == 'true' && steps.token.outputs.has_token == 'true' && steps.packages.outputs.packages == '' }}
         run: echo "No packages require publishing to Test PyPI." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build packages
-        if: ${{ steps.token.outputs.has_token == 'true' && steps.packages.outputs.packages != '' }}
+        if: ${{ steps.label.outputs.has_label == 'true' && steps.token.outputs.has_token == 'true' && steps.packages.outputs.packages != '' }}
         env:
           PACKAGES: ${{ steps.packages.outputs.packages }}
         run: |
@@ -225,7 +247,7 @@ jobs:
           PY
 
       - name: Publish packages to Test PyPI
-        if: ${{ steps.token.outputs.has_token == 'true' && steps.packages.outputs.packages != '' }}
+        if: ${{ steps.label.outputs.has_label == 'true' && steps.token.outputs.has_token == 'true' && steps.packages.outputs.packages != '' }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   release artifacts and upload them to Test PyPI for pre-release validation,
   mirroring the release workflow when any package code changes even if the
   version has not been bumped yet.
+- Fixed the Test PyPI publish workflow so labeled pull requests query the
+  current labels before deciding whether to run, ensuring tagged branches
+  actually build and upload packages for validation.
 - Removed the demo/contract helpers that manually persisted dataset records so
   the UI and pipelines rely solely on governance service APIs for run history,
   adding fixtures and helpers to tests to generate sample data on demand.


### PR DESCRIPTION
## Summary
- stop running the CI workflow on direct pushes to `main` to avoid duplicating the release workflow
- add a `publish-test-pypi` labelled job that builds the release artifacts and uploads them to Test PyPI when requested on a PR
- document the new Test PyPI option in the changelog

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_b_69078733c6b0832eaf869143cfd24d5e