### PR TITLE
Add active session stub to pyspark shim

### DIFF
--- a/packages/dc43-service-backends/tests/test_governance_delta_store.py
+++ b/packages/dc43-service-backends/tests/test_governance_delta_store.py
@@ -22,7 +22,17 @@ def _install_pyspark_stub() -> None:
     sql_module = types.ModuleType("pyspark.sql")
 
     class _StubSparkSession:  # pragma: no cover - attribute container only
-        pass
+        _active_session: "_StubSparkSession | None" = None
+
+        @classmethod
+        def getActiveSession(cls) -> "_StubSparkSession | None":
+            return cls._active_session
+
+        @classmethod
+        def setActiveSession(
+            cls, session: "_StubSparkSession | None"
+        ) -> None:
+            cls._active_session = session
 
     class _StubDataFrame:  # pragma: no cover - attribute container only
         pass


### PR DESCRIPTION
## Summary
- extend the pyspark SparkSession test shim with getActiveSession/setActiveSession helpers
- allow pyspark.sql.utils wrappers to query the shim without raising during tests

## Testing
- pytest packages/dc43-service-backends/tests/test_governance_delta_store.py::test_load_metrics_filters_results -q
- pytest -q *(fails: missing optional dependency `dc43_core` required by unrelated contract app tests)*

------
https://chatgpt.com/codex/tasks/task_b_690a78f929f8832ebd6cfe2c1427820d