### PR TITLE
Fix Delta governance status duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,9 @@
 - Hardened the Delta-backed stores to ignore empty version markers and treat
   ``draft`` suffixes as ordered pre-releases so historical placeholder rows no
   longer prevent ``latest`` resolution.
+- Delta governance stores now purge previous status rows before appending the
+  latest result so Databricks tables (and the contracts UI) no longer show the
+  same dataset version multiple times in the compatibility matrix.
 - Introduced governance-first Spark IO wrappers and updated documentation/tests
   so pipelines can rely on a single governance client instead of wiring
   contract/data-quality services manually.

--- a/packages/dc43-service-backends/CHANGELOG.md
+++ b/packages/dc43-service-backends/CHANGELOG.md
@@ -71,4 +71,7 @@
 - Governance read registration now mirrors that behaviour for pinned inputs so
   consumers that attach lineage metadata or source references don't create new
   drafts when they intentionally target an existing release.
+- Delta governance stores now delete existing status rows for a dataset/version
+  before recording a new verdict, preventing duplicate compatibility entries in
+  Databricks tables and in the contracts application history views.
 


### PR DESCRIPTION
## Summary
- purge existing Delta status rows before persisting a new governance verdict so a dataset version only records one status entry
- document the fix in the root and service-backend changelogs
- exercise the new behaviour with Delta store unit tests

## Testing
- pytest packages/dc43-service-backends/tests/test_governance_delta_store.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69177b89bc30832e876f4252c7b029b4)