### PR TITLE
Fix schema inference for delta governance activity writes

### DIFF
--- a/packages/dc43-service-backends/CHANGELOG.md
+++ b/packages/dc43-service-backends/CHANGELOG.md
@@ -34,6 +34,9 @@
   registration.
 
 ### Fixed
+- Delta governance stores now supply explicit schemas when persisting status,
+  link, and activity records so Spark no longer fails to infer field types when
+  optional values (such as lineage payloads) are null.
 - Hardened the governance status matrix endpoint so mixed payload types (for
   example, pre-encoded validation dictionaries) no longer trigger 500 errors
   when UI clients request batched status snapshots.

--- a/packages/dc43-service-backends/src/dc43_service_backends/governance/backend/stores/delta.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/governance/backend/stores/delta.py
@@ -293,7 +293,7 @@ class DeltaGovernanceStore(GovernanceStore):
                 }
             ),
         }
-        df = self._spark.createDataFrame([payload])
+        df = self._spark.createDataFrame([payload], schema=self._STATUS_SCHEMA)
         folder = self._table_path("status") if self._base_path else None
         self._write(df, table=self._status_table, folder=folder)
 
@@ -392,7 +392,7 @@ class DeltaGovernanceStore(GovernanceStore):
             "contract_version": contract_version,
             "linked_at": self._now(),
         }
-        df = self._spark.createDataFrame([payload])
+        df = self._spark.createDataFrame([payload], schema=self._LINK_SCHEMA)
         folder = self._table_path("links") if self._base_path else None
         self._write(df, table=self._link_table, folder=folder)
 
@@ -441,7 +441,7 @@ class DeltaGovernanceStore(GovernanceStore):
             "payload": json.dumps(dict(event)),
             "lineage_event": json.dumps(dict(lineage_event)) if lineage_event is not None else None,
         }
-        df = self._spark.createDataFrame([payload])
+        df = self._spark.createDataFrame([payload], schema=self._ACTIVITY_SCHEMA)
         folder = self._table_path("activity") if self._base_path else None
         self._write(df, table=self._activity_table, folder=folder)
 


### PR DESCRIPTION
## Summary
- ensure Delta governance status, link, and activity writes use explicit schemas so Spark no longer needs to infer nullable fields
- document the fix in the service backends changelog

## Testing
- `pytest -q packages/dc43-service-backends/tests`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691621600774832eb354cce3870d2837)