### PR TITLE
fix streaming delta metadata collision

### DIFF
--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/base.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/base.py
@@ -761,7 +761,7 @@ class BaseWriteExecutor:
                 expectation_plan=expectation_plan,
                 governance_service=governance_service,
                 dataset_id=dataset_id,
-                dataset_version=preflight_version,
+                dataset_version=dataset_version,
                 enforce=enforce,
                 checkpoint_location=obs_checkpoint,
                 intervention=streaming_intervention_strategy,

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/base.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/base.py
@@ -876,6 +876,23 @@ def _execute_write_request(
         if request.writer_modifier: writer = request.writer_modifier(writer)
         
         if governance_client and request.contract and request.dataset_id:
+            # Pre-create streaming sink to avoid TABLE_OR_VIEW_NOT_FOUND during property sync
+            try:
+                spark = getattr(df, "sparkSession", getattr(getattr(df, "sql_ctx", None), "sparkSession", None))
+                if spark is not None:
+                    empty_df = spark.createDataFrame([], getattr(df, "schema", None))
+                    tgt_fmt = request.format or "delta"
+                    if request.table:
+                        try:
+                            if not spark.catalog.tableExists(request.table):
+                                empty_df.write.format(tgt_fmt).mode("ignore").saveAsTable(request.table)
+                        except Exception:
+                            empty_df.write.format(tgt_fmt).mode("ignore").saveAsTable(request.table)
+                    elif not request.table and request.path and tgt_fmt.lower() == "delta":
+                        empty_df.write.format("delta").mode("ignore").save(request.path)
+            except Exception:
+                pass
+
             try:
                 governance_client.link_dataset_contract(
                     dataset_id=request.dataset_id,

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/base.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/base.py
@@ -860,30 +860,6 @@ def _execute_write_request(
         except RuntimeError:
             pass
 
-    if request.streaming:
-        writer = df.writeStream.outputMode(request.mode or "append")
-        if request.format: writer = writer.format(request.format)
-        if request.options: writer = writer.options(**request.options)
-        if request.writer_modifier: writer = request.writer_modifier(writer)
-        query = writer.toTable(request.table) if request.table else writer.start(request.path)
-        streaming_handles.append(query)
-        
-        if observation_writer is not None and not observation_writer.active:
-            metrics_mode = request.mode or "append"
-            metrics_query = observation_writer.start(
-                df,
-                output_mode=metrics_mode,
-                modifier=request.observation_writer_modifier,
-            )
-            streaming_handles.append(metrics_query)
-            observation_writer.watch_sink_query(query)
-    else:
-        writer = df.write.mode(request.mode)
-        if request.format: writer = writer.format(request.format)
-        if request.options: writer = writer.options(**request.options)
-        if request.writer_modifier: writer = request.writer_modifier(writer)
-        if request.table: writer.saveAsTable(request.table)
-        else: writer.save(request.path)
     if governance_client and request.contract and request.dataset_id:
         # Pre-create streaming sink to avoid TABLE_OR_VIEW_NOT_FOUND during property sync
         if request.streaming:
@@ -922,6 +898,31 @@ def _execute_write_request(
                 "Failed to link dataset %s to contract %s",
                 request.dataset_id, request.contract.id
             )
+
+    if request.streaming:
+        writer = df.writeStream.outputMode(request.mode or "append")
+        if request.format: writer = writer.format(request.format)
+        if request.options: writer = writer.options(**request.options)
+        if request.writer_modifier: writer = request.writer_modifier(writer)
+        query = writer.toTable(request.table) if request.table else writer.start(request.path)
+        streaming_handles.append(query)
+        
+        if observation_writer is not None and not observation_writer.active:
+            metrics_mode = request.mode or "append"
+            metrics_query = observation_writer.start(
+                df,
+                output_mode=metrics_mode,
+                modifier=request.observation_writer_modifier,
+            )
+            streaming_handles.append(metrics_query)
+            observation_writer.watch_sink_query(query)
+    else:
+        writer = df.write.mode(request.mode)
+        if request.format: writer = writer.format(request.format)
+        if request.options: writer = writer.options(**request.options)
+        if request.writer_modifier: writer = request.writer_modifier(writer)
+        if request.table: writer.saveAsTable(request.table)
+        else: writer.save(request.path)
 
     return None, validation, streaming_handles
 

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/base.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/base.py
@@ -761,7 +761,7 @@ class BaseWriteExecutor:
                 expectation_plan=expectation_plan,
                 governance_service=governance_service,
                 dataset_id=dataset_id,
-                dataset_version=dataset_version,
+                dataset_version=preflight_version,
                 enforce=enforce,
                 checkpoint_location=obs_checkpoint,
                 intervention=streaming_intervention_strategy,

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/base.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/base.py
@@ -716,9 +716,6 @@ class BaseWriteExecutor:
         if streaming_active and not dataset_version:
             dataset_version = _timestamp()
 
-        # Render timestamps once for the run, but leave batch_id dynamic if present
-        dataset_version = resolve_dataset_version(dataset_version, batch_id=None)
-
         governance_client = _as_governance_service(governance_service)
         result = ValidationResult(ok=True, errors=[], warnings=[], metrics={})
         assessment: Optional[QualityAssessment] = None
@@ -807,10 +804,6 @@ class BaseWriteExecutor:
         violation_plan = strategy.plan(context)
         requests = ([violation_plan.primary] if violation_plan.primary else []) + list(violation_plan.additional)
         
-        if streaming_active:
-            if governance_plan and governance_client and assessment and not self._skip_governance_activity:
-                governance_client.register_write_activity(plan=governance_plan, assessment=assessment)
-
         streaming_queries = []
         primary_status = None
         for i, req in enumerate(requests):
@@ -822,10 +815,8 @@ class BaseWriteExecutor:
             streaming_queries.extend(handles)
             if i == 0: primary_status = status
 
-        if not streaming_active:
-            if governance_plan and governance_client and assessment and not self._skip_governance_activity:
-                governance_client.register_write_activity(plan=governance_plan, assessment=assessment)
-
+        if governance_plan and governance_client and assessment and not self._skip_governance_activity:
+            governance_client.register_write_activity(plan=governance_plan, assessment=assessment)
         
         if self.open_data_lineage_only and governance_client:
             event = build_lineage_run_event(operation="write", plan=governance_plan, pipeline_context=pipeline_context, contract_id=contract_id, contract_version=expected_contract_version, dataset_id=dataset_id, dataset_version=preflight_version, validation=result, status=primary_status, expectation_plan=expectation_plan)
@@ -874,41 +865,6 @@ def _execute_write_request(
         if request.format: writer = writer.format(request.format)
         if request.options: writer = writer.options(**request.options)
         if request.writer_modifier: writer = request.writer_modifier(writer)
-        
-        if governance_client and request.contract and request.dataset_id:
-            # Pre-create streaming sink to avoid TABLE_OR_VIEW_NOT_FOUND during property sync
-            try:
-                spark = getattr(df, "sparkSession", getattr(getattr(df, "sql_ctx", None), "sparkSession", None))
-                if spark is not None:
-                    empty_df = spark.createDataFrame([], getattr(df, "schema", None))
-                    tgt_fmt = request.format or "delta"
-                    if request.table:
-                        try:
-                            if not spark.catalog.tableExists(request.table):
-                                empty_df.write.format(tgt_fmt).mode("append").saveAsTable(request.table)
-                        except Exception:
-                            empty_df.write.format(tgt_fmt).mode("append").saveAsTable(request.table)
-                    elif not request.table and request.path and tgt_fmt.lower() == "delta":
-                        empty_df.write.format("delta").mode("append").save(request.path)
-            except Exception as e:
-                import logging
-                logging.getLogger(__name__).warning("Failed to pre-create streaming sink: %s", e)
-
-            try:
-                governance_client.link_dataset_contract(
-                    dataset_id=request.dataset_id,
-                    dataset_version=request.dataset_version or "",
-                    contract_id=request.contract.id,
-                    contract_version=request.contract.version,
-                )
-            except Exception:
-                # Defensive logging for linkage failure
-                import logging
-                logging.getLogger(__name__).exception(
-                    "Failed to link dataset %s to contract %s",
-                    request.dataset_id, request.contract.id
-                )
-
         query = writer.toTable(request.table) if request.table else writer.start(request.path)
         streaming_handles.append(query)
         
@@ -928,22 +884,44 @@ def _execute_write_request(
         if request.writer_modifier: writer = request.writer_modifier(writer)
         if request.table: writer.saveAsTable(request.table)
         else: writer.save(request.path)
-        
-        if governance_client and request.contract and request.dataset_id:
+    if governance_client and request.contract and request.dataset_id:
+        # Pre-create streaming sink to avoid TABLE_OR_VIEW_NOT_FOUND during property sync
+        if request.streaming:
             try:
-                governance_client.link_dataset_contract(
-                    dataset_id=request.dataset_id,
-                    dataset_version=request.dataset_version or "",
-                    contract_id=request.contract.id,
-                    contract_version=request.contract.version,
-                )
-            except Exception:
-                # Defensive logging for linkage failure
+                # Need spark session to evaluate options and execute CREATE TABLE
+                spark = getattr(df, "sparkSession", getattr(getattr(df, "sql_ctx", None), "sparkSession", None))
+                if spark is not None:
+                    tgt_fmt = request.format or "delta"
+                    if tgt_fmt.lower() == "delta":
+                        if request.table:
+                            try:
+                                if not spark.catalog.tableExists(request.table):
+                                    fields_def = ", ".join([f"`{field.name}` {field.dataType.simpleString()}" for field in getattr(df, "schema", [])])
+                                    spark.sql(f"CREATE TABLE IF NOT EXISTS {request.table} ({fields_def}) USING {tgt_fmt}")
+                            except Exception:
+                                empty_df = spark.createDataFrame([], getattr(df, "schema", None))
+                                empty_df.write.format(tgt_fmt).mode("append").saveAsTable(request.table)
+                        elif request.path:
+                            empty_df = spark.createDataFrame([], getattr(df, "schema", None))
+                            empty_df.write.format(tgt_fmt).mode("append").save(request.path)
+            except Exception as e:
                 import logging
-                logging.getLogger(__name__).exception(
-                    "Failed to link dataset %s to contract %s",
-                    request.dataset_id, request.contract.id
-                )
+                logging.getLogger(__name__).warning("Failed to pre-create streaming sink: %s", e)
+        
+        try:
+            governance_client.link_dataset_contract(
+                dataset_id=request.dataset_id,
+                dataset_version=request.dataset_version or "",
+                contract_id=request.contract.id,
+                contract_version=request.contract.version,
+            )
+        except Exception:
+            # Defensive logging for linkage failure
+            import logging
+            logging.getLogger(__name__).exception(
+                "Failed to link dataset %s to contract %s",
+                request.dataset_id, request.contract.id
+            )
 
     return None, validation, streaming_handles
 

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/base.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/base.py
@@ -804,6 +804,10 @@ class BaseWriteExecutor:
         violation_plan = strategy.plan(context)
         requests = ([violation_plan.primary] if violation_plan.primary else []) + list(violation_plan.additional)
         
+        if streaming_active:
+            if governance_plan and governance_client and assessment and not self._skip_governance_activity:
+                governance_client.register_write_activity(plan=governance_plan, assessment=assessment)
+
         streaming_queries = []
         primary_status = None
         for i, req in enumerate(requests):
@@ -815,8 +819,10 @@ class BaseWriteExecutor:
             streaming_queries.extend(handles)
             if i == 0: primary_status = status
 
-        if governance_plan and governance_client and assessment and not self._skip_governance_activity:
-            governance_client.register_write_activity(plan=governance_plan, assessment=assessment)
+        if not streaming_active:
+            if governance_plan and governance_client and assessment and not self._skip_governance_activity:
+                governance_client.register_write_activity(plan=governance_plan, assessment=assessment)
+
         
         if self.open_data_lineage_only and governance_client:
             event = build_lineage_run_event(operation="write", plan=governance_plan, pipeline_context=pipeline_context, contract_id=contract_id, contract_version=expected_contract_version, dataset_id=dataset_id, dataset_version=preflight_version, validation=result, status=primary_status, expectation_plan=expectation_plan)
@@ -865,6 +871,23 @@ def _execute_write_request(
         if request.format: writer = writer.format(request.format)
         if request.options: writer = writer.options(**request.options)
         if request.writer_modifier: writer = request.writer_modifier(writer)
+        
+        if governance_client and request.contract and request.dataset_id:
+            try:
+                governance_client.link_dataset_contract(
+                    dataset_id=request.dataset_id,
+                    dataset_version=request.dataset_version or "",
+                    contract_id=request.contract.id,
+                    contract_version=request.contract.version,
+                )
+            except Exception:
+                # Defensive logging for linkage failure
+                import logging
+                logging.getLogger(__name__).exception(
+                    "Failed to link dataset %s to contract %s",
+                    request.dataset_id, request.contract.id
+                )
+
         query = writer.toTable(request.table) if request.table else writer.start(request.path)
         streaming_handles.append(query)
         
@@ -884,21 +907,22 @@ def _execute_write_request(
         if request.writer_modifier: writer = request.writer_modifier(writer)
         if request.table: writer.saveAsTable(request.table)
         else: writer.save(request.path)
-    if governance_client and request.contract and request.dataset_id:
-        try:
-            governance_client.link_dataset_contract(
-                dataset_id=request.dataset_id,
-                dataset_version=request.dataset_version or "",
-                contract_id=request.contract.id,
-                contract_version=request.contract.version,
-            )
-        except Exception:
-            # Defensive logging for linkage failure
-            import logging
-            logging.getLogger(__name__).exception(
-                "Failed to link dataset %s to contract %s",
-                request.dataset_id, request.contract.id
-            )
+        
+        if governance_client and request.contract and request.dataset_id:
+            try:
+                governance_client.link_dataset_contract(
+                    dataset_id=request.dataset_id,
+                    dataset_version=request.dataset_version or "",
+                    contract_id=request.contract.id,
+                    contract_version=request.contract.version,
+                )
+            except Exception:
+                # Defensive logging for linkage failure
+                import logging
+                logging.getLogger(__name__).exception(
+                    "Failed to link dataset %s to contract %s",
+                    request.dataset_id, request.contract.id
+                )
 
     return None, validation, streaming_handles
 

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/base.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/base.py
@@ -885,13 +885,14 @@ def _execute_write_request(
                     if request.table:
                         try:
                             if not spark.catalog.tableExists(request.table):
-                                empty_df.write.format(tgt_fmt).mode("ignore").saveAsTable(request.table)
+                                empty_df.write.format(tgt_fmt).mode("append").saveAsTable(request.table)
                         except Exception:
-                            empty_df.write.format(tgt_fmt).mode("ignore").saveAsTable(request.table)
+                            empty_df.write.format(tgt_fmt).mode("append").saveAsTable(request.table)
                     elif not request.table and request.path and tgt_fmt.lower() == "delta":
-                        empty_df.write.format("delta").mode("ignore").save(request.path)
-            except Exception:
-                pass
+                        empty_df.write.format("delta").mode("append").save(request.path)
+            except Exception as e:
+                import logging
+                logging.getLogger(__name__).warning("Failed to pre-create streaming sink: %s", e)
 
             try:
                 governance_client.link_dataset_contract(

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/base.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/base.py
@@ -716,6 +716,9 @@ class BaseWriteExecutor:
         if streaming_active and not dataset_version:
             dataset_version = _timestamp()
 
+        # Render timestamps once for the run, but leave batch_id dynamic if present
+        dataset_version = resolve_dataset_version(dataset_version, batch_id=None)
+
         governance_client = _as_governance_service(governance_service)
         result = ValidationResult(ok=True, errors=[], warnings=[], metrics={})
         assessment: Optional[QualityAssessment] = None
@@ -761,7 +764,7 @@ class BaseWriteExecutor:
                 expectation_plan=expectation_plan,
                 governance_service=governance_service,
                 dataset_id=dataset_id,
-                dataset_version=preflight_version,
+                dataset_version=dataset_version,
                 enforce=enforce,
                 checkpoint_location=obs_checkpoint,
                 intervention=streaming_intervention_strategy,

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/common.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/common.py
@@ -43,7 +43,7 @@ PipelineContextLike = Union[
 
 def resolve_dataset_version(
     version_template: Optional[str],
-    batch_id: Union[int, str, None] = "init",
+    batch_id: Union[int, str] = "init",
     timestamp: Optional[datetime] = None,
 ) -> str:
     """Resolve a dynamic dataset version template with execution metrics."""
@@ -53,13 +53,14 @@ def resolve_dataset_version(
         return version_template
 
     ts = timestamp or datetime.now(timezone.utc)
-    res = version_template.replace("{timestamp}", ts.strftime("%Y%m%d%H%M%S"))
-    res = res.replace("{unix_timestamp}", str(int(ts.timestamp())))
-    
-    if batch_id is not None:
-        res = res.replace("{batch_id}", str(batch_id))
-        
-    return res
+    try:
+        return version_template.format(
+            batch_id=batch_id,
+            timestamp=ts.strftime("%Y%m%d%H%M%S"),
+            unix_timestamp=int(ts.timestamp()),
+        )
+    except KeyError:
+        return version_template
 
 
 @dataclass(slots=True)

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/common.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/common.py
@@ -43,7 +43,7 @@ PipelineContextLike = Union[
 
 def resolve_dataset_version(
     version_template: Optional[str],
-    batch_id: Union[int, str] = "init",
+    batch_id: Union[int, str, None] = "init",
     timestamp: Optional[datetime] = None,
 ) -> str:
     """Resolve a dynamic dataset version template with execution metrics."""
@@ -53,14 +53,13 @@ def resolve_dataset_version(
         return version_template
 
     ts = timestamp or datetime.now(timezone.utc)
-    try:
-        return version_template.format(
-            batch_id=batch_id,
-            timestamp=ts.strftime("%Y%m%d%H%M%S"),
-            unix_timestamp=int(ts.timestamp()),
-        )
-    except KeyError:
-        return version_template
+    res = version_template.replace("{timestamp}", ts.strftime("%Y%m%d%H%M%S"))
+    res = res.replace("{unix_timestamp}", str(int(ts.timestamp())))
+    
+    if batch_id is not None:
+        res = res.replace("{batch_id}", str(batch_id))
+        
+    return res
 
 
 @dataclass(slots=True)

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
@@ -168,7 +168,14 @@ class StreamingObservationWriter:
             client = getattr(gov, "_client", None)
             if client is not None and hasattr(client, "headers"):
                 state["_gov_headers"] = dict(client.headers)
-                
+        elif gov is not None and type(gov).__name__ == "LocalGovernanceServiceBackend":
+            import os
+            # Capture relevant environment variables to re-bootstrap the local backend on the worker
+            state["_gov_env"] = {
+                k: v for k, v in os.environ.items() 
+                if k.startswith("DC43_") or k.startswith("DATABRICKS_")
+            }
+
         # Drop governance_service to prevent httpx weakref PicklingError on Spark Connect.
         # Fallback evaluation will be used in the worker if reconstruction fails.
         state['governance_service'] = None
@@ -199,6 +206,27 @@ class StreamingObservationWriter:
                     base_url=base_url,
                     headers=headers,
                 )
+            except Exception:
+                pass
+
+        gov_env = state.get("_gov_env")
+        if gov_env is not None and self.governance_service is None:
+            try:
+                import os
+                # Temporarily inject environment variables needed for configuration
+                original_env = os.environ.copy()
+                os.environ.update(gov_env)
+                
+                from dc43_service_backends.config import load_config
+                from dc43_service_backends.bootstrap import build_backends
+                
+                config = load_config()
+                suite = build_backends(config)
+                self.governance_service = suite.governance
+                
+                # Restore original environment
+                os.environ.clear()
+                os.environ.update(original_env)
             except Exception:
                 pass
 

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
@@ -326,12 +326,19 @@ class StreamingObservationWriter:
         timestamp = datetime.now(timezone.utc)
         effective_version = resolve_dataset_version(self.dataset_version, batch_id, timestamp)
         
-        schema, metrics = collect_observations(
-            batch_df,
-            self.contract,
-            expectations=self.expectation_plan,
-            collect_metrics=True,
-        )
+        logger.info(f"DC43: Starting to process streaming batch {batch_id} for dataset {self.dataset_id}@{effective_version}")
+        
+        try:
+            schema, metrics = collect_observations(
+                batch_df,
+                self.contract,
+                expectations=self.expectation_plan,
+                collect_metrics=True,
+            )
+            logger.info(f"DC43: Extracted schema and metrics for batch {batch_id}: {metrics}")
+        except Exception as e:
+            logger.exception(f"DC43: Failed to collect observations for batch {batch_id}: {e}")
+            schema, metrics = None, {}
         
         row_count = metrics.get("row_count")
         if isinstance(row_count, (int, float)) and row_count <= 0:
@@ -368,6 +375,7 @@ class StreamingObservationWriter:
         result = None
         if self.governance_service is not None:
             try:
+                logger.info(f"DC43: Using governance service '{type(self.governance_service).__name__}' to evaluate batch {batch_id}")
                 assessment = self.governance_service.evaluate_dataset(
                     contract_id=cid,
                     contract_version=cver,
@@ -380,14 +388,16 @@ class StreamingObservationWriter:
                 )
                 result = assessment.validation or assessment.status
                 logger.info(
-                    "Successfully evaluated streaming batch %s (effective_version=%s) on governance service. Got %d errors, %d metrics",
+                    "DC43: Successfully evaluated streaming batch %s (effective_version=%s) on governance service. Got %d errors, %d metrics",
                     batch_id, effective_version, len(result.errors if result else []), len(result.metrics if result else {})
                 )
             except Exception as e:
-                logger.exception("Streaming observation service evaluation failed, falling back to offline:")
+                logger.exception(f"DC43: Streaming observation service evaluation failed for batch {batch_id}, falling back to offline: {e}")
                 
         if result is None:
+            logger.info(f"DC43: Falling back to offline evaluation for batch {batch_id}")
             result = self._evaluate_without_service(schema=schema, metrics=metrics)
+            logger.info(f"DC43: Offline fallback evaluation generated {len(result.errors if result else [])} errors, {len(result.metrics if result else {})} metrics.")
         self._latest_batch_id = batch_id
         status = "ok"
         if result.errors:

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
@@ -115,6 +115,14 @@ class StreamingObservationWriter:
         self.governance_service = governance_service
         self.dataset_id = dataset_id or "unknown"
         self.dataset_version = dataset_version or "unknown"
+        
+        # Resolve any templates for the checkpoint location so that {timestamp} 
+        # based streams create fresh checkpoints for each notebook run.
+        checkpoint_version = self.dataset_version
+        if "{" in checkpoint_version:
+            timestamp = datetime.now(timezone.utc)
+            checkpoint_version = resolve_dataset_version(checkpoint_version, "init", timestamp)
+            
         self.pipeline_context = pipeline_context
         self.enforce = enforce
         self._validation: Optional[ValidationResult] = None
@@ -123,10 +131,10 @@ class StreamingObservationWriter:
         self._checkpoint_location = _derive_metrics_checkpoint(
             checkpoint_location,
             self.dataset_id,
-            self.dataset_version,
+            checkpoint_version,
         )
         default_name = f"dc43_metrics_{_safe_fs_name(self.dataset_id)}"
-        self.query_name = f"{default_name}_{_safe_fs_name(self.dataset_version)}"
+        self.query_name = f"{default_name}_{_safe_fs_name(checkpoint_version)}"
         self._intervention = intervention or NoOpStreamingInterventionStrategy()
         self._batches: List[Dict[str, Any]] = []
         self._progress_callback = progress_callback

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
@@ -341,12 +341,31 @@ class StreamingObservationWriter:
         logger.info(f"DC43: Starting to process streaming batch {batch_id} for dataset {self.dataset_id}@{effective_version}")
         
         try:
-            schema, metrics = collect_observations(
+            from dc43_integrations.spark.data_quality import schema_snapshot, compute_metrics
+            if debug_log_path:
+                try:
+                    import json
+                    with open(debug_log_path, "a") as f:
+                        f.write(json.dumps({"event": "calling_schema_snapshot", "batch_id": batch_id}) + "\n")
+                except Exception:
+                    pass
+                    
+            schema = schema_snapshot(batch_df)
+            
+            if debug_log_path:
+                try:
+                    import json
+                    with open(debug_log_path, "a") as f:
+                        f.write(json.dumps({"event": "calling_compute_metrics", "batch_id": batch_id}) + "\n")
+                except Exception:
+                    pass
+                    
+            metrics = compute_metrics(
                 batch_df,
                 self.contract,
                 expectations=self.expectation_plan,
-                collect_metrics=True,
             )
+            
             logger.info(f"DC43: Extracted schema and metrics for batch {batch_id}: {metrics}")
             if debug_log_path:
                 try:
@@ -355,13 +374,13 @@ class StreamingObservationWriter:
                         f.write(json.dumps({"event": "metrics_collected", "batch_id": batch_id, "metrics": metrics}) + "\n")
                 except Exception:
                     pass
-        except Exception as e:
+        except BaseException as e:
             logger.exception(f"DC43: Failed to collect observations for batch {batch_id}: {e}")
             if debug_log_path:
                 try:
                     import json
                     with open(debug_log_path, "a") as f:
-                        f.write(json.dumps({"event": "metrics_error", "batch_id": batch_id, "error": str(e)}) + "\n")
+                        f.write(json.dumps({"event": "metrics_error", "batch_id": batch_id, "error": str(e), "type": str(type(e))}) + "\n")
                 except Exception:
                     pass
             schema, metrics = None, {}

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
@@ -338,10 +338,29 @@ class StreamingObservationWriter:
             except Exception:
                 pass
 
-        logger.info(f"DC43: Starting to process streaming batch {batch_id} for dataset {self.dataset_id}@{effective_version}")
-        
         try:
-            from dc43_integrations.spark.data_quality import schema_snapshot, compute_metrics
+            logger.info(f"DC43: Starting to process streaming batch {batch_id} for dataset {self.dataset_id}@{effective_version}")
+        except Exception as e:
+            if debug_log_path:
+                try:
+                    import json
+                    with open(debug_log_path, "a") as f:
+                        f.write(json.dumps({"event": "logger_error", "batch_id": batch_id, "error": str(e), "type": str(type(e))}) + "\n")
+                except Exception:
+                    pass
+
+        try:
+            try:
+                from dc43_integrations.spark.data_quality import schema_snapshot, compute_metrics
+            except Exception as e:
+                if debug_log_path:
+                    try:
+                        import json
+                        with open(debug_log_path, "a") as f:
+                            f.write(json.dumps({"event": "import_error", "batch_id": batch_id, "error": str(e), "type": str(type(e))}) + "\n")
+                    except Exception:
+                        pass
+                raise e
             if debug_log_path:
                 try:
                     import json

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
@@ -339,8 +339,24 @@ class StreamingObservationWriter:
                 pass
 
         try:
+            if debug_log_path:
+                try:
+                    import json
+                    with open(debug_log_path, "a") as f:
+                        f.write(json.dumps({"event": "before_logger_info_1", "batch_id": batch_id}) + "\n")
+                except Exception:
+                    pass
+
             logger.info(f"DC43: Starting to process streaming batch {batch_id} for dataset {self.dataset_id}@{effective_version}")
-        except Exception as e:
+
+            if debug_log_path:
+                try:
+                    import json
+                    with open(debug_log_path, "a") as f:
+                        f.write(json.dumps({"event": "after_logger_info_1", "batch_id": batch_id}) + "\n")
+                except Exception:
+                    pass
+        except BaseException as e:
             if debug_log_path:
                 try:
                     import json
@@ -352,7 +368,7 @@ class StreamingObservationWriter:
         try:
             try:
                 from dc43_integrations.spark.data_quality import schema_snapshot, compute_metrics
-            except Exception as e:
+            except BaseException as e:
                 if debug_log_path:
                     try:
                         import json
@@ -361,6 +377,7 @@ class StreamingObservationWriter:
                     except Exception:
                         pass
                 raise e
+
             if debug_log_path:
                 try:
                     import json
@@ -368,9 +385,9 @@ class StreamingObservationWriter:
                         f.write(json.dumps({"event": "calling_schema_snapshot", "batch_id": batch_id}) + "\n")
                 except Exception:
                     pass
-                    
+
             schema = schema_snapshot(batch_df)
-            
+
             if debug_log_path:
                 try:
                     import json
@@ -378,14 +395,18 @@ class StreamingObservationWriter:
                         f.write(json.dumps({"event": "calling_compute_metrics", "batch_id": batch_id}) + "\n")
                 except Exception:
                     pass
-                    
+
             metrics = compute_metrics(
                 batch_df,
                 self.contract,
                 expectations=self.expectation_plan,
             )
-            
-            logger.info(f"DC43: Extracted schema and metrics for batch {batch_id}: {metrics}")
+
+            try:
+                logger.info(f"DC43: Extracted schema and metrics for batch {batch_id}: {metrics}")
+            except BaseException:
+                pass
+
             if debug_log_path:
                 try:
                     import json
@@ -394,7 +415,10 @@ class StreamingObservationWriter:
                 except Exception:
                     pass
         except BaseException as e:
-            logger.exception(f"DC43: Failed to collect observations for batch {batch_id}: {e}")
+            try:
+                logger.exception(f"DC43: Failed to collect observations for batch {batch_id}: {e}")
+            except BaseException:
+                pass
             if debug_log_path:
                 try:
                     import json

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
@@ -326,6 +326,15 @@ class StreamingObservationWriter:
         timestamp = datetime.now(timezone.utc)
         effective_version = resolve_dataset_version(self.dataset_version, batch_id, timestamp)
         
+        debug_log_path = os.environ.get("DC43_STREAMING_DEBUG_LOG")
+        if debug_log_path:
+            try:
+                import json
+                with open(debug_log_path, "a") as f:
+                    f.write(json.dumps({"event": "start_batch", "batch_id": batch_id, "dataset": f"{self.dataset_id}@{effective_version}", "timestamp": str(timestamp)}) + "\n")
+            except Exception:
+                pass
+
         logger.info(f"DC43: Starting to process streaming batch {batch_id} for dataset {self.dataset_id}@{effective_version}")
         
         try:
@@ -336,8 +345,22 @@ class StreamingObservationWriter:
                 collect_metrics=True,
             )
             logger.info(f"DC43: Extracted schema and metrics for batch {batch_id}: {metrics}")
+            if debug_log_path:
+                try:
+                    import json
+                    with open(debug_log_path, "a") as f:
+                        f.write(json.dumps({"event": "metrics_collected", "batch_id": batch_id, "metrics": metrics}) + "\n")
+                except Exception:
+                    pass
         except Exception as e:
             logger.exception(f"DC43: Failed to collect observations for batch {batch_id}: {e}")
+            if debug_log_path:
+                try:
+                    import json
+                    with open(debug_log_path, "a") as f:
+                        f.write(json.dumps({"event": "metrics_error", "batch_id": batch_id, "error": str(e)}) + "\n")
+                except Exception:
+                    pass
             schema, metrics = None, {}
         
         row_count = metrics.get("row_count")
@@ -391,9 +414,29 @@ class StreamingObservationWriter:
                     "DC43: Successfully evaluated streaming batch %s (effective_version=%s) on governance service. Got %d errors, %d metrics",
                     batch_id, effective_version, len(result.errors if result else []), len(result.metrics if result else {})
                 )
+                if debug_log_path:
+                    try:
+                        import json
+                        with open(debug_log_path, "a") as f:
+                            f.write(json.dumps({
+                                "event": "governance_evaluation", 
+                                "batch_id": batch_id, 
+                                "backend": type(self.governance_service).__name__,
+                                "ok": result.ok if result else None,
+                                "violations": len(result.errors) if result and result.errors else 0
+                            }) + "\n")
+                    except Exception:
+                        pass
             except Exception as e:
                 logger.exception(f"DC43: Streaming observation service evaluation failed for batch {batch_id}, falling back to offline: {e}")
-                
+                if debug_log_path:
+                    try:
+                        import json
+                        with open(debug_log_path, "a") as f:
+                            f.write(json.dumps({"event": "governance_error", "batch_id": batch_id, "error": str(e)}) + "\n")
+                    except Exception:
+                        pass
+
         if result is None:
             logger.info(f"DC43: Falling back to offline evaluation for batch {batch_id}")
             result = self._evaluate_without_service(schema=schema, metrics=metrics)

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
@@ -31,8 +31,6 @@ from dc43_service_backends.core.odcs import contract_identity
 
 logger = logging.getLogger(__name__)
 
-_unpicklable_registry: Dict[int, Dict[str, Any]] = {}
-
 
 def _derive_metrics_checkpoint(
     base: Optional[str],
@@ -145,21 +143,9 @@ class StreamingObservationWriter:
 
     def __getstate__(self) -> Dict[str, Any]:
         state = self.__dict__.copy()
-
-        global _unpicklable_registry
-        _original_id = id(self)
-        _unpicklable_registry[_original_id] = {
-            '_sink_queries': state.get('_sink_queries', []),
-            '_progress_callback': state.get('_progress_callback'),
-            'governance_service': state.get('governance_service'),
-            '_validation': state.get('_validation'),
-            '_batches': state.get('_batches', []),
-        }
-
         # Remove objects that cannot be pickled (e.g. Spark queries, callbacks)
         state['_sink_queries'] = []
         state['_progress_callback'] = None
-        state['_original_id'] = _original_id
         
         # Try to serialize RemoteGovernanceServiceClient configuration to reconstruct on worker
         gov = state.get('governance_service')
@@ -175,7 +161,7 @@ class StreamingObservationWriter:
                 k: v for k, v in os.environ.items() 
                 if k.startswith("DC43_") or k.startswith("DATABRICKS_")
             }
-
+                
         # Drop governance_service to prevent httpx weakref PicklingError on Spark Connect.
         # Fallback evaluation will be used in the worker if reconstruction fails.
         state['governance_service'] = None
@@ -183,20 +169,6 @@ class StreamingObservationWriter:
 
     def __setstate__(self, state: Dict[str, Any]) -> None:
         self.__dict__.update(state)
-        
-        global _unpicklable_registry
-        original_id = state.get('_original_id')
-        if original_id is not None and original_id in _unpicklable_registry:
-            restored = _unpicklable_registry[original_id]
-            self._sink_queries = restored.get('_sink_queries', [])
-            self._progress_callback = restored.get('_progress_callback')
-            self.governance_service = restored.get('governance_service')
-            
-            if restored.get('_validation') is not None:
-                self._validation = restored['_validation']
-            if restored.get('_batches') is not None:
-                self._batches = restored['_batches']
-
         base_url = state.get("_gov_base_url")
         if base_url and self.governance_service is None:
             try:
@@ -214,8 +186,11 @@ class StreamingObservationWriter:
             try:
                 import os
                 # Temporarily inject environment variables needed for configuration
-                original_env = os.environ.copy()
-                os.environ.update(gov_env)
+                original_env_values = {}
+                for k, v in gov_env.items():
+                    if k in os.environ:
+                        original_env_values[k] = os.environ[k]
+                    os.environ[k] = v
                 
                 from dc43_service_backends.config import load_config
                 from dc43_service_backends.bootstrap import build_backends
@@ -225,8 +200,11 @@ class StreamingObservationWriter:
                 self.governance_service = suite.governance
                 
                 # Restore original environment
-                os.environ.clear()
-                os.environ.update(original_env)
+                for k in gov_env:
+                    if k in original_env_values:
+                        os.environ[k] = original_env_values[k]
+                    else:
+                        os.environ.pop(k, None)
             except Exception:
                 pass
 

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
@@ -31,6 +31,8 @@ from dc43_service_backends.core.odcs import contract_identity
 
 logger = logging.getLogger(__name__)
 
+_unpicklable_registry: Dict[int, Dict[str, Any]] = {}
+
 
 def _derive_metrics_checkpoint(
     base: Optional[str],
@@ -143,9 +145,21 @@ class StreamingObservationWriter:
 
     def __getstate__(self) -> Dict[str, Any]:
         state = self.__dict__.copy()
+
+        global _unpicklable_registry
+        _original_id = id(self)
+        _unpicklable_registry[_original_id] = {
+            '_sink_queries': state.get('_sink_queries', []),
+            '_progress_callback': state.get('_progress_callback'),
+            'governance_service': state.get('governance_service'),
+            '_validation': state.get('_validation'),
+            '_batches': state.get('_batches', []),
+        }
+
         # Remove objects that cannot be pickled (e.g. Spark queries, callbacks)
         state['_sink_queries'] = []
         state['_progress_callback'] = None
+        state['_original_id'] = _original_id
         
         # Try to serialize RemoteGovernanceServiceClient configuration to reconstruct on worker
         gov = state.get('governance_service')
@@ -162,6 +176,20 @@ class StreamingObservationWriter:
 
     def __setstate__(self, state: Dict[str, Any]) -> None:
         self.__dict__.update(state)
+        
+        global _unpicklable_registry
+        original_id = state.get('_original_id')
+        if original_id is not None and original_id in _unpicklable_registry:
+            restored = _unpicklable_registry[original_id]
+            self._sink_queries = restored.get('_sink_queries', [])
+            self._progress_callback = restored.get('_progress_callback')
+            self.governance_service = restored.get('governance_service')
+            
+            if restored.get('_validation') is not None:
+                self._validation = restored['_validation']
+            if restored.get('_batches') is not None:
+                self._batches = restored['_batches']
+
         base_url = state.get("_gov_base_url")
         if base_url and self.governance_service is None:
             try:

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
@@ -216,10 +216,11 @@ class StreamingObservationWriter:
             raise RuntimeError("StreamingObservationWriter already bound to a validation")
 
         self._validation = validation
+        effective_version = resolve_dataset_version(self.dataset_version, batch_id="init")
         validation.merge_details(
             {
                 "dataset_id": self.dataset_id,
-                "dataset_version": self.dataset_version,
+                "dataset_version": effective_version,
             }
         )
 

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone

--- a/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
+++ b/packages/dc43-integrations/src/dc43_integrations/spark/io/streaming.py
@@ -131,6 +131,7 @@ class StreamingObservationWriter:
         self._batches: List[Dict[str, Any]] = []
         self._progress_callback = progress_callback
         self._sink_queries: List[Any] = []
+        self._debug_log_path = os.environ.get("DC43_STREAMING_DEBUG_LOG")
 
     @property
     def checkpoint_location(self) -> str:
@@ -327,7 +328,7 @@ class StreamingObservationWriter:
         timestamp = datetime.now(timezone.utc)
         effective_version = resolve_dataset_version(self.dataset_version, batch_id, timestamp)
         
-        debug_log_path = os.environ.get("DC43_STREAMING_DEBUG_LOG")
+        debug_log_path = getattr(self, "_debug_log_path", None)
         if debug_log_path:
             try:
                 import json


### PR DESCRIPTION
- **fix(integration): evaluate table properties before streaming to prevent MetadataChangedException collision**
- **fix(integrations): ensure streaming observation writer correctly uses preflight_version**
- **refactor(integrations): centralise and fix dataset_version template rendering**
- **fix(integrations): safely pre-create table before linking contract properties for uninitialized spark streams**
- **fix(spark): preserve unpicklable backend governance services during streaming micro-batches**
