### PR TITLE
Fix governance metric extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,10 @@
 - Governance write telemetry spans now prefer dataset identifiers and versions
   from resolved governance plans, keeping OpenTelemetry attributes aligned with
   pipeline metadata and avoiding contract-id fallbacks in tests.
+- Governance stores now extract metric observations from validation payload
+  details when the ``metrics`` attribute is empty, ensuring `dq_metrics`
+  tables (and the contracts UI) show dataset measurements recorded by remote
+  backends.
 - Governance write helpers once again preserve dataset links derived from
   dataset locators, so upgrading a contract keeps previously registered dataset
   references intact while telemetry continues to use governance plan metadata.

--- a/packages/dc43-service-backends/CHANGELOG.md
+++ b/packages/dc43-service-backends/CHANGELOG.md
@@ -40,6 +40,10 @@
 - Delta governance stores now supply explicit schemas when persisting status,
   link, and activity records so Spark no longer fails to infer field types when
   optional values (such as lineage payloads) are null.
+- Governance stores now pull metric observations from validation detail
+  payloads when the explicit ``metrics`` attribute is empty so SQL/Delta/HTTP
+  backends continue populating `dq_metrics` tables even when upstream
+  validations serialise observations only inside `dq_status` rows.
 - Hardened the governance status matrix endpoint so mixed payload types (for
   example, pre-encoded validation dictionaries) no longer trigger 500 errors
   when UI clients request batched status snapshots.

--- a/packages/dc43-service-backends/src/dc43_service_backends/governance/backend/stores/_metrics.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/governance/backend/stores/_metrics.py
@@ -1,0 +1,32 @@
+"""Helpers for normalising metrics stored with validation results."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from dc43_service_clients.data_quality import ValidationResult
+
+
+def extract_metrics(status: ValidationResult | None) -> dict[str, Any]:
+    """Return a serialisable metrics mapping for ``status``.
+
+    Some validation providers only attach metric observations inside the
+    :pyattr:`ValidationResult.details` payload instead of the ``metrics``
+    attribute. The governance stores expect explicit values to populate the
+    ``dq_metrics`` tables, so we merge both sources to avoid dropping data.
+    """
+
+    if status is None:
+        return {}
+
+    metrics: dict[str, Any] = {}
+    details = status.details
+    detail_metrics = details.get("metrics") if isinstance(details, Mapping) else None
+    if isinstance(detail_metrics, Mapping):
+        metrics.update(detail_metrics)
+    metrics.update(status.metrics or {})
+    return metrics
+
+
+__all__ = ["extract_metrics"]
+

--- a/packages/dc43-service-backends/src/dc43_service_backends/governance/backend/stores/delta.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/governance/backend/stores/delta.py
@@ -12,6 +12,7 @@ from typing import Mapping, Optional, Sequence, TYPE_CHECKING
 
 from dc43_service_clients.data_quality import ValidationResult, coerce_details
 
+from ._metrics import extract_metrics
 from .interface import GovernanceStore
 
 
@@ -334,6 +335,7 @@ class DeltaGovernanceStore(GovernanceStore):
             table=self._status_table,
             folder=folder,
         )
+        details_payload = status.details if status else {}
         payload = {
             "dataset_id": dataset_id,
             "dataset_version": dataset_version,
@@ -345,7 +347,7 @@ class DeltaGovernanceStore(GovernanceStore):
                 {
                     "status": status.status if status else "unknown",
                     "reason": status.reason if status else None,
-                    "details": status.details if status else {},
+                    "details": details_payload,
                     "contract_id": contract_id,
                     "contract_version": contract_version,
                     "dataset_id": dataset_id,
@@ -360,8 +362,9 @@ class DeltaGovernanceStore(GovernanceStore):
         if status is None:
             return
 
+        metrics_map = extract_metrics(status)
         metrics_records = []
-        for key, value in (status.metrics or {}).items():
+        for key, value in metrics_map.items():
             numeric_value: float | None = None
             if isinstance(value, Number):
                 numeric_value = float(value)

--- a/packages/dc43-service-backends/src/dc43_service_backends/governance/backend/stores/filesystem.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/governance/backend/stores/filesystem.py
@@ -12,6 +12,7 @@ from typing import Any, Mapping, Optional, Sequence
 
 from dc43_service_clients.data_quality import ValidationResult, coerce_details
 
+from ._metrics import extract_metrics
 from .interface import GovernanceStore
 
 
@@ -112,14 +113,15 @@ class FilesystemGovernanceStore(GovernanceStore):
         )
         self._write_json(path, asdict(record))
 
-        if status.metrics:
+        metrics_map = extract_metrics(status)
+        if metrics_map:
             self._append_metrics(
                 contract_id=contract_id,
                 contract_version=contract_version,
                 dataset_id=dataset_id,
                 dataset_version=dataset_version,
                 recorded_at=record.recorded_at,
-                metrics=status.metrics,
+                metrics=metrics_map,
             )
 
     def load_status(

--- a/packages/dc43-service-backends/src/dc43_service_backends/governance/backend/stores/http.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/governance/backend/stores/http.py
@@ -6,6 +6,7 @@ from typing import Mapping, Optional, Sequence
 
 from dc43_service_clients.data_quality import ValidationResult, coerce_details
 
+from ._metrics import extract_metrics
 from .interface import GovernanceStore
 
 try:  # pragma: no cover - optional dependency guard
@@ -76,8 +77,9 @@ class HttpGovernanceStore(GovernanceStore):
                 "reason": status.reason,
                 "details": status.details,
             }
-            if status.metrics:
-                payload["metrics"] = dict(status.metrics)
+            metrics_map = extract_metrics(status)
+            if metrics_map:
+                payload["metrics"] = metrics_map
         response = self._client.request(
             "DELETE" if status is None else "PUT",
             self._status_url(dataset_id, dataset_version),

--- a/packages/dc43-service-backends/src/dc43_service_backends/governance/backend/stores/memory.py
+++ b/packages/dc43-service-backends/src/dc43_service_backends/governance/backend/stores/memory.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Mapping, MutableMapping, Optional, Sequence
 
 from dc43_service_clients.data_quality import ValidationResult
 
+from ._metrics import extract_metrics
 from .interface import GovernanceStore
 
 
@@ -43,14 +44,15 @@ class InMemoryGovernanceStore(GovernanceStore):
 
         recorded_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
         self._status_cache[key] = status
-        if status.metrics:
+        metrics_map = extract_metrics(status)
+        if metrics_map:
             self._record_metrics(
                 contract_id=contract_id,
                 contract_version=contract_version,
                 dataset_id=dataset_id,
                 dataset_version=dataset_version,
                 recorded_at=recorded_at,
-                metrics=status.metrics,
+                metrics=metrics_map,
             )
 
     def load_status(


### PR DESCRIPTION
## Summary
- add a shared helper that merges validation metrics from both the ValidationResult.metrics field and any metrics embedded in the details payload
- update the SQL, Delta, filesystem, memory, and HTTP governance stores to rely on the helper so dq_metrics tables are populated even when upstream payloads only include metrics in dq_status
- cover the behaviour with new SQL and Delta store tests and document the fix in the changelogs

## Testing
- `pytest -q`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691acbbc8488832eb9522cdef1ad34d0)