### PR TITLE
Document governance publication modes

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -158,12 +158,22 @@ No additional fields are captured.
 
 ### Pipeline integration (`pipeline_integration`)
 
+Set the governance publication mode with the `publication_mode` field, the
+`DC43_GOVERNANCE_PUBLICATION_MODE` environment variable, or Spark configuration
+keys (`dc43.governance.publicationMode`, `dc43.governance.publication_mode`, or
+`governance.publication.mode`). Supported values are `legacy`,
+`open_data_lineage`, and `open_telemetry`; the legacy behaviour remains the
+default when no hint is provided.
+
 #### Apache Spark (`spark`)
 *Optional*
 - `runtime` – Free-form runtime hint (for example `databricks job`).
 - `workspace_url` – Databricks workspace URL used by the pipeline.
 - `workspace_profile` – Databricks CLI profile tied to the runtime.
 - `cluster_reference` – Cluster identifier, job name, or pool reference consumed by the bootstrap script.
+- `publication_mode` – Overrides the governance publication mode for Spark
+  helpers when present. Accepts `legacy`, `open_data_lineage`, or
+  `open_telemetry`.
 
 #### Databricks Delta Live Tables (`dlt`)
 *Required*
@@ -174,6 +184,9 @@ No additional fields are captured.
 - `workspace_profile` – Databricks CLI profile used for authentication.
 - `notebook_path` – Workspace notebook path for pipeline code.
 - `target_schema` – Target schema/database for published tables.
+- `publication_mode` – Optional override mirroring the Spark integration and
+  accepting the same `legacy`, `open_data_lineage`, or `open_telemetry`
+  values.
 
 ### Governance interface (`governance_service`)
 

--- a/docs/service-backends-configuration.md
+++ b/docs/service-backends-configuration.md
@@ -44,6 +44,13 @@ single field without editing the TOML file:
   * `DC43_CONTRACTS_APP_WORK_DIR` / `DC43_DEMO_WORK_DIR` – legacy workspace
     hints maintained for the demo app and backwards compatibility. The
     standalone UI no longer creates or manages filesystem workspaces.
