### PR TITLE
Stabilize generated dataset timestamps

### DIFF
--- a/packages/dc43-integrations/CHANGELOG.md
+++ b/packages/dc43-integrations/CHANGELOG.md
@@ -90,4 +90,7 @@
 - Governance write requests now retain locator-derived dataset identifiers when
   linking contracts, so upgrading a contract no longer drops the existing
   dataset association in local governance tests.
+- `generate_contract_dataset` now uses a deterministic timestamp range instead
+  of depending on the current clock so repeated calls with the same seed produce
+  identical rows.
 

--- a/packages/dc43-integrations/src/dc43_integrations/testing/datasets.py
+++ b/packages/dc43-integrations/src/dc43_integrations/testing/datasets.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import Callable, Iterable, List, Mapping, Sequence, Tuple
 
@@ -112,12 +113,19 @@ def _boolean_generator(fake: Faker, _: SchemaProperty) -> bool:
     return bool(fake.pybool())
 
 
+_REFERENCE_DATETIME = datetime(2025, 1, 1, 0, 0, 0)
+
+
 def _date_generator(fake: Faker, _: SchemaProperty):
-    return fake.date_between(start_date="-30d", end_date="today")
+    start = (_REFERENCE_DATETIME - timedelta(days=30)).date()
+    end = _REFERENCE_DATETIME.date()
+    return fake.date_between(start_date=start, end_date=end)
 
 
 def _timestamp_generator(fake: Faker, _: SchemaProperty):
-    return fake.date_time_between(start_date="-30d", end_date="now")
+    start = _REFERENCE_DATETIME - timedelta(days=30)
+    end = _REFERENCE_DATETIME
+    return fake.date_time_between_dates(datetime_start=start, datetime_end=end)
 
 
 def _binary_generator(fake: Faker, _: SchemaProperty) -> bytes:


### PR DESCRIPTION
## Summary
- make the Faker-based date and timestamp generators use a deterministic 30-day window anchored to a fixed reference date so seeded runs stay identical
- document the behaviour change in the dc43-integrations changelog

## Testing
- pytest tests/test_testing_dataset.py -k generate_contract_dataset_respects_seed


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69170697b58c832eaf3f50c4ae497c42)