### PR TITLE
Add dc43-core publish step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,6 +289,13 @@ jobs:
           password: ${{ secrets.PYPI_TOKEN }}
           packages-dir: release-artifacts/dc43
 
+      - name: Publish dc43-core to PyPI
+        if: needs.determine.outputs.dc43_core_tag != ''
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}
+          packages-dir: release-artifacts/dc43-core
+
       - name: Publish dc43-service-clients to PyPI
         if: needs.determine.outputs.service_clients_tag != ''
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- add the missing PyPI publish step for the dc43-core package in the release workflow

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691491b0cfbc832ea005cb920bbbd09a)