+* Pipeline integrations:
+  * `DC43_GOVERNANCE_PUBLICATION_MODE` – selects whether governed runs should
+    register activities (`legacy`), emit Open Data Lineage events
+    (`open_data_lineage`), or record OpenTelemetry spans (`open_telemetry`).
+    Spark integrations also consult configuration keys named
+    `dc43.governance.publicationMode`, `dc43.governance.publication_mode`, or
+    `governance.publication.mode`.
 * Additional backend specific overrides exist for the contracts UI (see
   [Contracts app configuration](#contracts-app-configuration)).
 

--- a/packages/dc43-integrations/src/dc43_integrations/spark/open_telemetry.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/open_telemetry.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+"""Helpers for recording OpenTelemetry spans for governance interactions."""
+
+from dataclasses import asdict, is_dataclass
+import json
+import logging
+from functools import lru_cache
+from typing import Any, Mapping, Optional, Sequence, Union
+
+from dc43_service_clients.data_products import (
+    DataProductInputBinding,
+    DataProductOutputBinding,
+)
+from dc43_service_clients.data_quality import ValidationResult
+from dc43_service_clients.governance import PipelineContext
+from dc43_service_clients.governance.models import ResolvedReadPlan, ResolvedWritePlan
+
+from .open_data_lineage import (
+    _binding_to_dict,
+    _drop_empty,
+    _merge_contexts,
+    _normalise_value,
+    _resolve_binding,
+    _resolve_contract_id,
+    _resolve_contract_version,
+    _resolve_dataset_id,
+    _resolve_dataset_version,
+    _resolve_expectation_plan,
+    _resolve_format,
+    _serialise_validation,
+)
+
+PipelineContextLike = Union[
+    PipelineContext,
+    Mapping[str, object],
+    Sequence[tuple[str, object]],
+    str,
+]
+
+_LineagePlan = Union[ResolvedReadPlan, ResolvedWritePlan]
+_Binding = Union[DataProductInputBinding, DataProductOutputBinding]
+
+logger = logging.getLogger(__name__)
+
+_TRACER_NAME = "dc43.integrations.governance"
+_ATTRIBUTE_PREFIX = "dc43.governance"
+_VALIDATION_EVENT = "dc43.validation"
+_EXPECTATION_EVENT = "dc43.expectations"
+
+
+@lru_cache(maxsize=1)
+def _resolve_tracer():
+    try:  # pragma: no cover - exercised when OpenTelemetry is available
+        from opentelemetry import trace
+        from opentelemetry.trace import SpanKind
+    except ImportError:  # pragma: no cover - optional dependency
+        logger.debug("OpenTelemetry is not installed; governance telemetry spans will be skipped")
+        return None, None
+    return trace.get_tracer(_TRACER_NAME), SpanKind
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, ValidationResult):
+        return _serialise_validation(value)
+    if is_dataclass(value):
+        return {key: _json_default(item) for key, item in asdict(value).items()}
+    if isinstance(value, Mapping):
+        return {str(key): _json_default(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_json_default(item) for item in value]
+    return str(value)
+
+
+def _encode_payload(value: Any) -> str:
+    return json.dumps(value, default=_json_default, sort_keys=True)
+
+
+def _attribute_value(value: Any) -> Any:
+    normalised = _normalise_value(value)
+    if normalised is None:
+        return None
+    if isinstance(normalised, (str, bool, int, float)):
+        return normalised
+    try:
+        return _encode_payload(normalised)
+    except (TypeError, ValueError):
+        return str(normalised)
+
+
+def _flatten_context(context: Mapping[str, Any]) -> Mapping[str, Any]:
+    flattened: dict[str, Any] = {}
+    for key, value in context.items():
+        attribute = _attribute_value(value)
+        if attribute is None:
+            continue
+        flattened[str(key)] = attribute
+    return flattened
+
+
+def _binding_payload(binding: Optional[_Binding]) -> Optional[Mapping[str, Any]]:
+    resolved = _binding_to_dict(binding)
+    if resolved is None:
+        return None
+    return _drop_empty(resolved)
+
+
+def _validation_event_payload(result: ValidationResult) -> Mapping[str, Any]:
+    payload = {
+        "status": result.status or "unknown",
+        "ok": bool(result.ok),
+        "reason": result.reason or "",
+        "errors_count": len(result.errors or []),
+        "warnings_count": len(result.warnings or []),
+        "details": _attribute_value(_serialise_validation(result)),
+    }
+    if not payload["reason"]:
+        payload.pop("reason")
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def record_telemetry_span(
+    *,
+    operation: str,
+    plan: Optional[_LineagePlan],
+    pipeline_context: Optional[PipelineContextLike],
+    contract_id: Optional[str],
+    contract_version: Optional[str],
+    dataset_id: Optional[str],
+    dataset_version: Optional[str],
+    dataset_format: Optional[str] = None,
+    table: Optional[str] = None,
+    path: Optional[str] = None,
+    binding: Optional[_Binding] = None,
+    validation: Optional[ValidationResult] = None,
+    status: Optional[ValidationResult] = None,
+    expectation_plan: Optional[Sequence[Mapping[str, Any]]] = None,
+) -> None:
+    tracer, span_kind = _resolve_tracer()
+    if tracer is None or span_kind is None:
+        return
+
+    operation = (operation or "run").strip().lower() or "run"
+    context = _merge_contexts(plan, pipeline_context)
+    resolved_contract_id = _resolve_contract_id(plan, contract_id)
+    resolved_contract_version = _resolve_contract_version(plan, contract_version)
+    resolved_dataset_id = _resolve_dataset_id(plan, dataset_id)
+    resolved_dataset_version = _resolve_dataset_version(plan, dataset_version)
+    resolved_format = _resolve_format(plan, dataset_format)
+    resolved_binding = _resolve_binding(plan, binding)
+    resolved_expectations = _resolve_expectation_plan(expectation_plan, validation)
+
+    span_name = f"{_TRACER_NAME}.{operation}"
+    with tracer.start_as_current_span(span_name, kind=span_kind.INTERNAL) as span:
+        span.set_attribute(f"{_ATTRIBUTE_PREFIX}.operation", operation)
+        if resolved_contract_id:
+            span.set_attribute(f"{_ATTRIBUTE_PREFIX}.contract.id", resolved_contract_id)
+        if resolved_contract_version:
+            span.set_attribute(
+                f"{_ATTRIBUTE_PREFIX}.contract.version", resolved_contract_version
+            )
+        if resolved_dataset_id:
+            span.set_attribute(f"{_ATTRIBUTE_PREFIX}.dataset.id", resolved_dataset_id)
+        if resolved_dataset_version:
+            span.set_attribute(
+                f"{_ATTRIBUTE_PREFIX}.dataset.version", resolved_dataset_version
+            )
+        if resolved_format:
+            span.set_attribute(f"{_ATTRIBUTE_PREFIX}.dataset.format", resolved_format)
+        if table:
+            span.set_attribute(f"{_ATTRIBUTE_PREFIX}.dataset.table", table)
+        if path:
+            span.set_attribute(f"{_ATTRIBUTE_PREFIX}.dataset.path", path)
+
+        binding_payload = _binding_payload(resolved_binding)
+        if binding_payload:
+            span.set_attribute(
+                f"{_ATTRIBUTE_PREFIX}.binding", _attribute_value(binding_payload)
+            )
+
+        flattened_context = _flatten_context(context)
+        for key, value in flattened_context.items():
+            span.set_attribute(f"{_ATTRIBUTE_PREFIX}.pipeline.{key}", value)
+
+        validation_result = status or validation
+        if validation_result is not None:
+            span.set_attribute(
+                f"{_ATTRIBUTE_PREFIX}.validation.status",
+                validation_result.status or "unknown",
+            )
+            span.set_attribute(
+                f"{_ATTRIBUTE_PREFIX}.validation.ok", bool(validation_result.ok)
+            )
+            if validation_result.reason:
+                span.set_attribute(
+                    f"{_ATTRIBUTE_PREFIX}.validation.reason",
+                    validation_result.reason,
+                )
+            span.add_event(
+                _VALIDATION_EVENT,
+                _validation_event_payload(validation_result),
+            )
+
+        if resolved_expectations:
+            span.add_event(
+                _EXPECTATION_EVENT,
+                {"plan": _attribute_value(_normalise_value(resolved_expectations))},
+            )
+
+
+__all__ = ["record_telemetry_span"]

--- a/packages/dc43-integrations/tests/test_open_telemetry.py
+++ b/packages/dc43-integrations/tests/test_open_telemetry.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Mapping
+
+import pytest
+
+from dc43_integrations.spark.io import (
+    GovernanceSparkReadRequest,
+    GovernanceSparkWriteRequest,
+    read_with_governance,
+    write_with_governance,
+)
+from dc43_integrations.spark import open_telemetry
+from dc43_service_clients.data_products import DataProductInputBinding, DataProductOutputBinding
+from dc43_service_clients.data_quality import ValidationResult
+from dc43_service_clients.governance import normalise_pipeline_context
+from dc43_service_clients.governance.models import (
+    GovernanceReadContext,
+    GovernanceWriteContext,
+    ResolvedReadPlan,
+    ResolvedWritePlan,
+)
+
+from .helpers.orders import build_orders_contract, materialise_orders
+
+
+class _RecordingSpan:
+    def __init__(self, name: str, kind: str | None) -> None:
+        self.name = name
+        self.kind = kind
+        self.attributes: dict[str, object] = {}
+        self.events: list[tuple[str, Mapping[str, object]]] = []
+
+    def __enter__(self) -> "_RecordingSpan":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - required by context protocol
+        return None
+
+    def set_attribute(self, key: str, value) -> None:
+        self.attributes[key] = value
+
+    def add_event(self, name: str, attributes: Mapping[str, object] | None = None) -> None:
+        payload = dict(attributes or {})
+        self.events.append((name, payload))
+
+
+class _RecordingTracer:
+    def __init__(self) -> None:
+        self.spans: list[_RecordingSpan] = []
+
+    def start_as_current_span(self, name: str, *, kind=None) -> _RecordingSpan:
+        span = _RecordingSpan(name, kind)
+        self.spans.append(span)
+        return span
+
+
+class _Resolver:
+    def __init__(self, tracer: _RecordingTracer) -> None:
+        self._tracer = tracer
+        self._span_kind = SimpleNamespace(INTERNAL="internal")
+
+    def __call__(self) -> tuple[_RecordingTracer, SimpleNamespace]:
+        return self._tracer, self._span_kind
+
+    def cache_clear(self) -> None:  # pragma: no cover - compatibility shim
+        return None
+
+
+class _Assessment:
+    def __init__(self, validation: ValidationResult) -> None:
+        self.status = validation
+        self.validation = validation
+        self.draft = None
+
+
+class _TelemetryGovernanceStub:
+    def __init__(
+        self,
+        *,
+        read_plan: ResolvedReadPlan | None = None,
+        write_plan: ResolvedWritePlan | None = None,
+    ) -> None:
+        self._read_plan = read_plan
+        self._write_plan = write_plan
+        self.read_activities: list[tuple[ResolvedReadPlan, _Assessment]] = []
+        self.write_activities: list[tuple[ResolvedWritePlan, _Assessment]] = []
+        self.expectation_plan: list[Mapping[str, object]] = []
+
+    def resolve_read_context(self, *, context: GovernanceReadContext) -> ResolvedReadPlan:  # type: ignore[override]
+        assert self._read_plan is not None
+        return self._read_plan
+
+    def resolve_write_context(self, *, context: GovernanceWriteContext) -> ResolvedWritePlan:  # type: ignore[override]
+        assert self._write_plan is not None
+        return self._write_plan
+
+    def describe_expectations(self, *, contract_id: str, contract_version: str):  # type: ignore[override]
+        return list(self.expectation_plan)
+
+    def evaluate_dataset(
+        self,
+        *,
+        contract_id: str,
+        contract_version: str,
+        dataset_id: str,
+        dataset_version: str,
+        validation: ValidationResult | None,
+        observations,
+        pipeline_context,
+        operation: str,
+        bump: str = "minor",
+        draft_on_violation: bool = False,
+    ) -> _Assessment:  # type: ignore[override]
+        payload = observations() if callable(observations) else observations
+        if validation is None:
+            validation = ValidationResult(
+                ok=True,
+                status="ok",
+                errors=[],
+                warnings=[],
+                metrics={},
+                schema={},
+            )
+        elif validation.status == "unknown":
+            validation.status = "ok"
+        assessment = _Assessment(validation)
+        assessment.payload = payload  # type: ignore[attr-defined]
+        return assessment
+
+    def evaluate_write_plan(
+        self,
+        *,
+        plan: ResolvedWritePlan,
+        validation: ValidationResult | None,
+        observations,
+    ) -> _Assessment:  # type: ignore[override]
+        payload = observations() if callable(observations) else observations
+        if validation is None:
+            validation = ValidationResult(
+                ok=True,
+                status="ok",
+                errors=[],
+                warnings=[],
+                metrics={},
+                schema={},
+            )
+        elif validation.status == "unknown":
+            validation.status = "ok"
+        assessment = _Assessment(validation)
+        assessment.payload = payload  # type: ignore[attr-defined]
+        return assessment
+
+    def register_read_activity(self, *, plan: ResolvedReadPlan, assessment: _Assessment) -> None:  # type: ignore[override]
+        self.read_activities.append((plan, assessment))
+
+    def register_write_activity(self, *, plan: ResolvedWritePlan, assessment: _Assessment) -> None:  # type: ignore[override]
+        self.write_activities.append((plan, assessment))
+
+
+@pytest.fixture
+def _patched_tracer(monkeypatch: pytest.MonkeyPatch) -> _RecordingTracer:
+    tracer = _RecordingTracer()
+    resolver = _Resolver(tracer)
+    open_telemetry._resolve_tracer.cache_clear()
+    monkeypatch.setattr(open_telemetry, "_resolve_tracer", resolver)
+    return tracer
+
+
+def test_open_telemetry_read_emits_span(
+    spark,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _patched_tracer: _RecordingTracer,
+) -> None:
+    tracer = _patched_tracer
+    dataset_path = materialise_orders(spark, tmp_path / "otel-orders")
+    contract = build_orders_contract(dataset_path)
+    binding = DataProductInputBinding(
+        data_product="Sales.Orders",
+        port_name="orders.raw",
+        data_product_version="1.0.0",
+    )
+    plan = ResolvedReadPlan(
+        contract=contract,
+        contract_id=contract.id,
+        contract_version=contract.version,
+        dataset_id="otel.orders",
+        dataset_version="2024-01-01",
+        dataset_format="delta",
+        input_binding=binding,
+        pipeline_context={"job_name": "orders-read-otel"},
+        bump="minor",
+        draft_on_violation=False,
+    )
+    governance = _TelemetryGovernanceStub(read_plan=plan)
+
+    monkeypatch.setenv("DC43_GOVERNANCE_PUBLICATION_MODE", "open_telemetry")
+    request = GovernanceSparkReadRequest(
+        context=GovernanceReadContext(contract={"contract_id": contract.id, "contract_version": contract.version}),
+        format="delta",
+        path=str(dataset_path),
+    )
+    request.context.pipeline_context = normalise_pipeline_context({"run_id": "otel-read"})
+
+    df, status = read_with_governance(
+        spark,
+        request,
+        governance_service=governance,
+        enforce=True,
+        auto_cast=True,
+        return_status=True,
+    )
+
+    assert df.count() == 2
+    assert status is not None and status.ok
+    assert not governance.read_activities, "register_read_activity should be skipped in open telemetry mode"
+    assert tracer.spans, "telemetry span should be recorded"
+    span = tracer.spans[-1]
+    assert span.name.endswith(".read")
+    assert span.attributes["dc43.governance.operation"] == "read"
+    assert span.attributes["dc43.governance.dataset.id"] == "otel.orders"
+    assert span.attributes["dc43.governance.pipeline.run_id"] == "otel-read"
+    assert any(name == "dc43.validation" for name, _ in span.events)
+
+
+def test_open_telemetry_write_emits_span(
+    spark,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _patched_tracer: _RecordingTracer,
+) -> None:
+    tracer = _patched_tracer
+    output_path = tmp_path / "otel-out"
+    contract = build_orders_contract(output_path)
+    binding = DataProductOutputBinding(
+        data_product="Sales.Orders",
+        port_name="orders.curated",
+    )
+    plan = ResolvedWritePlan(
+        contract=contract,
+        contract_id=contract.id,
+        contract_version=contract.version,
+        dataset_id="otel.orders.curated",
+        dataset_version="2024-01-02",
+        dataset_format="parquet",
+        output_binding=binding,
+        pipeline_context={"job_name": "orders-write-otel"},
+        bump="minor",
+        draft_on_violation=False,
+    )
+    governance = _TelemetryGovernanceStub(write_plan=plan)
+
+    df = spark.createDataFrame([(1, "EUR"), (2, "USD")], ["order_id", "currency"])
+    monkeypatch.setenv("DC43_GOVERNANCE_PUBLICATION_MODE", "open_telemetry")
+    request = GovernanceSparkWriteRequest(
+        context=GovernanceWriteContext(contract={"contract_id": contract.id, "contract_version": contract.version}),
+        format="parquet",
+        path=str(output_path),
+    )
+    request.context.pipeline_context = normalise_pipeline_context({"run_id": "otel-write"})
+
+    result, status = write_with_governance(
+        df=df,
+        request=request,
+        governance_service=governance,
+        enforce=True,
+        auto_cast=True,
+        return_status=True,
+    )
+
+    assert result.ok
+    assert status is None or status.ok
+    assert not governance.write_activities, "register_write_activity should be skipped in open telemetry mode"
+    assert tracer.spans, "telemetry span should be recorded"
+    span = tracer.spans[-1]
+    assert span.name.endswith(".write")
+    assert span.attributes["dc43.governance.operation"] == "write"
+    assert span.attributes["dc43.governance.dataset.id"] == "otel.orders.curated"
+    assert span.attributes["dc43.governance.pipeline.run_id"] == "otel-write"
+    assert any(name == "dc43.validation" for name, _ in span.events)


### PR DESCRIPTION
## Summary
- extend the governance and integration component documentation to describe the Open Data Lineage and OpenTelemetry publication paths and update the diagrams accordingly
- document how to configure the publication mode through environment variables, runtime configuration keys, and integration request overrides

## Testing
- pytest -q *(fails: missing optional `openlineage` dependency)*

------
https://chatgpt.com/codex/tasks/task_b_690c9f228430832e99ca29235cb9511d